### PR TITLE
AMP-205.1 Add interactive REPL mode to AMPERE CLI

### DIFF
--- a/ampere-cli/build.gradle.kts
+++ b/ampere-cli/build.gradle.kts
@@ -35,6 +35,9 @@ kotlin {
                 // Terminal rendering with colors and styles
                 implementation("com.github.ajalt.mordant:mordant:2.7.2")
 
+                // REPL terminal handling
+                implementation("org.jline:jline:3.25.0")
+
                 // Coroutines
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
 

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/InteractiveCommand.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/InteractiveCommand.kt
@@ -1,0 +1,27 @@
+package link.socket.ampere
+
+import com.github.ajalt.clikt.core.CliktCommand
+import link.socket.ampere.repl.ReplSession
+
+/**
+ * Launches an interactive REPL session for AMPERE.
+ *
+ * This is the default mode when no subcommand is specified.
+ * It keeps the environment running while allowing multiple commands
+ * to be executed in sequence.
+ */
+class InteractiveCommand(
+    private val context: AmpereContext
+) : CliktCommand(
+    name = "interactive",
+    help = "Start an interactive REPL session (default mode)"
+) {
+    override fun run() {
+        val session = ReplSession(context)
+        try {
+            session.start()
+        } finally {
+            session.close()
+        }
+    }
+}

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/Main.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/Main.kt
@@ -9,7 +9,7 @@ import com.github.ajalt.clikt.core.subcommands
  * This function:
  * 1. Creates an AmpereContext to initialize all dependencies
  * 2. Starts the environment orchestrator
- * 3. Runs the CLI command
+ * 3. Runs the CLI command (defaults to interactive mode if no args)
  * 4. Cleans up resources on exit
  */
 fun main(args: Array<String>) {
@@ -20,15 +20,23 @@ fun main(args: Array<String>) {
         // Start all orchestrator services
         context.start()
 
+        // If no arguments provided, launch interactive mode
+        val effectiveArgs = if (args.isEmpty()) {
+            arrayOf("interactive")
+        } else {
+            args
+        }
+
         // Run the CLI with injected dependencies
         AmpereCommand()
             .subcommands(
+                InteractiveCommand(context),
                 WatchCommand(context.eventRelayService),
                 ThreadCommand(context.threadViewService),
                 StatusCommand(context.threadViewService, context.ticketViewService),
                 OutcomesCommand(context.outcomeMemoryRepository)
             )
-            .main(args)
+            .main(effectiveArgs)
     } finally {
         // Clean up resources
         context.close()

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/repl/ReplSession.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/repl/ReplSession.kt
@@ -1,0 +1,122 @@
+package link.socket.ampere.repl
+
+import link.socket.ampere.AmpereContext
+import org.jline.reader.LineReader
+import org.jline.reader.LineReaderBuilder
+import org.jline.terminal.Terminal
+import org.jline.terminal.TerminalBuilder
+
+/**
+ * Manages an interactive REPL session for the AMPERE CLI.
+ *
+ * The REPL session maintains a persistent environment where multiple
+ * commands can be executed sequentially without restarting the substrate.
+ * This is the "brainstem interface" connecting human input to agent activity.
+ */
+class ReplSession(
+    private val context: AmpereContext
+) {
+    private val terminal: Terminal = TerminalBuilder.builder()
+        .system(true)
+        .build()
+
+    private val reader: LineReader = LineReaderBuilder.builder()
+        .terminal(terminal)
+        .build()
+
+    /**
+     * Start the REPL loop.
+     * Displays welcome banner, then enters command loop until exit.
+     */
+    fun start() {
+        displayWelcomeBanner()
+        runCommandLoop()
+    }
+
+    private fun displayWelcomeBanner() {
+        val banner = """
+        ╔═══════════════════════════════════════════════════════╗
+        ║  AMPERE Interactive Shell v0.1.0                      ║
+        ║  Autonomous Multi-Process Execution & Relay Env       ║
+        ║                                                       ║
+        ║  Type 'help' for commands, 'exit' to quit            ║
+        ║  Press Ctrl+C to interrupt running observations       ║
+        ╚═══════════════════════════════════════════════════════╝
+        """.trimIndent()
+
+        terminal.writer().println(banner)
+        terminal.writer().println()
+
+        // Display initial system status
+        displaySystemStatus()
+        terminal.writer().println()
+    }
+
+    private fun displaySystemStatus() {
+        // TODO: Pull actual metrics from context services
+        terminal.writer().println("System Status: ● Running")
+    }
+
+    private fun runCommandLoop() {
+        while (true) {
+            try {
+                val line = reader.readLine("ampere> ")
+
+                if (line.isNullOrBlank()) {
+                    continue
+                }
+
+                val result = executeCommand(line.trim())
+
+                if (result == CommandResult.EXIT) {
+                    terminal.writer().println("Goodbye! Shutting down environment...")
+                    break
+                }
+
+            } catch (e: Exception) {
+                terminal.writer().println("Error: ${e.message}")
+            }
+        }
+    }
+
+    private fun executeCommand(input: String): CommandResult {
+        val parts = input.split(" ", limit = 2)
+        val command = parts[0].lowercase()
+        val args = parts.getOrNull(1) ?: ""
+
+        return when (command) {
+            "exit", "quit" -> CommandResult.EXIT
+            "help" -> {
+                displayHelp()
+                CommandResult.SUCCESS
+            }
+            else -> {
+                terminal.writer().println("Unknown command: $command")
+                terminal.writer().println("Type 'help' for available commands")
+                CommandResult.ERROR
+            }
+        }
+    }
+
+    private fun displayHelp() {
+        val help = """
+        Available commands:
+          help             Show this help message
+          exit, quit       Exit the interactive session
+
+        More commands coming soon...
+        """.trimIndent()
+
+        terminal.writer().println(help)
+    }
+
+    fun close() {
+        terminal.close()
+    }
+}
+
+enum class CommandResult {
+    SUCCESS,
+    ERROR,
+    EXIT
+}


### PR DESCRIPTION
Implements foundation for interactive shell that maintains persistent environment across commands. This establishes the "motor cortex" interface for affecting the substrate.

Changes:
- Add JLine3 dependency for terminal handling
- Create ReplSession class with command loop and banner
- Create InteractiveCommand as Clikt subcommand
- Update Main.kt to default to interactive mode when no args provided
- Support both 'exit' and 'quit' commands
- Display welcome banner with system status
- Basic help command showing available commands

The REPL acts as the brainstem interface between human commands and autonomous agent processes, keeping the AmpereContext alive across multiple sequential command invocations.

Subsequent tickets will add:
- Signal handling for Ctrl+C interruption
- Integration of existing observation commands
- Action commands (ticket create, message post, agent wake)
- Command history and tab completion

Closes #65 