### PR TITLE
Add SQLDelight queries for time-range event retrieval with filtering

### DIFF
--- a/shared/src/commonMain/sqldelight/link/socket/ampere/db/events/EventStore.sq
+++ b/shared/src/commonMain/sqldelight/link/socket/ampere/db/events/EventStore.sq
@@ -43,3 +43,31 @@ SELECT event_id, event_type, source_id, timestamp, payload
 FROM EventStore
 WHERE timestamp >= ? AND timestamp <= ?
 ORDER BY timestamp ASC;
+
+-- Query events with event type filter
+getEventsBetweenWithEventTypes:
+SELECT event_id, event_type, source_id, timestamp, payload
+FROM EventStore
+WHERE timestamp >= :fromTime
+  AND timestamp <= :toTime
+  AND event_type IN :eventTypes
+ORDER BY timestamp ASC;
+
+-- Query events with source ID filter
+getEventsBetweenWithSourceIds:
+SELECT event_id, event_type, source_id, timestamp, payload
+FROM EventStore
+WHERE timestamp >= :fromTime
+  AND timestamp <= :toTime
+  AND source_id IN :sourceIds
+ORDER BY timestamp ASC;
+
+-- Query events with both event type and source ID filters
+getEventsBetweenWithBothFilters:
+SELECT event_id, event_type, source_id, timestamp, payload
+FROM EventStore
+WHERE timestamp >= :fromTime
+  AND timestamp <= :toTime
+  AND event_type IN :eventTypes
+  AND source_id IN :sourceIds
+ORDER BY timestamp ASC;


### PR DESCRIPTION
Implements Task 5 of AMPERE-001 (issue #17) to enable historical event replay with database-level filtering for better performance.

Changes:
- Added 3 new SQLDelight queries to EventStore.sq:
  * getEventsBetweenWithEventTypes: Filter by event types
  * getEventsBetweenWithSourceIds: Filter by source IDs
  * getEventsBetweenWithBothFilters: Combine both filters

- Added getEventsWithFilters() method to EventRepository that intelligently selects the appropriate query based on which filters are provided, applying filters at the database level rather than in memory

- Updated EventRelayServiceImpl.replayEvents() to use the new filtered queries for event types and source IDs, with remaining filters (urgency, eventId) still applied in-memory

- Added comprehensive test coverage in EventRepositoryTest:
  * Time range filtering
  * Event type filtering
  * Source ID filtering
  * Combined filters with AND logic
  * Edge cases (empty ranges, exact timestamps, chronological ordering)

This enables time-travel debugging by efficiently querying historical events within specific time windows with optional filtering by event type and source.