### PR TITLE
AMP-205.4: Add interactivity to REPL

### DIFF
--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/AmpereContext.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/AmpereContext.kt
@@ -15,6 +15,9 @@ import link.socket.ampere.agents.events.tickets.DefaultTicketViewService
 import link.socket.ampere.agents.events.tickets.TicketViewService
 import link.socket.ampere.agents.events.utils.ConsoleEventLogger
 import link.socket.ampere.agents.events.utils.EventLogger
+import link.socket.ampere.agents.service.AgentActionService
+import link.socket.ampere.agents.service.MessageActionService
+import link.socket.ampere.agents.service.TicketActionService
 import link.socket.ampere.data.DEFAULT_JSON
 import link.socket.ampere.db.Database
 
@@ -118,6 +121,38 @@ class AmpereContext(
      */
     val outcomeMemoryRepository: link.socket.ampere.agents.core.memory.OutcomeMemoryRepository
         get() = environmentService.outcomeMemoryRepository
+
+    /**
+     * Ticket action service for creating and managing tickets from CLI.
+     */
+    val ticketActionService: TicketActionService by lazy {
+        val eventApi = environmentService.createEventApi("human-cli")
+        TicketActionService(
+            ticketRepository = environmentService.ticketRepository,
+            eventApi = eventApi,
+        )
+    }
+
+    /**
+     * Message action service for posting messages and creating threads from CLI.
+     */
+    val messageActionService: MessageActionService by lazy {
+        val eventApi = environmentService.createEventApi("human-cli")
+        MessageActionService(
+            messageRepository = environmentService.messageRepository,
+            eventApi = eventApi,
+        )
+    }
+
+    /**
+     * Agent action service for triggering agent actions from CLI.
+     */
+    val agentActionService: AgentActionService by lazy {
+        val eventApi = environmentService.createEventApi("human-cli")
+        AgentActionService(
+            eventApi = eventApi,
+        )
+    }
 
     /**
      * Subscribe to all events for an agent.

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/repl/ActionCommandRegistry.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/repl/ActionCommandRegistry.kt
@@ -1,0 +1,344 @@
+package link.socket.ampere.repl
+
+import kotlinx.coroutines.runBlocking
+import link.socket.ampere.AmpereContext
+import link.socket.ampere.agents.core.status.TicketStatus
+import link.socket.ampere.agents.events.tickets.TicketPriority
+import link.socket.ampere.agents.events.tickets.TicketType
+import org.jline.terminal.Terminal
+
+/**
+ * Registry of action commands that affect the substrate.
+ *
+ * These commands send impulses through the motor cortex - emitting
+ * events that trigger agent reactions and state changes.
+ */
+class ActionCommandRegistry(
+    private val context: AmpereContext,
+    private val terminal: Terminal,
+) {
+    /**
+     * Execute an action command from user input.
+     * Returns null if the command is not an action command.
+     */
+    suspend fun executeIfMatches(input: String): CommandResult? {
+        val parts = input.split(" ")
+        val command = parts[0].lowercase()
+
+        return when (command) {
+            "ticket" -> executeTicketAction(parts.drop(1))
+            "message" -> executeMessageAction(parts.drop(1))
+            "agent" -> executeAgentAction(parts.drop(1))
+            else -> null
+        }
+    }
+
+    private suspend fun executeTicketAction(args: List<String>): CommandResult {
+        if (args.isEmpty()) {
+            terminal.writer().println("Usage: ticket <create|assign|status|list> ...")
+            return CommandResult.ERROR
+        }
+
+        return when (args[0].lowercase()) {
+            "create" -> createTicket(args.drop(1))
+            "assign" -> assignTicket(args.drop(1))
+            "status" -> updateTicketStatus(args.drop(1))
+            "list" -> listTickets(args.drop(1))
+            else -> {
+                terminal.writer().println("Unknown ticket subcommand: ${args[0]}")
+                CommandResult.ERROR
+            }
+        }
+    }
+
+    private suspend fun createTicket(args: List<String>): CommandResult {
+        // Parse: ticket create "TITLE" --priority HIGH --description "DESC" --type FEATURE
+        if (args.isEmpty()) {
+            terminal.writer().println("Usage: ticket create \"TITLE\" [--priority PRIORITY] [--description \"DESC\"] [--type TYPE]")
+            return CommandResult.ERROR
+        }
+
+        val title = args[0].trim('"')
+        var priority = TicketPriority.MEDIUM
+        var description = ""
+        var type = TicketType.TASK
+
+        // Parse flags
+        var i = 1
+        while (i < args.size) {
+            when (args[i].lowercase()) {
+                "--priority" -> {
+                    if (i + 1 < args.size) {
+                        priority = try {
+                            TicketPriority.valueOf(args[i + 1].uppercase())
+                        } catch (e: IllegalArgumentException) {
+                            terminal.writer().println("Invalid priority: ${args[i + 1]}")
+                            terminal.writer().println("Valid values: LOW, MEDIUM, HIGH, CRITICAL")
+                            return CommandResult.ERROR
+                        }
+                        i += 2
+                    } else {
+                        terminal.writer().println("Missing value for --priority")
+                        return CommandResult.ERROR
+                    }
+                }
+                "--description" -> {
+                    if (i + 1 < args.size) {
+                        description = args[i + 1].trim('"')
+                        i += 2
+                    } else {
+                        terminal.writer().println("Missing value for --description")
+                        return CommandResult.ERROR
+                    }
+                }
+                "--type" -> {
+                    if (i + 1 < args.size) {
+                        type = try {
+                            TicketType.valueOf(args[i + 1].uppercase())
+                        } catch (e: IllegalArgumentException) {
+                            terminal.writer().println("Invalid type: ${args[i + 1]}")
+                            terminal.writer().println("Valid values: FEATURE, BUG, TASK, SPIKE")
+                            return CommandResult.ERROR
+                        }
+                        i += 2
+                    } else {
+                        terminal.writer().println("Missing value for --type")
+                        return CommandResult.ERROR
+                    }
+                }
+                else -> i++
+            }
+        }
+
+        val result = context.ticketActionService.createTicket(
+            title = title,
+            description = description,
+            priority = priority,
+            type = type,
+        )
+
+        return when {
+            result.isSuccess -> {
+                val ticket = result.getOrThrow()
+                terminal.writer().println("✓ Created ticket ${ticket.id}: $title [$priority]")
+                terminal.writer().println("  Event: TicketCreated emitted")
+                CommandResult.SUCCESS
+            }
+            else -> {
+                terminal.writer().println("✗ Failed to create ticket: ${result.exceptionOrNull()?.message}")
+                CommandResult.ERROR
+            }
+        }
+    }
+
+    private suspend fun assignTicket(args: List<String>): CommandResult {
+        // Parse: ticket assign TICKET_ID AGENT_ID
+        if (args.size < 2) {
+            terminal.writer().println("Usage: ticket assign TICKET_ID AGENT_ID")
+            return CommandResult.ERROR
+        }
+
+        val ticketId = args[0]
+        val agentId = args[1]
+
+        val result = context.ticketActionService.assignTicket(ticketId, agentId)
+
+        return when {
+            result.isSuccess -> {
+                terminal.writer().println("✓ Assigned ticket $ticketId to $agentId")
+                terminal.writer().println("  Event: TicketAssigned emitted")
+                CommandResult.SUCCESS
+            }
+            else -> {
+                terminal.writer().println("✗ Failed to assign ticket: ${result.exceptionOrNull()?.message}")
+                CommandResult.ERROR
+            }
+        }
+    }
+
+    private suspend fun updateTicketStatus(args: List<String>): CommandResult {
+        // Parse: ticket status TICKET_ID STATUS
+        if (args.size < 2) {
+            terminal.writer().println("Usage: ticket status TICKET_ID STATUS")
+            return CommandResult.ERROR
+        }
+
+        val ticketId = args[0]
+        val status = try {
+            TicketStatus.fromString(args[1])
+        } catch (e: IllegalArgumentException) {
+            terminal.writer().println("Invalid status: ${args[1]}")
+            terminal.writer().println("Valid values: Backlog, Ready, InProgress, Blocked, Done, Cancelled")
+            return CommandResult.ERROR
+        }
+
+        val result = context.ticketActionService.updateStatus(ticketId, status)
+
+        return when {
+            result.isSuccess -> {
+                terminal.writer().println("✓ Updated ticket $ticketId status to $status")
+                terminal.writer().println("  Event: TicketStatusChanged emitted")
+                CommandResult.SUCCESS
+            }
+            else -> {
+                terminal.writer().println("✗ Failed to update status: ${result.exceptionOrNull()?.message}")
+                CommandResult.ERROR
+            }
+        }
+    }
+
+    private suspend fun listTickets(args: List<String>): CommandResult {
+        // This is actually an observation command but fits thematically here
+        terminal.writer().println("Ticket listing: use 'status' command to see system-wide ticket status")
+        return CommandResult.SUCCESS
+    }
+
+    private suspend fun executeMessageAction(args: List<String>): CommandResult {
+        if (args.isEmpty()) {
+            terminal.writer().println("Usage: message <post|create-thread> ...")
+            return CommandResult.ERROR
+        }
+
+        return when (args[0].lowercase()) {
+            "post" -> postMessage(args.drop(1))
+            "create-thread" -> createThread(args.drop(1))
+            else -> {
+                terminal.writer().println("Unknown message subcommand: ${args[0]}")
+                CommandResult.ERROR
+            }
+        }
+    }
+
+    private suspend fun postMessage(args: List<String>): CommandResult {
+        // Parse: message post THREAD_ID "CONTENT" --sender SENDER_ID
+        if (args.size < 2) {
+            terminal.writer().println("Usage: message post THREAD_ID \"CONTENT\" [--sender SENDER_ID]")
+            return CommandResult.ERROR
+        }
+
+        val threadId = args[0]
+        val content = args[1].trim('"')
+        val senderId = if (args.size > 3 && args[2] == "--sender") {
+            args[3]
+        } else {
+            "human"
+        }
+
+        val result = context.messageActionService.postMessage(
+            threadId = threadId,
+            content = content,
+            senderId = senderId,
+        )
+
+        return when {
+            result.isSuccess -> {
+                terminal.writer().println("✓ Posted message to thread $threadId")
+                terminal.writer().println("  Event: MessagePosted emitted")
+                CommandResult.SUCCESS
+            }
+            else -> {
+                terminal.writer().println("✗ Failed to post message: ${result.exceptionOrNull()?.message}")
+                CommandResult.ERROR
+            }
+        }
+    }
+
+    private suspend fun createThread(args: List<String>): CommandResult {
+        // Parse: message create-thread --title "TITLE" --participants ID1,ID2
+        var title: String? = null
+        var participants: List<String>? = null
+
+        var i = 0
+        while (i < args.size) {
+            when (args[i].lowercase()) {
+                "--title" -> {
+                    if (i + 1 < args.size) {
+                        title = args[i + 1].trim('"')
+                        i += 2
+                    } else {
+                        terminal.writer().println("Missing value for --title")
+                        return CommandResult.ERROR
+                    }
+                }
+                "--participants" -> {
+                    if (i + 1 < args.size) {
+                        participants = args[i + 1].split(",").map { it.trim() }
+                        i += 2
+                    } else {
+                        terminal.writer().println("Missing value for --participants")
+                        return CommandResult.ERROR
+                    }
+                }
+                else -> i++
+            }
+        }
+
+        if (title == null || participants == null) {
+            terminal.writer().println("Usage: message create-thread --title \"TITLE\" --participants ID1,ID2")
+            return CommandResult.ERROR
+        }
+
+        val result = context.messageActionService.createThread(
+            title = title,
+            participantIds = participants,
+        )
+
+        return when {
+            result.isSuccess -> {
+                val thread = result.getOrThrow()
+                terminal.writer().println("✓ Created thread ${thread.id}: $title")
+                terminal.writer().println("  Participants: ${participants.joinToString(", ")}")
+                terminal.writer().println("  Event: ThreadCreated emitted")
+                CommandResult.SUCCESS
+            }
+            else -> {
+                terminal.writer().println("✗ Failed to create thread: ${result.exceptionOrNull()?.message}")
+                CommandResult.ERROR
+            }
+        }
+    }
+
+    private suspend fun executeAgentAction(args: List<String>): CommandResult {
+        if (args.isEmpty()) {
+            terminal.writer().println("Usage: agent <wake|list> ...")
+            return CommandResult.ERROR
+        }
+
+        return when (args[0].lowercase()) {
+            "wake" -> wakeAgent(args.drop(1))
+            "list" -> listAgents(args.drop(1))
+            else -> {
+                terminal.writer().println("Unknown agent subcommand: ${args[0]}")
+                CommandResult.ERROR
+            }
+        }
+    }
+
+    private suspend fun wakeAgent(args: List<String>): CommandResult {
+        if (args.isEmpty()) {
+            terminal.writer().println("Usage: agent wake AGENT_ID")
+            return CommandResult.ERROR
+        }
+
+        val agentId = args[0]
+        val result = context.agentActionService.wakeAgent(agentId)
+
+        return when {
+            result.isSuccess -> {
+                terminal.writer().println("✓ Sent wake signal to $agentId")
+                terminal.writer().println("  Event: TaskCreated emitted (assigned to $agentId)")
+                CommandResult.SUCCESS
+            }
+            else -> {
+                terminal.writer().println("✗ Failed to wake agent: ${result.exceptionOrNull()?.message}")
+                CommandResult.ERROR
+            }
+        }
+    }
+
+    private suspend fun listAgents(args: List<String>): CommandResult {
+        // Observation command - could delegate to service
+        terminal.writer().println("Agent listing: use 'status' command to see active agents")
+        return CommandResult.SUCCESS
+    }
+}

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/repl/ReplSession.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/repl/ReplSession.kt
@@ -36,6 +36,12 @@ class ReplSession(
         executor
     )
 
+    // Add registry for action commands
+    private val actionCommands = ActionCommandRegistry(
+        context,
+        terminal
+    )
+
     init {
         // Install signal handler for Ctrl+C
         installSignalHandler()
@@ -117,6 +123,12 @@ class ReplSession(
             return observationResult
         }
 
+        // Then check if it's an action command
+        val actionResult = actionCommands.executeIfMatches(input)
+        if (actionResult != null) {
+            return actionResult
+        }
+
         // Otherwise check built-in REPL commands
         val parts = input.split(" ", limit = 2)
         val command = parts[0].lowercase()
@@ -159,11 +171,22 @@ class ReplSession(
           outcomes executor <id> [--limit N]     Show executor performance
           outcomes stats                         Show aggregate statistics
 
+        Action Commands (affect the substrate):
+          ticket create "TITLE" [--priority P] [--description "DESC"] [--type TYPE]
+                                                 Create new ticket (P: LOW|MEDIUM|HIGH|CRITICAL)
+          ticket assign TICKET_ID AGENT_ID       Assign ticket to agent
+          ticket status TICKET_ID STATUS         Update ticket status
+
+          message post THREAD_ID "CONTENT" [--sender ID]
+                                                 Post message to thread
+          message create-thread --title "TITLE" --participants ID1,ID2
+                                                 Create new thread
+
+          agent wake AGENT_ID                    Send wake signal to agent
+
         Session Commands:
           help                Show this help message
           exit, quit          Exit the interactive session
-
-        Action commands coming soon...
         """.trimIndent()
 
         terminal.writer().println(help)

--- a/shared/src/commonMain/kotlin/link/socket/ampere/agents/service/AgentActionService.kt
+++ b/shared/src/commonMain/kotlin/link/socket/ampere/agents/service/AgentActionService.kt
@@ -1,0 +1,40 @@
+package link.socket.ampere.agents.service
+
+import kotlinx.datetime.Clock
+import link.socket.ampere.agents.core.AgentId
+import link.socket.ampere.agents.events.EventSource
+import link.socket.ampere.agents.events.Urgency
+import link.socket.ampere.agents.events.api.AgentEventApi
+import link.socket.ampere.agents.events.utils.generateUUID
+
+/**
+ * Service for agent-related actions.
+ */
+class AgentActionService(
+    private val eventApi: AgentEventApi,
+) {
+    /**
+     * Send a wake signal to an agent by publishing a TaskCreated event.
+     *
+     * This triggers the agent's perceive-reason-act cycle,
+     * causing it to check for new work and decide what to do.
+     *
+     * Note: Since there's no specific AgentWakeRequested event yet,
+     * we use TaskCreated as a wake-up mechanism.
+     */
+    suspend fun wakeAgent(agentId: AgentId): Result<Unit> {
+        return try {
+            // Emit a low-priority task event that will wake the agent
+            eventApi.publishTaskCreated(
+                taskId = "wake-${agentId}-${Clock.System.now().toEpochMilliseconds()}",
+                urgency = Urgency.LOW,
+                description = "Manual wake signal from CLI",
+                assignedTo = agentId,
+            )
+
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/link/socket/ampere/agents/service/MessageActionService.kt
+++ b/shared/src/commonMain/kotlin/link/socket/ampere/agents/service/MessageActionService.kt
@@ -1,0 +1,125 @@
+package link.socket.ampere.agents.service
+
+import kotlinx.datetime.Clock
+import link.socket.ampere.agents.events.EventSource
+import link.socket.ampere.agents.events.EventStatus
+import link.socket.ampere.agents.events.MessageEvent
+import link.socket.ampere.agents.events.api.AgentEventApi
+import link.socket.ampere.agents.events.messages.Message
+import link.socket.ampere.agents.events.messages.MessageChannel
+import link.socket.ampere.agents.events.messages.MessageRepository
+import link.socket.ampere.agents.events.messages.MessageSender
+import link.socket.ampere.agents.events.messages.MessageThread
+import link.socket.ampere.agents.events.messages.MessageThreadId
+import link.socket.ampere.agents.events.utils.generateUUID
+
+/**
+ * Service for message and thread operations that affect the substrate.
+ */
+class MessageActionService(
+    private val messageRepository: MessageRepository,
+    private val eventApi: AgentEventApi,
+) {
+    /**
+     * Post a message to an existing thread and emit MessagePosted event.
+     */
+    suspend fun postMessage(
+        threadId: MessageThreadId,
+        content: String,
+        senderId: String = "human",
+    ): Result<Message> {
+        return try {
+            val now = Clock.System.now()
+            val sender = MessageSender.fromSenderId(senderId)
+
+            val message = Message(
+                id = generateMessageId(),
+                threadId = threadId,
+                sender = sender,
+                content = content,
+                timestamp = now,
+                metadata = null,
+            )
+
+            // Get the thread to find the channel
+            val thread = messageRepository.findThreadById(threadId)
+                .getOrNull()
+                ?: return Result.failure(IllegalArgumentException("Thread not found: $threadId"))
+
+            messageRepository.addMessageToThread(threadId, message)
+                .onSuccess {
+                    // Emit event to notify the substrate
+                    val event = MessageEvent.MessagePosted(
+                        eventId = generateUUID(message.id),
+                        threadId = threadId,
+                        channel = thread.channel,
+                        message = message,
+                    )
+                    eventApi.publish(event)
+                }
+
+            Result.success(message)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    /**
+     * Create a new message thread and emit ThreadCreated event.
+     */
+    suspend fun createThread(
+        title: String,
+        participantIds: List<String>,
+        channel: MessageChannel = MessageChannel.Public.Engineering,
+    ): Result<MessageThread> {
+        return try {
+            val now = Clock.System.now()
+            val threadId = generateThreadId()
+
+            // Create initial message for the thread
+            val initialMessage = Message(
+                id = generateMessageId(),
+                threadId = threadId,
+                sender = MessageSender.Human,
+                content = "Thread created: $title",
+                timestamp = now,
+                metadata = null,
+            )
+
+            val participants = participantIds.map { MessageSender.fromSenderId(it) }.toSet() + MessageSender.Human
+
+            val thread = MessageThread(
+                id = threadId,
+                channel = channel,
+                createdBy = MessageSender.Human,
+                participants = participants,
+                messages = listOf(initialMessage),
+                status = EventStatus.OPEN,
+                createdAt = now,
+                updatedAt = now,
+            )
+
+            messageRepository.saveThread(thread)
+                .onSuccess {
+                    // Emit event to notify the substrate
+                    val event = MessageEvent.ThreadCreated(
+                        eventId = generateUUID(threadId),
+                        thread = thread,
+                    )
+                    eventApi.publish(event)
+                }
+
+            Result.success(thread)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    private fun generateThreadId(): MessageThreadId {
+        return "thread-${Clock.System.now().toEpochMilliseconds()}"
+    }
+
+    private fun generateMessageId(): String {
+        return "msg-${Clock.System.now().toEpochMilliseconds()}"
+    }
+}

--- a/shared/src/commonMain/kotlin/link/socket/ampere/agents/service/TicketActionService.kt
+++ b/shared/src/commonMain/kotlin/link/socket/ampere/agents/service/TicketActionService.kt
@@ -1,0 +1,145 @@
+package link.socket.ampere.agents.service
+
+import kotlinx.datetime.Clock
+import link.socket.ampere.agents.core.AgentId
+import link.socket.ampere.agents.core.status.TicketStatus
+import link.socket.ampere.agents.events.EventSource
+import link.socket.ampere.agents.events.TicketEvent
+import link.socket.ampere.agents.events.Urgency
+import link.socket.ampere.agents.events.api.AgentEventApi
+import link.socket.ampere.agents.events.tickets.Ticket
+import link.socket.ampere.agents.events.tickets.TicketId
+import link.socket.ampere.agents.events.tickets.TicketPriority
+import link.socket.ampere.agents.events.tickets.TicketRepository
+import link.socket.ampere.agents.events.tickets.TicketType
+import link.socket.ampere.agents.events.utils.generateUUID
+
+/**
+ * Service for executing ticket-related actions that affect the substrate.
+ *
+ * All operations emit events through the event bus to notify
+ * agents and update the observable state.
+ */
+class TicketActionService(
+    private val ticketRepository: TicketRepository,
+    private val eventApi: AgentEventApi,
+) {
+    /**
+     * Create a new ticket and emit TicketCreated event.
+     */
+    suspend fun createTicket(
+        title: String,
+        description: String,
+        priority: TicketPriority,
+        type: TicketType = TicketType.TASK,
+    ): Result<Ticket> {
+        return try {
+            val now = Clock.System.now()
+            val ticketId = generateTicketId()
+
+            val ticket = Ticket(
+                id = ticketId,
+                title = title,
+                description = description,
+                type = type,
+                priority = priority,
+                status = TicketStatus.Backlog,
+                assignedAgentId = null,
+                createdByAgentId = "human-cli",
+                createdAt = now,
+                updatedAt = now,
+                dueDate = null,
+            )
+
+            ticketRepository.createTicket(ticket)
+                .onSuccess {
+                    // Emit event to notify the substrate
+                    val event = TicketEvent.TicketCreated(
+                        eventId = generateUUID(ticketId),
+                        ticketId = ticket.id,
+                        title = ticket.title,
+                        description = ticket.description,
+                        type = ticket.type,
+                        priority = ticket.priority,
+                        createdBy = "human-cli",
+                        timestamp = now,
+                        urgency = when (priority) {
+                            TicketPriority.CRITICAL -> Urgency.HIGH
+                            TicketPriority.HIGH -> Urgency.HIGH
+                            TicketPriority.MEDIUM -> Urgency.MEDIUM
+                            TicketPriority.LOW -> Urgency.LOW
+                        },
+                    )
+                    eventApi.publish(event)
+                }
+
+            Result.success(ticket)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    /**
+     * Assign a ticket to an agent and emit TicketAssigned event.
+     */
+    suspend fun assignTicket(
+        ticketId: TicketId,
+        agentId: AgentId?,
+    ): Result<Unit> {
+        return try {
+            ticketRepository.assignTicket(ticketId, agentId)
+                .onSuccess {
+                    // Emit event to notify the substrate
+                    val event = TicketEvent.TicketAssigned(
+                        eventId = generateUUID(ticketId),
+                        ticketId = ticketId,
+                        assignedTo = agentId,
+                        assignedBy = "human-cli",
+                        timestamp = Clock.System.now(),
+                        urgency = Urgency.MEDIUM,
+                    )
+                    eventApi.publish(event)
+                }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    /**
+     * Update ticket status and emit TicketStatusChanged event.
+     */
+    suspend fun updateStatus(
+        ticketId: TicketId,
+        newStatus: TicketStatus,
+    ): Result<Unit> {
+        return try {
+            // Get the current ticket to find old status
+            val ticket = ticketRepository.getTicket(ticketId)
+                .getOrNull()
+                ?: return Result.failure(IllegalArgumentException("Ticket not found: $ticketId"))
+
+            val oldStatus = ticket.status
+
+            ticketRepository.updateStatus(ticketId, newStatus)
+                .onSuccess {
+                    // Emit event to notify the substrate
+                    val event = TicketEvent.TicketStatusChanged(
+                        eventId = generateUUID(ticketId),
+                        ticketId = ticketId,
+                        previousStatus = oldStatus,
+                        newStatus = newStatus,
+                        changedBy = "human-cli",
+                        timestamp = Clock.System.now(),
+                        urgency = Urgency.MEDIUM,
+                    )
+                    eventApi.publish(event)
+                }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    private fun generateTicketId(): TicketId {
+        return "ticket-${Clock.System.now().toEpochMilliseconds()}"
+    }
+}


### PR DESCRIPTION
Implements the motor cortex for the AMPERE CLI, enabling direct interaction with the substrate through action commands that emit events and trigger agent reactions.

Changes:
- Created TicketActionService for ticket operations (create, assign, status)
- Created MessageActionService for messaging operations (post, create-thread)
- Created AgentActionService for agent wake operations
- Added action services to AmpereContext with lazy initialization
- Created ActionCommandRegistry to handle parsing and execution
- Integrated ActionCommandRegistry into ReplSession
- Updated help text to document all action commands

New Commands:
  ticket create "TITLE" [--priority P] [--description D] [--type T] ticket assign TICKET_ID AGENT_ID ticket status TICKET_ID STATUS message post THREAD_ID "CONTENT" [--sender ID] message create-thread --title "TITLE" --participants ID1,ID2 agent wake AGENT_ID

All action commands emit events through the EventBus, making them observable via the watch command and triggering agent reactions asynchronously. This completes the metabolic loop at the CLI level.

Resolves: #68 (AMP-205.4: Add action commands to REPL)
Related: #67, #66, #65, #64

Closes #68 