### PR TITLE
Add StatusCommand for system-wide dashboard view 

### DIFF
--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/AmpereContext.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/AmpereContext.kt
@@ -10,6 +10,8 @@ import link.socket.ampere.agents.events.EnvironmentService
 import link.socket.ampere.agents.events.messages.DefaultThreadViewService
 import link.socket.ampere.agents.events.messages.ThreadViewService
 import link.socket.ampere.agents.events.relay.EventRelayService
+import link.socket.ampere.agents.events.tickets.DefaultTicketViewService
+import link.socket.ampere.agents.events.tickets.TicketViewService
 import link.socket.ampere.agents.events.utils.ConsoleEventLogger
 import link.socket.ampere.agents.events.utils.EventLogger
 import link.socket.ampere.data.DEFAULT_JSON
@@ -100,6 +102,14 @@ class AmpereContext(
      */
     val threadViewService: ThreadViewService = DefaultThreadViewService(
         messageRepository = environmentService.messageRepository
+    )
+
+    /**
+     * Ticket view service for querying ticket state.
+     * Provides high-level views of ticket data for CLI display.
+     */
+    val ticketViewService: TicketViewService = DefaultTicketViewService(
+        ticketRepository = environmentService.ticketRepository
     )
 
     /**

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/Main.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/Main.kt
@@ -24,7 +24,8 @@ fun main(args: Array<String>) {
         AmpereCommand(context)
             .subcommands(
                 WatchCommand(context.eventRelayService),
-                ThreadCommand(context.threadViewService)
+                ThreadCommand(context.threadViewService),
+                StatusCommand(context.threadViewService, context.ticketViewService)
             )
             .main(args)
     } finally {

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/StatusCommand.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/StatusCommand.kt
@@ -1,0 +1,228 @@
+package link.socket.ampere
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.mordant.rendering.TextColors.cyan
+import com.github.ajalt.mordant.rendering.TextColors.gray
+import com.github.ajalt.mordant.rendering.TextColors.green
+import com.github.ajalt.mordant.rendering.TextColors.red
+import com.github.ajalt.mordant.rendering.TextColors.yellow
+import com.github.ajalt.mordant.rendering.TextStyles.bold
+import com.github.ajalt.mordant.rendering.TextStyles.dim
+import com.github.ajalt.mordant.table.table
+import com.github.ajalt.mordant.terminal.Terminal
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import link.socket.ampere.agents.events.messages.ThreadViewService
+import link.socket.ampere.agents.events.tickets.TicketViewService
+import link.socket.ampere.data.DEFAULT_JSON
+import kotlin.time.Duration.Companion.hours
+
+/**
+ * Display a comprehensive dashboard of system state.
+ * This is your situational awareness command.
+ */
+class StatusCommand(
+    private val threadViewService: ThreadViewService,
+    private val ticketViewService: TicketViewService
+) : CliktCommand(
+    name = "status",
+    help = "Show system-wide status dashboard"
+) {
+    private val jsonOutput by option("--json", "-j", help = "Output as JSON").flag()
+
+    private val terminal = Terminal()
+
+    override fun run() = runBlocking {
+        // Fetch data from multiple services concurrently
+        val threadsDeferred = async { threadViewService.listActiveThreads() }
+        val ticketsDeferred = async { ticketViewService.listActiveTickets() }
+
+        val threadsResult = threadsDeferred.await()
+        val ticketsResult = ticketsDeferred.await()
+
+        if (jsonOutput) {
+            // JSON output mode
+            outputJson(threadsResult, ticketsResult)
+        } else {
+            // Human-readable dashboard
+            outputDashboard(threadsResult, ticketsResult)
+        }
+    }
+
+    /**
+     * Output status as JSON for scripting/automation.
+     */
+    private fun outputJson(
+        threadsResult: Result<List<link.socket.ampere.agents.events.messages.ThreadSummary>>,
+        ticketsResult: Result<List<link.socket.ampere.agents.events.tickets.TicketSummary>>
+    ) {
+        val status = StatusDashboard(
+            threads = threadsResult.getOrNull()?.let { threads ->
+                ThreadStatus(
+                    total = threads.size,
+                    withEscalations = threads.count { it.hasUnreadEscalations },
+                    needingAttention = threads.count {
+                        it.hasUnreadEscalations || isStale(it.lastActivity)
+                    }
+                )
+            },
+            tickets = ticketsResult.getOrNull()?.let { tickets ->
+                TicketStatus(
+                    total = tickets.size,
+                    byStatus = tickets.groupBy { it.status }.mapValues { it.value.size },
+                    unassigned = tickets.count { it.assigneeId == null },
+                    highPriority = tickets.count { it.priority == "High" || it.priority == "Critical" }
+                )
+            },
+            errors = buildList {
+                threadsResult.exceptionOrNull()?.let { add("threads: ${it.message}") }
+                ticketsResult.exceptionOrNull()?.let { add("tickets: ${it.message}") }
+            }.takeIf { it.isNotEmpty() }
+        )
+
+        terminal.println(DEFAULT_JSON.encodeToString(status))
+    }
+
+    /**
+     * Output status as a formatted dashboard for human viewing.
+     */
+    private fun outputDashboard(
+        threadsResult: Result<List<link.socket.ampere.agents.events.messages.ThreadSummary>>,
+        ticketsResult: Result<List<link.socket.ampere.agents.events.tickets.TicketSummary>>
+    ) {
+        terminal.println(bold(cyan("⚡ AMPERE System Status")))
+        terminal.println()
+
+        // Threads section
+        terminal.println(bold("📝 Threads"))
+        threadsResult.fold(
+            onSuccess = { threads ->
+                if (threads.isEmpty()) {
+                    terminal.println(dim("  No active threads"))
+                } else {
+                    val escalated = threads.count { it.hasUnreadEscalations }
+                    val stale = threads.count { isStale(it.lastActivity) && !it.hasUnreadEscalations }
+
+                    terminal.println("  Total: ${green(threads.size.toString())} active")
+
+                    if (escalated > 0) {
+                        terminal.println("  ${red("⚠ $escalated")} with escalations")
+                    }
+
+                    if (stale > 0) {
+                        terminal.println("  ${yellow("⏰ $stale")} stale (>24h since activity)")
+                    }
+                }
+            },
+            onFailure = { error ->
+                terminal.println(red("  Error: ${error.message}"))
+            }
+        )
+        terminal.println()
+
+        // Tickets section
+        terminal.println(bold("🎫 Tickets"))
+        ticketsResult.fold(
+            onSuccess = { tickets ->
+                if (tickets.isEmpty()) {
+                    terminal.println(dim("  No active tickets"))
+                } else {
+                    val byStatus = tickets.groupBy { it.status }
+                    val unassigned = tickets.count { it.assigneeId == null }
+                    val highPriority = tickets.count { it.priority == "High" || it.priority == "Critical" }
+
+                    terminal.println("  Total: ${green(tickets.size.toString())} active")
+
+                    // Show breakdown by status
+                    byStatus.entries.sortedByDescending { it.value.size }.forEach { (status, statusTickets) ->
+                        val color = when (status) {
+                            "InProgress" -> green
+                            "Todo" -> cyan
+                            "Blocked" -> red
+                            else -> gray
+                        }
+                        terminal.println("    ${color(status)}: ${statusTickets.size}")
+                    }
+
+                    if (unassigned > 0) {
+                        terminal.println("  ${yellow("⚠ $unassigned")} unassigned")
+                    }
+
+                    if (highPriority > 0) {
+                        terminal.println("  ${red("🔥 $highPriority")} high priority")
+                    }
+                }
+            },
+            onFailure = { error ->
+                terminal.println(red("  Error: ${error.message}"))
+            }
+        )
+        terminal.println()
+
+        // Summary section with any urgent items
+        val urgentItems = mutableListOf<String>()
+
+        threadsResult.getOrNull()?.let { threads ->
+            val escalated = threads.filter { it.hasUnreadEscalations }
+            if (escalated.isNotEmpty()) {
+                urgentItems.add("${escalated.size} thread(s) need human attention")
+            }
+        }
+
+        ticketsResult.getOrNull()?.let { tickets ->
+            val blocked = tickets.filter { it.status == "Blocked" }
+            if (blocked.isNotEmpty()) {
+                urgentItems.add("${blocked.size} ticket(s) blocked")
+            }
+        }
+
+        if (urgentItems.isNotEmpty()) {
+            terminal.println(bold(red("⚠ Needs Attention:")))
+            urgentItems.forEach { item ->
+                terminal.println("  • $item")
+            }
+        } else {
+            terminal.println(green("✓ All systems nominal"))
+        }
+    }
+
+    /**
+     * Check if a thread is stale (no activity in 24 hours).
+     */
+    private fun isStale(lastActivity: Instant): Boolean {
+        val now = Clock.System.now()
+        val threshold = 24.hours
+        return (now - lastActivity) > threshold
+    }
+}
+
+/**
+ * JSON representation of system status.
+ */
+@Serializable
+data class StatusDashboard(
+    val threads: ThreadStatus?,
+    val tickets: TicketStatus?,
+    val errors: List<String>?
+)
+
+@Serializable
+data class ThreadStatus(
+    val total: Int,
+    val withEscalations: Int,
+    val needingAttention: Int
+)
+
+@Serializable
+data class TicketStatus(
+    val total: Int,
+    val byStatus: Map<String, Int>,
+    val unassigned: Int,
+    val highPriority: Int
+)


### PR DESCRIPTION
Implements AMPERE-002 Task 5: Create a comprehensive status command that provides situational awareness across the entire system. 

Closes #24 

Changes:
- Add StatusCommand.kt with dashboard display functionality
- Support both human-readable and JSON output modes
- Add TicketViewService to AmpereContext for ticket queries
- Register StatusCommand in Main.kt

Features:
- Shows thread statistics (total, escalations, stale threads)
- Shows ticket statistics (by status, unassigned, high priority)
- Highlights urgent items needing attention
- Concurrent data fetching for performance
- Color-coded output for easy scanning
- JSON mode for scripting/automation with --json flag