### PR TITLE
Refactor orchestrators to remove circular dependencies

### DIFF
--- a/shared/src/commonMain/kotlin/link/socket/kore/agents/events/EnvironmentOrchestrator.kt
+++ b/shared/src/commonMain/kotlin/link/socket/kore/agents/events/EnvironmentOrchestrator.kt
@@ -1,0 +1,91 @@
+package link.socket.kore.agents.events
+
+import link.socket.kore.agents.events.api.AgentEventApi
+import link.socket.kore.agents.events.bus.EventBus
+import link.socket.kore.agents.events.meetings.Meeting
+import link.socket.kore.agents.events.meetings.MeetingOrchestrator
+import link.socket.kore.agents.events.meetings.MeetingRepository
+import link.socket.kore.agents.events.meetings.MeetingSchedulingService
+import link.socket.kore.agents.events.messages.AgentMessageApi
+import link.socket.kore.agents.events.tickets.TicketOrchestrator
+import link.socket.kore.agents.events.tickets.TicketRepository
+import link.socket.kore.agents.events.utils.ConsoleEventLogger
+import link.socket.kore.agents.events.utils.EventLogger
+
+/**
+ * Top-level orchestrator that coordinates all domain orchestrators.
+ *
+ * This class manages the lifecycle and dependencies of:
+ * - MeetingOrchestrator: Handles meeting scheduling and lifecycle
+ * - TicketOrchestrator: Handles ticket creation and workflow
+ * - EventRouter: Routes events between subscribed agents
+ *
+ * By centralizing orchestrator management here, we avoid circular dependencies
+ * between orchestrators while allowing them to communicate with each other
+ * through this parent. For example, TicketOrchestrator can schedule meetings
+ * without depending directly on MeetingOrchestrator.
+ */
+class EnvironmentOrchestrator(
+    private val meetingRepository: MeetingRepository,
+    private val ticketRepository: TicketRepository,
+    private val eventBus: EventBus,
+    private val messageApi: AgentMessageApi,
+    private val eventApi: AgentEventApi,
+    private val logger: EventLogger = ConsoleEventLogger(),
+) {
+    /**
+     * The meeting orchestrator that handles meeting lifecycle operations.
+     */
+    val meetingOrchestrator: MeetingOrchestrator = MeetingOrchestrator(
+        repository = meetingRepository,
+        eventBus = eventBus,
+        messageApi = messageApi,
+        logger = logger,
+    )
+
+    /**
+     * The ticket orchestrator that handles ticket lifecycle operations.
+     *
+     * Uses a MeetingSchedulingService that delegates to the meetingOrchestrator,
+     * allowing TicketOrchestrator to schedule meetings without direct dependency.
+     */
+    val ticketOrchestrator: TicketOrchestrator = TicketOrchestrator(
+        ticketRepository = ticketRepository,
+        eventBus = eventBus,
+        messageApi = messageApi,
+        meetingSchedulingService = createMeetingSchedulingService(),
+        logger = logger,
+    )
+
+    /**
+     * The event router that routes events to subscribed agents.
+     */
+    val eventRouter: EventRouter = EventRouter(
+        eventApi = eventApi,
+        eventBus = eventBus,
+    )
+
+    /**
+     * Start all orchestrator services.
+     *
+     * This starts the event routing system. Individual orchestrators don't need
+     * explicit startup as they respond to method calls.
+     */
+    fun start() {
+        eventRouter.startRouting()
+    }
+
+    /**
+     * Creates a MeetingSchedulingService that delegates to the meetingOrchestrator.
+     *
+     * This enables TicketOrchestrator to schedule meetings without directly
+     * depending on MeetingOrchestrator, allowing for potential bidirectional
+     * communication in the future where MeetingOrchestrator could also
+     * interact with TicketOrchestrator.
+     */
+    private fun createMeetingSchedulingService(): MeetingSchedulingService {
+        return MeetingSchedulingService { meeting: Meeting, scheduledBy: EventSource ->
+            meetingOrchestrator.scheduleMeeting(meeting, scheduledBy)
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/link/socket/kore/agents/events/meetings/MeetingSchedulingService.kt
+++ b/shared/src/commonMain/kotlin/link/socket/kore/agents/events/meetings/MeetingSchedulingService.kt
@@ -1,0 +1,25 @@
+package link.socket.kore.agents.events.meetings
+
+import link.socket.kore.agents.events.EventSource
+
+/**
+ * Functional interface for scheduling meetings.
+ *
+ * This interface decouples the TicketOrchestrator from MeetingOrchestrator,
+ * allowing them to be composed by a higher-level orchestrator without
+ * direct dependencies. This enables bidirectional communication between
+ * orchestrators through the parent EnvironmentOrchestrator.
+ */
+fun interface MeetingSchedulingService {
+    /**
+     * Schedule a meeting.
+     *
+     * @param meeting The meeting to schedule
+     * @param scheduledBy The event source that is scheduling the meeting
+     * @return Result containing the scheduled meeting with updated thread info
+     */
+    suspend fun scheduleMeeting(
+        meeting: Meeting,
+        scheduledBy: EventSource,
+    ): Result<Meeting>
+}

--- a/shared/src/commonMain/kotlin/link/socket/kore/agents/events/tickets/TicketOrchestrator.kt
+++ b/shared/src/commonMain/kotlin/link/socket/kore/agents/events/tickets/TicketOrchestrator.kt
@@ -12,7 +12,7 @@ import link.socket.kore.agents.events.bus.EventBus
 import link.socket.kore.agents.events.meetings.Meeting
 import link.socket.kore.agents.events.meetings.MeetingId
 import link.socket.kore.agents.events.meetings.MeetingInvitation
-import link.socket.kore.agents.events.meetings.MeetingOrchestrator
+import link.socket.kore.agents.events.meetings.MeetingSchedulingService
 import link.socket.kore.agents.events.meetings.MeetingStatus
 import link.socket.kore.agents.events.meetings.MeetingType
 import link.socket.kore.agents.events.messages.AgentMessageApi
@@ -33,7 +33,7 @@ class TicketOrchestrator(
     private val ticketRepository: TicketRepository,
     private val eventBus: EventBus,
     private val messageApi: AgentMessageApi,
-    private val meetingOrchestrator: MeetingOrchestrator,
+    private val meetingSchedulingService: MeetingSchedulingService,
     private val logger: EventLogger = ConsoleEventLogger(),
 ) {
 
@@ -481,8 +481,8 @@ class TicketOrchestrator(
             ),
         )
 
-        // Schedule the meeting using MeetingOrchestrator
-        val meetingResult = meetingOrchestrator.scheduleMeeting(
+        // Schedule the meeting using MeetingSchedulingService
+        val meetingResult = meetingSchedulingService.scheduleMeeting(
             meeting = meeting,
             scheduledBy = EventSource.Agent(messageApi.agentId),
         )

--- a/shared/src/jvmTest/kotlin/link/socket/kore/agents/events/tickets/BacklogAnalyticsTest.kt
+++ b/shared/src/jvmTest/kotlin/link/socket/kore/agents/events/tickets/BacklogAnalyticsTest.kt
@@ -17,6 +17,7 @@ import link.socket.kore.agents.events.Database
 import link.socket.kore.agents.events.bus.EventBus
 import link.socket.kore.agents.events.meetings.MeetingOrchestrator
 import link.socket.kore.agents.events.meetings.MeetingRepository
+import link.socket.kore.agents.events.meetings.MeetingSchedulingService
 import link.socket.kore.agents.events.messages.AgentMessageApi
 import link.socket.kore.agents.events.messages.MessageRepository
 import link.socket.kore.data.DEFAULT_JSON
@@ -60,11 +61,16 @@ class BacklogAnalyticsTest {
             messageApi = messageApi,
         )
 
+        // Create a MeetingSchedulingService that delegates to the meetingOrchestrator
+        val meetingSchedulingService = MeetingSchedulingService { meeting, scheduledBy ->
+            meetingOrchestrator.scheduleMeeting(meeting, scheduledBy)
+        }
+
         ticketOrchestrator = TicketOrchestrator(
             ticketRepository = ticketRepository,
             eventBus = eventBus,
             messageApi = messageApi,
-            meetingOrchestrator = meetingOrchestrator,
+            meetingSchedulingService = meetingSchedulingService,
         )
     }
 

--- a/shared/src/jvmTest/kotlin/link/socket/kore/agents/events/tickets/TicketBuilderTest.kt
+++ b/shared/src/jvmTest/kotlin/link/socket/kore/agents/events/tickets/TicketBuilderTest.kt
@@ -19,6 +19,7 @@ import link.socket.kore.agents.events.Database
 import link.socket.kore.agents.events.bus.EventBus
 import link.socket.kore.agents.events.meetings.MeetingOrchestrator
 import link.socket.kore.agents.events.meetings.MeetingRepository
+import link.socket.kore.agents.events.meetings.MeetingSchedulingService
 import link.socket.kore.agents.events.messages.AgentMessageApi
 import link.socket.kore.agents.events.messages.MessageRepository
 import link.socket.kore.data.DEFAULT_JSON
@@ -61,11 +62,16 @@ class TicketBuilderTest {
             messageApi = messageApi,
         )
 
+        // Create a MeetingSchedulingService that delegates to the meetingOrchestrator
+        val meetingSchedulingService = MeetingSchedulingService { meeting, scheduledBy ->
+            meetingOrchestrator.scheduleMeeting(meeting, scheduledBy)
+        }
+
         ticketOrchestrator = TicketOrchestrator(
             ticketRepository = ticketRepository,
             eventBus = eventBus,
             messageApi = messageApi,
-            meetingOrchestrator = meetingOrchestrator,
+            meetingSchedulingService = meetingSchedulingService,
         )
     }
 

--- a/shared/src/jvmTest/kotlin/link/socket/kore/agents/events/tickets/TicketMeetingIntegrationTest.kt
+++ b/shared/src/jvmTest/kotlin/link/socket/kore/agents/events/tickets/TicketMeetingIntegrationTest.kt
@@ -22,6 +22,7 @@ import link.socket.kore.agents.events.api.EventHandler
 import link.socket.kore.agents.events.bus.EventBus
 import link.socket.kore.agents.events.meetings.MeetingOrchestrator
 import link.socket.kore.agents.events.meetings.MeetingRepository
+import link.socket.kore.agents.events.meetings.MeetingSchedulingService
 import link.socket.kore.agents.events.messages.AgentMessageApi
 import link.socket.kore.agents.events.messages.MessageRepository
 import link.socket.kore.agents.events.tasks.AgendaItem
@@ -70,11 +71,16 @@ class TicketMeetingIntegrationTest {
             messageApi = messageApi,
         )
 
+        // Create a MeetingSchedulingService that delegates to the meetingOrchestrator
+        val meetingSchedulingService = MeetingSchedulingService { meeting, scheduledBy ->
+            meetingOrchestrator.scheduleMeeting(meeting, scheduledBy)
+        }
+
         ticketOrchestrator = TicketOrchestrator(
             ticketRepository = ticketRepository,
             eventBus = eventBus,
             messageApi = messageApi,
-            meetingOrchestrator = meetingOrchestrator,
+            meetingSchedulingService = meetingSchedulingService,
         )
 
         // Subscribe to capture published events

--- a/shared/src/jvmTest/kotlin/link/socket/kore/agents/events/tickets/TicketOrchestratorTest.kt
+++ b/shared/src/jvmTest/kotlin/link/socket/kore/agents/events/tickets/TicketOrchestratorTest.kt
@@ -20,6 +20,7 @@ import link.socket.kore.agents.events.api.EventHandler
 import link.socket.kore.agents.events.bus.EventBus
 import link.socket.kore.agents.events.meetings.MeetingOrchestrator
 import link.socket.kore.agents.events.meetings.MeetingRepository
+import link.socket.kore.agents.events.meetings.MeetingSchedulingService
 import link.socket.kore.agents.events.messages.AgentMessageApi
 import link.socket.kore.agents.events.messages.MessageRepository
 import link.socket.kore.data.DEFAULT_JSON
@@ -65,11 +66,16 @@ class TicketOrchestratorTest {
             messageApi = messageApi,
         )
 
+        // Create a MeetingSchedulingService that delegates to the meetingOrchestrator
+        val meetingSchedulingService = MeetingSchedulingService { meeting, scheduledBy ->
+            meetingOrchestrator.scheduleMeeting(meeting, scheduledBy)
+        }
+
         ticketOrchestrator = TicketOrchestrator(
             ticketRepository = ticketRepository,
             eventBus = eventBus,
             messageApi = messageApi,
-            meetingOrchestrator = meetingOrchestrator,
+            meetingSchedulingService = meetingSchedulingService,
         )
 
         // Subscribe to capture published events


### PR DESCRIPTION
Remove direct MeetingOrchestrator dependency from TicketOrchestrator to enable bidirectional communication between orchestrators.

- Add MeetingSchedulingService functional interface for decoupling
- Create EnvironmentOrchestrator to manage Meeting/Ticket/Event orchestrators
- Update TicketOrchestrator to use MeetingSchedulingService
- Update tests to use new architecture

This allows orchestrators to call each other through the parent EnvironmentOrchestrator without circular dependencies.