### PR TITLE
Add Gradle JVM tests to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,12 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Create local.properties
-        run: touch local.properties
+        run: |
+          cat > local.properties << 'EOF'
+          anthropic_api_key=placeholder
+          google_api_key=placeholder
+          openai_api_key=placeholder
+          EOF
 
       - name: Run JVM tests
         run: ./gradlew jvmTest


### PR DESCRIPTION
Add CI workflow that runs jvmTest on pull requests and pushes to main branches to ensure no regressions before merging.