### PR TITLE
Fix Kotlin hierarchy template warning in logs

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -90,6 +90,8 @@ sqldelight {
 }
 
 kotlin {
+    applyDefaultHierarchyTemplate()
+
     androidTarget {
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_21)
@@ -173,12 +175,7 @@ kotlin {
         val iosX64Main by getting
         val iosArm64Main by getting
         val iosSimulatorArm64Main by getting
-        val iosMain by creating {
-            dependsOn(commonMain)
-            iosX64Main.dependsOn(this)
-            iosArm64Main.dependsOn(this)
-            iosSimulatorArm64Main.dependsOn(this)
-
+        val iosMain by getting {
             dependencies {
                 implementation("app.cash.sqldelight:native-driver:2.2.1")
                 implementation("io.ktor:ktor-client-darwin:3.2.2")


### PR DESCRIPTION
…e warning

The Default Kotlin Hierarchy Template automatically handles iOS source set relationships. Changed iosMain from 'creating' to 'getting' and removed explicit dependsOn() calls as these are now managed by the template.

This resolves the warning:
'Default Kotlin Hierarchy Template Not Applied Correctly'