### PR TITLE
AMP-205.7: Fix IntelliJ CLI color output

### DIFF
--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/OutcomesCommand.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/OutcomesCommand.kt
@@ -14,10 +14,10 @@ import com.github.ajalt.mordant.rendering.TextColors.red
 import com.github.ajalt.mordant.rendering.TextColors.yellow
 import com.github.ajalt.mordant.rendering.TextStyles.dim
 import com.github.ajalt.mordant.table.table
-import com.github.ajalt.mordant.terminal.Terminal
 import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.Instant
 import link.socket.ampere.agents.core.memory.OutcomeMemoryRepository
+import link.socket.ampere.repl.TerminalFactory
 
 /**
  * Root command for viewing outcome memory.
@@ -59,7 +59,7 @@ class OutcomesTicketCommand(
     )
 
     override fun run() = runBlocking {
-        val terminal = Terminal()
+        val terminal = TerminalFactory.createTerminal()
 
         outcomeRepository.getOutcomesByTicket(ticketId).fold(
             onSuccess = { outcomes ->
@@ -151,7 +151,7 @@ class OutcomesSearchCommand(
         .default(10)
 
     override fun run() = runBlocking {
-        val terminal = Terminal()
+        val terminal = TerminalFactory.createTerminal()
 
         outcomeRepository.findSimilarOutcomes(query, limit).fold(
             onSuccess = { outcomes ->
@@ -207,7 +207,7 @@ class OutcomesExecutorCommand(
         .default(20)
 
     override fun run() = runBlocking {
-        val terminal = Terminal()
+        val terminal = TerminalFactory.createTerminal()
 
         outcomeRepository.getOutcomesByExecutor(executorId, limit).fold(
             onSuccess = { outcomes ->
@@ -283,7 +283,7 @@ class OutcomesStatsCommand(
     // This would query aggregate data from the repository
     // For now, just a placeholder showing what it could display
     override fun run() {
-        val terminal = Terminal()
+        val terminal = TerminalFactory.createTerminal()
         terminal.println(cyan("📊 OUTCOME STATISTICS"))
         terminal.println()
         terminal.println(yellow("This command shows aggregate learning metrics:"))

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/StatusCommand.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/StatusCommand.kt
@@ -11,7 +11,6 @@ import com.github.ajalt.mordant.rendering.TextColors.yellow
 import com.github.ajalt.mordant.rendering.TextStyles.bold
 import com.github.ajalt.mordant.rendering.TextStyles.dim
 import com.github.ajalt.mordant.table.table
-import com.github.ajalt.mordant.terminal.Terminal
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.Clock
@@ -19,6 +18,7 @@ import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
 import link.socket.ampere.agents.events.messages.ThreadViewService
 import link.socket.ampere.agents.events.tickets.TicketViewService
+import link.socket.ampere.repl.TerminalFactory
 import kotlin.time.Duration.Companion.hours
 
 /**
@@ -32,7 +32,7 @@ class StatusCommand(
     name = "status",
     help = "Show system-wide status dashboard"
 ) {
-    private val terminal = Terminal()
+    private val terminal = TerminalFactory.createTerminal()
 
     override fun run() = runBlocking {
         // Fetch data from multiple services concurrently

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/ThreadCommand.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/ThreadCommand.kt
@@ -3,9 +3,9 @@ package link.socket.ampere
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.subcommands
 import com.github.ajalt.clikt.parameters.arguments.argument
-import com.github.ajalt.mordant.terminal.Terminal
 import kotlinx.coroutines.runBlocking
 import link.socket.ampere.agents.events.messages.ThreadViewService
+import link.socket.ampere.repl.TerminalFactory
 
 /**
  * Root command for thread operations. Doesn't do anything itself,
@@ -13,7 +13,7 @@ import link.socket.ampere.agents.events.messages.ThreadViewService
  */
 class ThreadCommand(
     threadViewService: ThreadViewService,
-    renderer: link.socket.ampere.renderer.CLIRenderer = link.socket.ampere.renderer.CLIRenderer(Terminal())
+    renderer: link.socket.ampere.renderer.CLIRenderer = link.socket.ampere.renderer.CLIRenderer(TerminalFactory.createTerminal())
 ) : CliktCommand(
     name = "thread",
     help = "View conversation threads in the environment"

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/WatchCommand.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/WatchCommand.kt
@@ -3,7 +3,6 @@ package link.socket.ampere
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.options.multiple
 import com.github.ajalt.clikt.parameters.options.option
-import com.github.ajalt.mordant.terminal.Terminal
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.runBlocking
@@ -11,6 +10,7 @@ import link.socket.ampere.agents.events.EventSource
 import link.socket.ampere.agents.events.relay.EventRelayFilters
 import link.socket.ampere.agents.events.relay.EventRelayService
 import link.socket.ampere.renderer.CLIRenderer
+import link.socket.ampere.repl.TerminalFactory
 import link.socket.ampere.util.EventTypeParser
 
 /**
@@ -24,7 +24,7 @@ import link.socket.ampere.util.EventTypeParser
  */
 class WatchCommand(
     private val eventRelayService: EventRelayService,
-    private val renderer: CLIRenderer = CLIRenderer(Terminal()),
+    private val renderer: CLIRenderer = CLIRenderer(TerminalFactory.createTerminal()),
 ) : CliktCommand(
     name = "watch",
     help = """

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/repl/ObservationCommandRegistry.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/repl/ObservationCommandRegistry.kt
@@ -4,7 +4,6 @@ import kotlinx.coroutines.delay
 import link.socket.ampere.*
 import link.socket.ampere.renderer.CLIRenderer
 import org.jline.terminal.Terminal
-import com.github.ajalt.mordant.terminal.Terminal as MordantTerminal
 
 /**
  * Registry of observation commands available in the REPL.
@@ -20,7 +19,7 @@ class ObservationCommandRegistry(
     private val statusBar: StatusBar,
     private val filterCycler: EventFilterCycler
 ) {
-    private val renderer = CLIRenderer(MordantTerminal())
+    private val renderer = CLIRenderer(TerminalFactory.createTerminal())
 
     /**
      * Execute an observation command from user input.

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/repl/ReplSession.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/repl/ReplSession.kt
@@ -338,6 +338,10 @@ class ReplSession(
                 terminal.flush()
                 return CommandResult.SUCCESS
             }
+            ".test-colors", ".colors" -> {
+                testColorOutput()
+                return CommandResult.SUCCESS
+            }
         }
 
         // Expand aliases
@@ -388,6 +392,26 @@ class ReplSession(
                 CommandResult.ERROR
             }
         }
+    }
+
+    /**
+     * Test color output to verify terminal color support.
+     */
+    private fun testColorOutput() {
+        terminal.writer().println()
+        terminal.writer().println("Color Support Test:")
+        terminal.writer().println("━".repeat(50))
+        terminal.writer().println()
+
+        // Display all color tests
+        TerminalColors.getColorTests().forEach { (label, coloredText) ->
+            terminal.writer().println("  $label: $coloredText")
+        }
+
+        terminal.writer().println()
+        terminal.writer().println("If you see colors above, your terminal supports ANSI codes.")
+        terminal.writer().println("Colors enabled: ${TerminalColors.enabled}")
+        terminal.writer().println()
     }
 
     /**
@@ -454,6 +478,9 @@ class ReplSession(
             Ctrl+L      Clear
             ↑/↓         History
 
+            ─── DEBUG ───
+            .test-colors    Test color support
+
             Type 'help <command>' for details
         """.trimIndent()
 
@@ -514,6 +541,9 @@ class ReplSession(
             ═══ ALIASES ═══
             w → watch     s → status    t → thread
             o → outcomes  q → quit      ? → help
+
+            ═══ DEBUG COMMANDS ═══
+            .test-colors    Verify terminal color support
 
             Tip: Start in INSERT mode, press Esc for NORMAL mode shortcuts
         """.trimIndent()

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/repl/TerminalColors.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/repl/TerminalColors.kt
@@ -1,10 +1,10 @@
 package link.socket.ampere.repl
 
-import com.github.ajalt.mordant.rendering.TextColors.*
-import com.github.ajalt.mordant.rendering.TextStyles.*
-
 /**
  * Terminal color utilities for consistent visual feedback.
+ *
+ * Uses raw ANSI codes for maximum compatibility across terminal emulators,
+ * including IntelliJ IDEA, VS Code, iTerm2, and standard terminals.
  *
  * Provides semantic coloring for different types of output:
  * - Success: Green with ✓
@@ -14,11 +14,39 @@ import com.github.ajalt.mordant.rendering.TextStyles.*
  * - Dim: Gray for secondary information
  */
 object TerminalColors {
-    fun success(message: String) = green("✓ $message")
-    fun error(message: String) = red("✗ $message")
-    fun info(message: String) = cyan("ℹ $message")
-    fun warning(message: String) = yellow("⚠ $message")
-    fun dim(message: String) = gray(message)
-    fun emphasis(message: String) = bold(message)
-    fun highlight(message: String) = blue(bold(message))
+    // ANSI color codes - compatible with all modern terminals
+    private const val RESET = "\u001B[0m"
+    private const val GREEN = "\u001B[32m"
+    private const val RED = "\u001B[31m"
+    private const val CYAN = "\u001B[36m"
+    private const val YELLOW = "\u001B[33m"
+    private const val BLUE = "\u001B[34m"
+    private const val GRAY = "\u001B[90m"
+    private const val BOLD = "\u001B[1m"
+
+    /**
+     * Enable/disable colors (can be toggled for testing or non-color terminals).
+     */
+    var enabled: Boolean = true
+
+    fun success(message: String) = if (enabled) "$GREEN✓ $message$RESET" else "✓ $message"
+    fun error(message: String) = if (enabled) "$RED✗ $message$RESET" else "✗ $message"
+    fun info(message: String) = if (enabled) "$CYAN$message$RESET" else message
+    fun warning(message: String) = if (enabled) "$YELLOW⚠ $message$RESET" else "⚠ $message"
+    fun dim(message: String) = if (enabled) "$GRAY$message$RESET" else message
+    fun emphasis(message: String) = if (enabled) "$BOLD$message$RESET" else message
+    fun highlight(message: String) = if (enabled) "$BLUE$BOLD$message$RESET" else message
+
+    /**
+     * Returns all color test strings for verifying terminal support.
+     */
+    fun getColorTests(): List<Pair<String, String>> = listOf(
+        "Success" to success("Success message (should be green)"),
+        "Error" to error("Error message (should be red)"),
+        "Info" to info("Info message (should be cyan)"),
+        "Warning" to warning("Warning message (should be yellow)"),
+        "Highlight" to highlight("Highlighted text (should be bold blue)"),
+        "Dim" to dim("Dimmed text (should be gray)"),
+        "Emphasis" to emphasis("Emphasized text (should be bold)")
+    )
 }

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/repl/TerminalFactory.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/repl/TerminalFactory.kt
@@ -1,0 +1,26 @@
+package link.socket.ampere.repl
+
+import com.github.ajalt.mordant.rendering.AnsiLevel
+import com.github.ajalt.mordant.terminal.Terminal
+
+/**
+ * Factory for creating Mordant Terminal instances with proper configuration
+ * for maximum compatibility across terminal emulators.
+ *
+ * Forces ANSI color support to ensure colors display correctly in:
+ * - IntelliJ IDEA terminal
+ * - VS Code integrated terminal
+ * - iTerm2
+ * - macOS Terminal.app
+ * - Standard Linux terminals
+ */
+object TerminalFactory {
+    /**
+     * Creates a Mordant Terminal with forced ANSI support for color output.
+     */
+    fun createTerminal(): Terminal {
+        return Terminal(
+            ansiLevel = AnsiLevel.TRUECOLOR
+        )
+    }
+}


### PR DESCRIPTION
Replace Mordant auto-detection with forced ANSI support to ensure colors display correctly across all terminal emulators, especially IntelliJ IDEA's integrated terminal.

Changes:
- Replace TerminalColors.kt to use raw ANSI codes instead of Mordant's TextColors functions for maximum compatibility
- Add TerminalFactory.createTerminal() to centralize Mordant Terminal creation with forced ANSI support (AnsiLevel.TRUECOLOR)
- Update all command classes to use TerminalFactory instead of Terminal() constructor (WatchCommand, StatusCommand, ThreadCommand, OutcomesCommand, ObservationCommandRegistry)
- Add .test-colors debug command to verify color support in any terminal
- Add TerminalColors.enabled flag for toggling colors if needed
- Update help text to document the new .test-colors command

This ensures the blue lightning bolt ⚡, colored success/error messages, and all other CLI output display correctly in IntelliJ, VS Code, iTerm2, and standard terminals.

Fixes color rendering issues in IntelliJ IDEA terminal.

Closes #86 