### PR TITLE
AMP-205.8: Setup mode-based CLI

### DIFF
--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/repl/CommandExecutor.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/repl/CommandExecutor.kt
@@ -49,6 +49,13 @@ class CommandExecutor(
         currentJob = null
     }
 
+    /**
+     * Check if a command is currently executing.
+     */
+    fun isExecuting(): Boolean {
+        return currentJob != null && currentJob?.isActive == true
+    }
+
     fun close() {
         scope.cancel()
     }

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/repl/EventFilterCycler.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/repl/EventFilterCycler.kt
@@ -1,0 +1,45 @@
+package link.socket.ampere.repl
+
+/**
+ * Manages cycling through common event filters during watch.
+ */
+class EventFilterCycler {
+    private val commonFilters = listOf(
+        null,  // All events
+        "TaskCreated",
+        "MessagePosted",
+        "TicketStatusChanged",
+        "TicketAssigned",
+        "QuestionRaised",
+        "CodeSubmitted"
+    )
+
+    private var currentIndex = 0
+
+    /**
+     * Cycle to next filter and return it.
+     */
+    fun cycle(): String? {
+        currentIndex = (currentIndex + 1) % commonFilters.size
+        return commonFilters[currentIndex]
+    }
+
+    /**
+     * Get current filter.
+     */
+    fun current(): String? = commonFilters[currentIndex]
+
+    /**
+     * Get display name for current filter.
+     */
+    fun currentDisplayName(): String {
+        return current() ?: "All Events"
+    }
+
+    /**
+     * Reset to showing all events.
+     */
+    fun reset() {
+        currentIndex = 0
+    }
+}

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/repl/Mode.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/repl/Mode.kt
@@ -1,0 +1,54 @@
+package link.socket.ampere.repl
+
+/**
+ * REPL interaction modes (vim-inspired).
+ */
+enum class Mode {
+    /** Command mode - single-key shortcuts active */
+    NORMAL,
+
+    /** Insert mode - full command entry */
+    INSERT,
+
+    /** Observing mode - watching events or viewing output */
+    OBSERVING
+}
+
+/**
+ * Manages mode transitions and state.
+ */
+class ModeManager {
+    private var currentMode = Mode.INSERT  // Start in insert mode
+    private var lastEscapeTime = 0L
+    private val doubleEscapeThresholdMs = 300L
+
+    fun getCurrentMode() = currentMode
+
+    fun setMode(mode: Mode) {
+        currentMode = mode
+    }
+
+    /**
+     * Handle Escape key press.
+     * Returns true if should trigger emergency exit (double-tap).
+     */
+    fun handleEscape(): Boolean {
+        val now = System.currentTimeMillis()
+        val timeSinceLastEscape = now - lastEscapeTime
+
+        return if (timeSinceLastEscape < doubleEscapeThresholdMs) {
+            // Double-tap detected
+            true
+        } else {
+            // Single escape - switch to normal mode
+            lastEscapeTime = now
+            currentMode = Mode.NORMAL
+            false
+        }
+    }
+
+    fun enterInsertMode() {
+        currentMode = Mode.INSERT
+        lastEscapeTime = 0L
+    }
+}

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/repl/ObservationCommandRegistry.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/repl/ObservationCommandRegistry.kt
@@ -16,7 +16,9 @@ import com.github.ajalt.mordant.terminal.Terminal as MordantTerminal
 class ObservationCommandRegistry(
     private val context: AmpereContext,
     private val terminal: Terminal,
-    private val executor: CommandExecutor
+    private val executor: CommandExecutor,
+    private val statusBar: StatusBar,
+    private val filterCycler: EventFilterCycler
 ) {
     private val renderer = CLIRenderer(MordantTerminal())
 

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/repl/StatusBar.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/repl/StatusBar.kt
@@ -1,0 +1,61 @@
+package link.socket.ampere.repl
+
+import org.jline.terminal.Terminal
+
+/**
+ * Renders the status bar showing current mode, filter, and helpful hints.
+ *
+ * This provides contextual awareness similar to vim's status line,
+ * showing what mode you're in and what actions are available.
+ */
+class StatusBar(
+    private val terminal: Terminal
+) {
+    private var currentMode: Mode = Mode.INSERT
+    private var currentFilter: String? = null
+    private var customMessage: String? = null
+
+    fun render(mode: Mode, filter: String? = null, message: String? = null) {
+        currentMode = mode
+        currentFilter = filter
+        customMessage = message
+
+        val width = terminal.width
+        val separator = "─".repeat(width.coerceAtLeast(1))
+
+        terminal.writer().println(separator)
+
+        // Render mode and status line
+        val statusLine = buildStatusLine()
+        terminal.writer().println(statusLine)
+
+        // Render prompt based on mode
+        val prompt = when (mode) {
+            Mode.NORMAL -> TerminalColors.highlight("⚡") + " "
+            Mode.INSERT -> TerminalColors.highlight("⚡") + " "
+            Mode.OBSERVING -> ""  // No prompt during observation
+        }
+
+        terminal.writer().print(prompt)
+        terminal.writer().flush()
+    }
+
+    private fun buildStatusLine(): String {
+        return when (currentMode) {
+            Mode.NORMAL -> {
+                "  ${TerminalColors.emphasis("-- NORMAL --")} Single-key commands active (i=insert, ?=help)"
+            }
+            Mode.INSERT -> {
+                "  ${TerminalColors.dim("-- INSERT --")} Type commands (Esc=normal mode)"
+            }
+            Mode.OBSERVING -> {
+                val filterInfo = if (currentFilter != null) {
+                    " | Filter: ${TerminalColors.emphasis(currentFilter!!)}"
+                } else {
+                    ""
+                }
+                "  ${TerminalColors.emphasis("-- OBSERVING --")} Press Enter to stop | Ctrl+E to cycle filter$filterInfo"
+            }
+        }
+    }
+}

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/repl/TerminalColors.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/repl/TerminalColors.kt
@@ -20,4 +20,5 @@ object TerminalColors {
     fun warning(message: String) = yellow("⚠ $message")
     fun dim(message: String) = gray(message)
     fun emphasis(message: String) = bold(message)
+    fun highlight(message: String) = blue(bold(message))
 }


### PR DESCRIPTION
Add a complete vim-style modal interaction system to the REPL that enables power users to efficiently navigate and control the CLI through keyboard shortcuts and contextual modes.

Features:
- Three modes: NORMAL (single-key commands), INSERT (full command entry), and OBSERVING (active event watching)
- Single-key shortcuts in NORMAL mode: w=watch, s=status, t=threads, o=outcomes, h=help, c=clear, q=quit
- Mode transitions: Esc switches to NORMAL, i/a/Enter switches to INSERT
- Emergency exit: Double-tap Esc or Ctrl+C for immediate exit
- Event filter cycling: Ctrl+E cycles through common event filters during watch
- Context-aware Ctrl+D: Stops observation or exits depending on current mode
- Visual status bar showing current mode, filter, and helpful hints
- Smart Enter key: Stops observation when pressed during active watching

Components:
- Mode.kt: Mode enum and ModeManager for state tracking
- EventFilterCycler.kt: Cycles through common event type filters
- StatusBar.kt: Renders mode-aware status line with contextual hints
- Updated ReplSession.kt: Complete modal command handling and key bindings
- Updated CommandExecutor.kt: Added isExecuting() for context awareness
- Updated TerminalColors.kt: Added highlight() for emphasized text
- Updated ObservationCommandRegistry.kt: Accepts StatusBar and EventFilterCycler

This transforms the REPL from basic command entry into a professional, ergonomic interface that feels natural to vim users while remaining approachable to all users.

Related: #64 (Phase 5 CLI Interactivity Epic)
Closes #87 