### PR TITLE
Add CLI watch command

### DIFF
--- a/ampere-cli/WATCH_COMMAND_USAGE.md
+++ b/ampere-cli/WATCH_COMMAND_USAGE.md
@@ -1,0 +1,194 @@
+# Watch Command Usage Guide
+
+The `ampere watch` command connects to the event stream and displays events in real-time with color coding and formatting.
+
+## Prerequisites
+
+- **Java 21** or higher is required to run the CLI
+- Check your Java version: `java -version`
+- If you have multiple Java versions, you can list them: `/usr/libexec/java_home -V`
+
+## Building the CLI
+
+```bash
+./gradlew :ampere-cli:installJvmDist
+```
+
+The executable will be located at:
+```
+ampere-cli/build/install/ampere-cli-jvm/bin/ampere-cli
+```
+
+## Running with Java 21
+
+### Option 1: Use the wrapper script (recommended)
+
+A wrapper script is provided that automatically uses Java 21:
+
+```bash
+./ampere-cli/ampere watch
+```
+
+### Option 2: Set JAVA_HOME manually
+
+If your default Java version is not 21+, set JAVA_HOME before running:
+
+```bash
+export JAVA_HOME=$(/usr/libexec/java_home -v 21)
+ampere-cli/build/install/ampere-cli-jvm/bin/ampere-cli watch
+```
+
+Or inline:
+
+```bash
+JAVA_HOME=$(/usr/libexec/java_home -v 21) ampere-cli/build/install/ampere-cli-jvm/bin/ampere-cli watch
+```
+
+## Basic Usage
+
+### Watch all events
+```bash
+./ampere-cli/ampere watch
+```
+
+This will display all events from the event bus in real-time.
+
+### Filter by event type
+```bash
+# Watch only TaskCreated events
+./ampere-cli/ampere watch --filter TaskCreated
+
+# Watch multiple event types
+./ampere-cli/ampere watch --filter TaskCreated --filter QuestionRaised
+```
+
+### Filter by agent
+```bash
+# Watch events from a specific agent
+./ampere-cli/ampere watch --agent agent-pm
+
+# Watch events from multiple agents
+./ampere-cli/ampere watch --agent agent-pm --agent agent-dev
+```
+
+### Combine filters
+```bash
+# Watch TaskCreated events from agent-pm
+./ampere-cli/ampere watch \
+  --filter TaskCreated \
+  --agent agent-pm
+```
+
+### Short option names
+```bash
+# Use -f for --filter and -a for --agent
+./ampere-cli/ampere watch -f TaskCreated -a agent-pm
+```
+
+## Available Event Types
+
+The following event types can be used with `--filter`:
+
+### Base Events
+- `TaskCreated`
+- `QuestionRaised`
+- `CodeSubmitted`
+
+### Meeting Events
+- `MeetingScheduled`
+- `MeetingStarted`
+- `AgendaItemStarted`
+- `AgendaItemCompleted`
+- `MeetingCompleted`
+- `MeetingCanceled`
+
+### Ticket Events
+- `TicketCreated`
+- `TicketStatusChanged`
+- `TicketAssigned`
+- `TicketBlocked`
+- `TicketCompleted`
+- `TicketMeetingScheduled`
+
+### Message Events
+- `ThreadCreated`
+- `MessagePosted`
+- `ThreadStatusChanged`
+- `EscalationRequested`
+
+### Notification Events
+- `NotificationToAgent`
+- `NotificationToHuman`
+
+Event type names are **case-insensitive** (e.g., `taskcreated`, `TaskCreated`, `TASKCREATED` all work).
+
+## Output Format
+
+Events are displayed in the following format:
+```
+[timestamp] [icon] [event type]  [summary]
+```
+
+For example:
+```
+14:32:18  📋  TaskCreated              Task #123: Implement authentication (assigned to: agent-auth) [HIGH] from agent-pm
+14:32:25  ❓  QuestionRaised           "How should we handle this error?" - Context: During database migration [MEDIUM] from agent-dev
+14:33:01  💻  CodeSubmitted            src/main/Auth.kt - Add OAuth support (review required) for agent-reviewer [LOW] from agent-dev
+```
+
+### Color Coding
+
+#### Event Types
+- **Green** (📋🎫): Tasks and tickets (actionable items)
+- **Magenta** (❓📅): Questions and meetings (need attention)
+- **Cyan** (💻): Code submissions (technical)
+- **Blue** (💬): Messages (communication)
+- **White** (🔔): Notifications (informational)
+
+#### Urgency Levels
+- **Red** [HIGH]: Needs immediate attention
+- **Yellow** [MEDIUM]: Should be addressed soon
+- **Gray** [LOW]: Can wait
+
+#### Other
+- **Gray**: Timestamps and sources
+
+## Integration Testing
+
+To test the watch command with actual events, you'll need to:
+
+1. **Start the watch command**:
+   ```bash
+   ./ampere-cli/ampere watch
+   ```
+
+2. **Publish events from another process** (using the event publishing API):
+   ```kotlin
+   import link.socket.ampere.agents.events.bus.EventSerialBus
+   import link.socket.ampere.agents.events.Event
+   import kotlinx.coroutines.runBlocking
+
+   runBlocking {
+       val eventBus = EventSerialBus(scope)
+       eventBus.publish(Event.TaskCreated(...))
+   }
+   ```
+
+The events should appear in the watch command output immediately.
+
+## Troubleshooting
+
+### No events appearing
+- Make sure events are being published to the EventBus
+- Check that your filters match the events being published
+- Verify the event types are spelled correctly (use `--help` for examples)
+
+### Invalid event type warning
+If you see a warning about invalid event types, check the spelling and refer to the list of available event types above.
+
+## Help
+
+For full command help:
+```bash
+./ampere-cli/ampere watch --help
+```

--- a/ampere-cli/ampere
+++ b/ampere-cli/ampere
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Wrapper script for ampere CLI that ensures Java 21+ is used
+
+# Find Java 21 or higher
+JAVA_21=$(/usr/libexec/java_home -v 21 2>/dev/null)
+JAVA_24=$(/usr/libexec/java_home -v 24 2>/dev/null)
+
+if [ -n "$JAVA_24" ]; then
+    export JAVA_HOME="$JAVA_24"
+elif [ -n "$JAVA_21" ]; then
+    export JAVA_HOME="$JAVA_21"
+else
+    echo "Error: Java 21 or higher is required to run ampere CLI"
+    echo "Please install Java 21+ from:"
+    echo "  - https://www.oracle.com/java/technologies/downloads/"
+    echo "  - https://adoptium.net/"
+    exit 1
+fi
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Execute the ampere CLI
+exec "$SCRIPT_DIR/build/install/ampere-cli-jvm/bin/ampere-cli" "$@"

--- a/ampere-cli/build.gradle.kts
+++ b/ampere-cli/build.gradle.kts
@@ -1,5 +1,6 @@
 @file:OptIn(ExperimentalKotlinGradlePluginApi::class)
 
+import org.gradle.jvm.application.tasks.CreateStartScripts
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
@@ -45,6 +46,9 @@ kotlin {
 
                 // DateTime
                 implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.1")
+
+                // SLF4J no-op implementation to suppress warnings
+                implementation("org.slf4j:slf4j-nop:2.0.16")
             }
         }
 
@@ -53,6 +57,7 @@ kotlin {
                 implementation(kotlin("test"))
                 implementation("org.junit.jupiter:junit-jupiter:5.10.2")
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
+                implementation("com.github.ajalt.clikt:clikt:4.4.0")
             }
         }
     }
@@ -60,4 +65,9 @@ kotlin {
 
 tasks.named<Test>("jvmTest") {
     useJUnitPlatform()
+}
+
+// Configure JVM arguments for the start scripts to suppress JNA warnings
+tasks.named<CreateStartScripts>("startScriptsForJvm") {
+    defaultJvmOpts = listOf("--enable-native-access=ALL-UNNAMED")
 }

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/WatchCommand.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/WatchCommand.kt
@@ -1,15 +1,36 @@
 package link.socket.ampere
 
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import com.github.ajalt.clikt.core.CliktCommand
-import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.multiple
 import com.github.ajalt.clikt.parameters.options.option
-import com.github.ajalt.clikt.parameters.types.int
 import com.github.ajalt.mordant.rendering.TextColors.cyan
+import com.github.ajalt.mordant.rendering.TextColors.red
 import com.github.ajalt.mordant.rendering.TextColors.yellow
 import com.github.ajalt.mordant.rendering.TextStyles.bold
 import com.github.ajalt.mordant.rendering.TextStyles.dim
 import com.github.ajalt.mordant.terminal.Terminal
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import link.socket.ampere.agents.events.EventRepository
+import link.socket.ampere.agents.events.EventSource
+import link.socket.ampere.agents.events.bus.EventSerialBus
+import link.socket.ampere.agents.events.relay.EventRelayFilters
+import link.socket.ampere.agents.events.relay.EventRelayServiceImpl
+import link.socket.ampere.data.DEFAULT_JSON
+import link.socket.ampere.db.Database
+import link.socket.ampere.renderer.EventRenderer
+import link.socket.ampere.util.EventTypeParser
 
+/**
+ * Command to observe the substrate's electrical activity in real-time.
+ *
+ * This is the CLI's primary sensory interface - it lets you feel the pulse
+ * of the organizational organism by streaming events as they occur.
+ */
 class WatchCommand : CliktCommand(
     name = "watch",
     help = """
@@ -19,54 +40,116 @@ class WatchCommand : CliktCommand(
         and formatting for human readability.
 
         Examples:
-          ampere watch                    # Watch all events
-          ampere watch --type TaskCreated # Filter by event type
-          ampere watch --since 1h         # Events from last hour
+          ampere watch                         # Watch all events
+          ampere watch --filter TaskCreated    # Filter by event type
+          ampere watch --filter TaskCreated --filter QuestionRaised  # Multiple types
+          ampere watch --agent agent-pm        # Filter by agent ID
     """.trimIndent()
 ) {
-    private val eventType by option(
-        "--type", "-t",
-        help = "Filter events by type (TaskCreated, QuestionRaised, CodeSubmitted)"
-    )
+    // Repeatable option for filtering by event types
+    private val filterTypes by option(
+        "--filter", "-f",
+        help = "Filter by event type (e.g., TaskCreated, QuestionRaised). Repeatable."
+    ).multiple()
 
-    private val agent by option(
+    // Repeatable option for filtering by agent IDs
+    private val filterAgents by option(
         "--agent", "-a",
-        help = "Filter events by agent ID"
-    )
-
-    private val since by option(
-        "--since", "-s",
-        help = "Show events since timestamp (e.g., '1h', '30m', '2024-01-01')"
-    )
-
-    private val limit by option(
-        "--limit", "-n",
-        help = "Limit number of events to display"
-    ).int().default(100)
-
-    private val replay by option(
-        "--replay", "-r",
-        help = "Replay historical events from database before watching"
-    )
+        help = "Filter by agent ID (e.g., agent-pm, agent-dev). Repeatable."
+    ).multiple()
 
     private val terminal = Terminal()
 
-    override fun run() {
-        terminal.println(
-            bold(cyan("AMPERE")) + " - AniMA Model Protocol Example Runtime Environment"
-        )
+    override fun run() = runBlocking {
+        // Show startup banner
+        terminal.println(bold(cyan("⚡ AMPERE")) + " - Connecting to AniMA Model Protocol virtual environment")
         terminal.println(dim("Connecting to event stream..."))
         terminal.println()
 
-        // Placeholder for actual implementation
-        terminal.println(yellow("Watch command invoked with:"))
-        eventType?.let { terminal.println("  Event type: $it") }
-        agent?.let { terminal.println("  Agent: $it") }
-        since?.let { terminal.println("  Since: $it") }
-        terminal.println("  Limit: $limit")
-        replay?.let { terminal.println("  Replay: $it") }
+        // Set up the event infrastructure
+        val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
 
+        try {
+            // Create database schema
+            Database.Schema.create(driver)
+            val database = Database(driver)
+
+            // Initialize event infrastructure
+            val eventRepository = EventRepository(DEFAULT_JSON, scope, database)
+            val eventBus = EventSerialBus(scope)
+            val eventRelayService = EventRelayServiceImpl(eventBus, eventRepository)
+
+            // Create event renderer
+            val renderer = EventRenderer(terminal)
+
+            // Build filters from command options
+            val filters = buildFilters()
+
+            // Show active filters
+            showActiveFilters(filters)
+
+            // Subscribe to live events and render them
+            terminal.println(bold("Watching events... (Ctrl+C to stop)"))
+            terminal.println()
+
+            eventRelayService.subscribeToLiveEvents(filters)
+                .collect { event ->
+                    renderer.render(event)
+                }
+        } catch (e: Exception) {
+            terminal.println(red("Error: ${e.message}"))
+            throw e
+        } finally {
+            driver.close()
+            scope.cancel()
+        }
+    }
+
+    /**
+     * Build EventRelayFilters from command-line options.
+     */
+    private fun buildFilters(): EventRelayFilters {
+        // Parse event types
+        val eventTypes = if (filterTypes.isNotEmpty()) {
+            val parsed = EventTypeParser.parseMultiple(filterTypes)
+            if (parsed.isEmpty()) {
+                terminal.println(yellow("Warning: No valid event types found in filters"))
+                terminal.println(yellow("Available types: ${EventTypeParser.getAllEventTypeNames().sorted().joinToString(", ")}"))
+            }
+            parsed
+        } else {
+            null
+        }
+
+        // Parse agent IDs to EventSource.Agent objects
+        val eventSources = if (filterAgents.isNotEmpty()) {
+            filterAgents.map { EventSource.Agent(it) }.toSet()
+        } else {
+            null
+        }
+
+        return EventRelayFilters(
+            eventTypes = eventTypes,
+            eventSources = eventSources
+        )
+    }
+
+    /**
+     * Display active filters to the user.
+     */
+    private fun showActiveFilters(filters: EventRelayFilters) {
+        if (filters.isEmpty()) {
+            terminal.println(dim("Watching all events (no filters)"))
+        } else {
+            terminal.println(dim("Active filters:"))
+            filters.eventTypes?.let { types ->
+                terminal.println(dim("  Event types: ${types.map { it.second }.joinToString(", ")}"))
+            }
+            filters.eventSources?.let { sources ->
+                terminal.println(dim("  Agents: ${sources.map { (it as EventSource.Agent).agentId }.joinToString(", ")}"))
+            }
+        }
         terminal.println()
-        terminal.println(dim("Event streaming will be implemented in subsequent tasks."))
     }
 }

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/util/EventTypeParser.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/util/EventTypeParser.kt
@@ -1,0 +1,92 @@
+package link.socket.ampere.util
+
+import link.socket.ampere.agents.events.Event
+import link.socket.ampere.agents.events.EventClassType
+import link.socket.ampere.agents.events.MeetingEvent
+import link.socket.ampere.agents.events.MessageEvent
+import link.socket.ampere.agents.events.NotificationEvent
+import link.socket.ampere.agents.events.TicketEvent
+
+/**
+ * Utility for parsing event type names from command-line strings to EventClassType.
+ *
+ * This enables users to filter events by typing event names like "TaskCreated" or "MeetingScheduled".
+ */
+object EventTypeParser {
+
+    /**
+     * Map of event type names (case-insensitive) to their EventClassType.
+     *
+     * Includes all event types in the system for comprehensive filtering support.
+     */
+    private val eventTypeMap: Map<String, EventClassType> = mapOf(
+        // Base Event types
+        "taskcreated" to Event.TaskCreated.EVENT_CLASS_TYPE,
+        "questionraised" to Event.QuestionRaised.EVENT_CLASS_TYPE,
+        "codesubmitted" to Event.CodeSubmitted.EVENT_CLASS_TYPE,
+
+        // MeetingEvent types
+        "meetingscheduled" to MeetingEvent.MeetingScheduled.EVENT_CLASS_TYPE,
+        "meetingstarted" to MeetingEvent.MeetingStarted.EVENT_CLASS_TYPE,
+        "agendaitemstarted" to MeetingEvent.AgendaItemStarted.EVENT_CLASS_TYPE,
+        "agendaitemcompleted" to MeetingEvent.AgendaItemCompleted.EVENT_CLASS_TYPE,
+        "meetingcompleted" to MeetingEvent.MeetingCompleted.EVENT_CLASS_TYPE,
+        "meetingcanceled" to MeetingEvent.MeetingCanceled.EVENT_CLASS_TYPE,
+
+        // TicketEvent types
+        "ticketcreated" to TicketEvent.TicketCreated.EVENT_CLASS_TYPE,
+        "ticketstatuschanged" to TicketEvent.TicketStatusChanged.EVENT_CLASS_TYPE,
+        "ticketassigned" to TicketEvent.TicketAssigned.EVENT_CLASS_TYPE,
+        "ticketblocked" to TicketEvent.TicketBlocked.EVENT_CLASS_TYPE,
+        "ticketcompleted" to TicketEvent.TicketCompleted.EVENT_CLASS_TYPE,
+        "ticketmeetingscheduled" to TicketEvent.TicketMeetingScheduled.EVENT_CLASS_TYPE,
+
+        // MessageEvent types
+        "threadcreated" to MessageEvent.ThreadCreated.EVENT_CLASS_TYPE,
+        "messageposted" to MessageEvent.MessagePosted.EVENT_CLASS_TYPE,
+        "threadstatuschanged" to MessageEvent.ThreadStatusChanged.EVENT_CLASS_TYPE,
+        "escalationrequested" to MessageEvent.EscalationRequested.EVENT_CLASS_TYPE,
+
+        // NotificationEvent types
+        "notificationtoagent" to NotificationEvent.ToAgent.EVENT_CLASS_TYPE,
+        "notificationtohuman" to NotificationEvent.ToHuman.EVENT_CLASS_TYPE,
+    )
+
+    /**
+     * Parse a single event type name to its EventClassType.
+     *
+     * @param typeName The event type name (case-insensitive)
+     * @return The EventClassType, or null if not found
+     */
+    fun parse(typeName: String): EventClassType? {
+        return eventTypeMap[typeName.lowercase()]
+    }
+
+    /**
+     * Parse multiple event type names to a Set of EventClassTypes.
+     *
+     * @param typeNames List of event type names
+     * @return Set of EventClassTypes (skips invalid names)
+     */
+    fun parseMultiple(typeNames: List<String>): Set<EventClassType> {
+        return typeNames.mapNotNull { parse(it) }.toSet()
+    }
+
+    /**
+     * Get all available event type names.
+     *
+     * @return Set of all recognized event type names
+     */
+    fun getAllEventTypeNames(): Set<String> {
+        return eventTypeMap.keys
+    }
+
+    /**
+     * Get all EventClassTypes in the system.
+     *
+     * @return Set of all EventClassTypes
+     */
+    fun getAllEventTypes(): Set<EventClassType> {
+        return eventTypeMap.values.toSet()
+    }
+}

--- a/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/WatchCommandTest.kt
+++ b/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/WatchCommandTest.kt
@@ -1,0 +1,54 @@
+package link.socket.ampere
+
+import com.github.ajalt.clikt.testing.test
+import org.junit.jupiter.api.Test
+import kotlin.test.assertContains
+
+/**
+ * Tests for WatchCommand.
+ *
+ * Note: These tests only verify command-line help and option parsing.
+ * Full integration testing with live event streaming is done through manual testing
+ * or would require complex mocking of the EventRelayService.
+ */
+class WatchCommandTest {
+
+    @Test
+    fun `watch command help text shows usage`() {
+        val command = WatchCommand()
+        val result = command.test("--help")
+
+        assertContains(result.output, "Watch events streaming")
+        assertContains(result.output, "Examples")
+        assertContains(result.output, "ampere watch")
+        assertContains(result.output, "--filter")
+        assertContains(result.output, "--agent")
+    }
+
+    @Test
+    fun `watch command help shows filter option description`() {
+        val command = WatchCommand()
+        val result = command.test("--help")
+
+        assertContains(result.output, "Filter by event type")
+        assertContains(result.output, "Repeatable")
+    }
+
+    @Test
+    fun `watch command help shows agent option description`() {
+        val command = WatchCommand()
+        val result = command.test("--help")
+
+        assertContains(result.output, "Filter by agent ID")
+        assertContains(result.output, "agent-pm")
+    }
+
+    @Test
+    fun `watch command help shows examples for filtering`() {
+        val command = WatchCommand()
+        val result = command.test("--help")
+
+        assertContains(result.output, "TaskCreated")
+        assertContains(result.output, "QuestionRaised")
+    }
+}

--- a/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/util/EventTypeParserTest.kt
+++ b/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/util/EventTypeParserTest.kt
@@ -1,0 +1,177 @@
+package link.socket.ampere.util
+
+import link.socket.ampere.agents.events.Event
+import link.socket.ampere.agents.events.MeetingEvent
+import link.socket.ampere.agents.events.MessageEvent
+import link.socket.ampere.agents.events.NotificationEvent
+import link.socket.ampere.agents.events.TicketEvent
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class EventTypeParserTest {
+
+    @Test
+    fun `parse TaskCreated returns correct EventClassType`() {
+        val result = EventTypeParser.parse("TaskCreated")
+        assertNotNull(result)
+        assertEquals(Event.TaskCreated.EVENT_CLASS_TYPE, result)
+    }
+
+    @Test
+    fun `parse is case-insensitive`() {
+        val lowercase = EventTypeParser.parse("taskcreated")
+        val uppercase = EventTypeParser.parse("TASKCREATED")
+        val mixedcase = EventTypeParser.parse("TaskCreated")
+
+        assertNotNull(lowercase)
+        assertNotNull(uppercase)
+        assertNotNull(mixedcase)
+        assertEquals(lowercase, uppercase)
+        assertEquals(uppercase, mixedcase)
+    }
+
+    @Test
+    fun `parse returns null for invalid event type`() {
+        val result = EventTypeParser.parse("InvalidEventType")
+        assertNull(result)
+    }
+
+    @Test
+    fun `parse handles all base Event types`() {
+        assertNotNull(EventTypeParser.parse("TaskCreated"))
+        assertNotNull(EventTypeParser.parse("QuestionRaised"))
+        assertNotNull(EventTypeParser.parse("CodeSubmitted"))
+    }
+
+    @Test
+    fun `parse handles all MeetingEvent types`() {
+        assertNotNull(EventTypeParser.parse("MeetingScheduled"))
+        assertNotNull(EventTypeParser.parse("MeetingStarted"))
+        assertNotNull(EventTypeParser.parse("AgendaItemStarted"))
+        assertNotNull(EventTypeParser.parse("AgendaItemCompleted"))
+        assertNotNull(EventTypeParser.parse("MeetingCompleted"))
+        assertNotNull(EventTypeParser.parse("MeetingCanceled"))
+    }
+
+    @Test
+    fun `parse handles all TicketEvent types`() {
+        assertNotNull(EventTypeParser.parse("TicketCreated"))
+        assertNotNull(EventTypeParser.parse("TicketStatusChanged"))
+        assertNotNull(EventTypeParser.parse("TicketAssigned"))
+        assertNotNull(EventTypeParser.parse("TicketBlocked"))
+        assertNotNull(EventTypeParser.parse("TicketCompleted"))
+        assertNotNull(EventTypeParser.parse("TicketMeetingScheduled"))
+    }
+
+    @Test
+    fun `parse handles all MessageEvent types`() {
+        assertNotNull(EventTypeParser.parse("ThreadCreated"))
+        assertNotNull(EventTypeParser.parse("MessagePosted"))
+        assertNotNull(EventTypeParser.parse("ThreadStatusChanged"))
+        assertNotNull(EventTypeParser.parse("EscalationRequested"))
+    }
+
+    @Test
+    fun `parse handles all NotificationEvent types`() {
+        assertNotNull(EventTypeParser.parse("NotificationToAgent"))
+        assertNotNull(EventTypeParser.parse("NotificationToHuman"))
+    }
+
+    @Test
+    fun `parseMultiple returns set of EventClassTypes`() {
+        val result = EventTypeParser.parseMultiple(
+            listOf("TaskCreated", "QuestionRaised", "MeetingScheduled")
+        )
+
+        assertEquals(3, result.size)
+        assertTrue(result.contains(Event.TaskCreated.EVENT_CLASS_TYPE))
+        assertTrue(result.contains(Event.QuestionRaised.EVENT_CLASS_TYPE))
+        assertTrue(result.contains(MeetingEvent.MeetingScheduled.EVENT_CLASS_TYPE))
+    }
+
+    @Test
+    fun `parseMultiple skips invalid type names`() {
+        val result = EventTypeParser.parseMultiple(
+            listOf("TaskCreated", "InvalidType", "QuestionRaised")
+        )
+
+        assertEquals(2, result.size)
+        assertTrue(result.contains(Event.TaskCreated.EVENT_CLASS_TYPE))
+        assertTrue(result.contains(Event.QuestionRaised.EVENT_CLASS_TYPE))
+    }
+
+    @Test
+    fun `parseMultiple returns empty set for all invalid types`() {
+        val result = EventTypeParser.parseMultiple(
+            listOf("Invalid1", "Invalid2")
+        )
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `parseMultiple handles empty list`() {
+        val result = EventTypeParser.parseMultiple(emptyList())
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `getAllEventTypeNames returns all event types`() {
+        val allNames = EventTypeParser.getAllEventTypeNames()
+
+        // Should have at least the basic event types
+        assertTrue(allNames.contains("taskcreated"))
+        assertTrue(allNames.contains("questionraised"))
+        assertTrue(allNames.contains("codesubmitted"))
+
+        // Should have meeting events
+        assertTrue(allNames.contains("meetingscheduled"))
+
+        // Should have ticket events
+        assertTrue(allNames.contains("ticketcreated"))
+
+        // Should have message events
+        assertTrue(allNames.contains("threadcreated"))
+
+        // Should have notification events
+        assertTrue(allNames.contains("notificationtoagent"))
+        assertTrue(allNames.contains("notificationtohuman"))
+    }
+
+    @Test
+    fun `getAllEventTypes returns all EventClassTypes`() {
+        val allTypes = EventTypeParser.getAllEventTypes()
+
+        // Should have at least the basic event types
+        assertTrue(allTypes.contains(Event.TaskCreated.EVENT_CLASS_TYPE))
+        assertTrue(allTypes.contains(Event.QuestionRaised.EVENT_CLASS_TYPE))
+        assertTrue(allTypes.contains(Event.CodeSubmitted.EVENT_CLASS_TYPE))
+
+        // Should have meeting events
+        assertTrue(allTypes.contains(MeetingEvent.MeetingScheduled.EVENT_CLASS_TYPE))
+
+        // Should have ticket events
+        assertTrue(allTypes.contains(TicketEvent.TicketCreated.EVENT_CLASS_TYPE))
+
+        // Should have message events
+        assertTrue(allTypes.contains(MessageEvent.ThreadCreated.EVENT_CLASS_TYPE))
+
+        // Should have notification events
+        assertTrue(allTypes.contains(NotificationEvent.ToAgent.EVENT_CLASS_TYPE))
+        assertTrue(allTypes.contains(NotificationEvent.ToHuman.EVENT_CLASS_TYPE))
+    }
+
+    @Test
+    fun `parsed event type has correct string name`() {
+        val taskCreated = EventTypeParser.parse("TaskCreated")
+        assertNotNull(taskCreated)
+        assertEquals("TaskCreated", taskCreated.second)
+
+        val meetingScheduled = EventTypeParser.parse("MeetingScheduled")
+        assertNotNull(meetingScheduled)
+        assertEquals("MeetingScheduled", meetingScheduled.second)
+    }
+}


### PR DESCRIPTION
Here is what the current CLI usage looks like:
```
./ampere-cli/ampere watch
⚡ AMPERE - Connecting to AniMA Model Protocol virtual environment
Connecting to event stream...

Watching all events (no filters)

Watching events... (Ctrl+C to stop)

[EventBus][SUBSCRIPTION] type=(class link.socket.ampere.agents.events.Event$TaskCreated, TaskCreated) subscription=ByEventClassType(agentIdOverride=event-stream-6f222da2-133b-45fe-bbf7-62022ed2df30, eventClassTypes=[(class link.socket.ampere.agents.events.Event$TaskCreated, TaskCreated)])
[EventBus][SUBSCRIPTION] type=(class link.socket.ampere.agents.events.Event$QuestionRaised, QuestionRaised) subscription=ByEventClassType(agentIdOverride=event-stream-30cd4054-69fb-4dd3-bdcc-783f478fd36a, eventClassTypes=[(class link.socket.ampere.agents.events.Event$QuestionRaised, QuestionRaised)])
[EventBus][SUBSCRIPTION] type=(class link.socket.ampere.agents.events.Event$CodeSubmitted, CodeSubmitted) subscription=ByEventClassType(agentIdOverride=event-stream-3dff64e7-812a-4691-9593-bf5d16d4c685, eventClassTypes=[(class link.socket.ampere.agents.events.Event$CodeSubmitted, CodeSubmitted)])
```

---

The changes in this PR were written entirely by Claude Code, and it's not implementing the functionality in a scalable way.

I've created Issue #16 for fixing this.  