### PR TITLE
AMP-204.6: Implement runLLMToEvaluateOutcomes for learning loop closure

### DIFF
--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/implementations/code/CodeWriterAgent.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/implementations/code/CodeWriterAgent.kt
@@ -1089,7 +1089,7 @@ open class CodeWriterAgent(
      * @param outcomes List of outcomes from recent executions
      * @return An Idea containing synthesized learnings from the outcomes
      */
-    private fun evaluateOutcomesAndGenerateLearnings(outcomes: List<Outcome>): Idea {
+    protected open fun evaluateOutcomesAndGenerateLearnings(outcomes: List<Outcome>): Idea {
         // Handle empty outcomes
         if (outcomes.isEmpty()) {
             return Idea(
@@ -1477,7 +1477,7 @@ open class CodeWriterAgent(
      * @param reason Why the fallback was needed
      * @return A basic Idea with outcome statistics
      */
-    private fun createFallbackLearningIdea(outcomes: List<Outcome>, reason: String): Idea {
+    protected open fun createFallbackLearningIdea(outcomes: List<Outcome>, reason: String): Idea {
         val successCount = outcomes.count { it is Outcome.Success }
         val failureCount = outcomes.count { it is Outcome.Failure }
         val successRate = if (outcomes.isNotEmpty()) {

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/implementations/CodeWriterAgentTest.jvm.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/implementations/CodeWriterAgentTest.jvm.kt
@@ -1132,7 +1132,7 @@ actual class CodeWriterAgentTest {
                 executionStartTimestamp = now,
                 executionEndTimestamp = now.plus(1.seconds),
                 changedFiles = listOf("/absolute/path/User.kt"),
-                validation = link.socket.ampere.agents.execution.results.ExecutionResult.Validated
+                validation = link.socket.ampere.agents.execution.results.ExecutionResult(codeChanges = null, compilation = null, linting = null, tests = null)
             ),
             ExecutionOutcome.CodeChanged.Success(
                 executorId = "executor-1",
@@ -1141,7 +1141,7 @@ actual class CodeWriterAgentTest {
                 executionStartTimestamp = now,
                 executionEndTimestamp = now.plus(1.seconds),
                 changedFiles = listOf("/absolute/path/Order.kt"),
-                validation = link.socket.ampere.agents.execution.results.ExecutionResult.Validated
+                validation = link.socket.ampere.agents.execution.results.ExecutionResult(codeChanges = null, compilation = null, linting = null, tests = null)
             ),
             ExecutionOutcome.CodeChanged.Success(
                 executorId = "executor-1",
@@ -1150,7 +1150,7 @@ actual class CodeWriterAgentTest {
                 executionStartTimestamp = now,
                 executionEndTimestamp = now.plus(1.seconds),
                 changedFiles = listOf("/absolute/path/Product.kt"),
-                validation = link.socket.ampere.agents.execution.results.ExecutionResult.Validated
+                validation = link.socket.ampere.agents.execution.results.ExecutionResult(codeChanges = null, compilation = null, linting = null, tests = null)
             )
         )
 
@@ -1218,7 +1218,7 @@ actual class CodeWriterAgentTest {
                 executionStartTimestamp = now,
                 executionEndTimestamp = now.plus(500.seconds),
                 changedFiles = listOf("Simple.kt"),
-                validation = link.socket.ampere.agents.execution.results.ExecutionResult.Validated
+                validation = link.socket.ampere.agents.execution.results.ExecutionResult(codeChanges = null, compilation = null, linting = null, tests = null)
             ),
             ExecutionOutcome.CodeChanged.Failure(
                 executorId = "executor-1",
@@ -1226,9 +1226,9 @@ actual class CodeWriterAgentTest {
                 taskId = "task-complex",
                 executionStartTimestamp = now,
                 executionEndTimestamp = now.plus(3.seconds),
-                error = link.socket.ampere.agents.core.errors.ExecutionError.ToolError(
-                    message = "Complex task failed",
-                    toolId = "write_code_file"
+                error = link.socket.ampere.agents.core.errors.ExecutionError(
+                    type = link.socket.ampere.agents.core.errors.ExecutionError.Type.TOOL_UNAVAILABLE,
+                    message = "Complex task failed"
                 )
             )
         )
@@ -1298,7 +1298,7 @@ actual class CodeWriterAgentTest {
                 executionStartTimestamp = now,
                 executionEndTimestamp = now.plus(1.seconds),
                 changedFiles = listOf("File1.kt"),
-                validation = link.socket.ampere.agents.execution.results.ExecutionResult.Validated
+                validation = link.socket.ampere.agents.execution.results.ExecutionResult(codeChanges = null, compilation = null, linting = null, tests = null)
             )
         )
 
@@ -1317,7 +1317,7 @@ actual class CodeWriterAgentTest {
                 executionStartTimestamp = now,
                 executionEndTimestamp = now.plus(1.seconds),
                 changedFiles = listOf("File$i.kt"),
-                validation = link.socket.ampere.agents.execution.results.ExecutionResult.Validated
+                validation = link.socket.ampere.agents.execution.results.ExecutionResult(codeChanges = null, compilation = null, linting = null, tests = null)
             )
         }
 
@@ -1390,7 +1390,7 @@ actual class CodeWriterAgentTest {
                 executionStartTimestamp = now,
                 executionEndTimestamp = now.plus(1.seconds),
                 changedFiles = listOf("Test.kt"),
-                validation = link.socket.ampere.agents.execution.results.ExecutionResult.Validated
+                validation = link.socket.ampere.agents.execution.results.ExecutionResult(codeChanges = null, compilation = null, linting = null, tests = null)
             )
         )
 
@@ -1456,7 +1456,7 @@ actual class CodeWriterAgentTest {
                 executionStartTimestamp = now,
                 executionEndTimestamp = now.plus(1.seconds),
                 changedFiles = listOf("Success1.kt"),
-                validation = link.socket.ampere.agents.execution.results.ExecutionResult.Validated
+                validation = link.socket.ampere.agents.execution.results.ExecutionResult(codeChanges = null, compilation = null, linting = null, tests = null)
             ),
             ExecutionOutcome.CodeChanged.Failure(
                 executorId = "executor-1",
@@ -1464,9 +1464,9 @@ actual class CodeWriterAgentTest {
                 taskId = "task-2",
                 executionStartTimestamp = now,
                 executionEndTimestamp = now.plus(2.seconds),
-                error = link.socket.ampere.agents.core.errors.ExecutionError.ToolError(
-                    message = "Failed",
-                    toolId = "write_code_file"
+                error = link.socket.ampere.agents.core.errors.ExecutionError(
+                    type = link.socket.ampere.agents.core.errors.ExecutionError.Type.TOOL_UNAVAILABLE,
+                    message = "Failed"
                 )
             ),
             ExecutionOutcome.CodeChanged.Success(
@@ -1476,7 +1476,7 @@ actual class CodeWriterAgentTest {
                 executionStartTimestamp = now,
                 executionEndTimestamp = now.plus(1.seconds),
                 changedFiles = listOf("Success2.kt"),
-                validation = link.socket.ampere.agents.execution.results.ExecutionResult.Validated
+                validation = link.socket.ampere.agents.execution.results.ExecutionResult(codeChanges = null, compilation = null, linting = null, tests = null)
             )
         )
 
@@ -1548,7 +1548,7 @@ actual class CodeWriterAgentTest {
                 executionStartTimestamp = now,
                 executionEndTimestamp = now.plus(i.seconds),
                 changedFiles = listOf("File$i.kt"),
-                validation = link.socket.ampere.agents.execution.results.ExecutionResult.Validated
+                validation = link.socket.ampere.agents.execution.results.ExecutionResult(codeChanges = null, compilation = null, linting = null, tests = null)
             )
         }
 
@@ -1609,7 +1609,7 @@ actual class CodeWriterAgentTest {
                 executionStartTimestamp = now,
                 executionEndTimestamp = now.plus(1.seconds),
                 changedFiles = listOf("File1.kt"),
-                validation = link.socket.ampere.agents.execution.results.ExecutionResult.Validated
+                validation = link.socket.ampere.agents.execution.results.ExecutionResult(codeChanges = null, compilation = null, linting = null, tests = null)
             ),
             ExecutionOutcome.CodeChanged.Success(
                 executorId = "executor-1",
@@ -1618,7 +1618,7 @@ actual class CodeWriterAgentTest {
                 executionStartTimestamp = now,
                 executionEndTimestamp = now.plus(1.seconds),
                 changedFiles = listOf("File2.kt"),
-                validation = link.socket.ampere.agents.execution.results.ExecutionResult.Validated
+                validation = link.socket.ampere.agents.execution.results.ExecutionResult(codeChanges = null, compilation = null, linting = null, tests = null)
             )
         )
 
@@ -1697,7 +1697,7 @@ actual class CodeWriterAgentTest {
                 executionStartTimestamp = now,
                 executionEndTimestamp = now.plus(1.seconds),
                 changedFiles = listOf("Success.kt"),
-                validation = link.socket.ampere.agents.execution.results.ExecutionResult.Validated
+                validation = link.socket.ampere.agents.execution.results.ExecutionResult(codeChanges = null, compilation = null, linting = null, tests = null)
             ),
             ExecutionOutcome.CodeChanged.Failure(
                 executorId = "executor-1",
@@ -1705,9 +1705,9 @@ actual class CodeWriterAgentTest {
                 taskId = "task-2",
                 executionStartTimestamp = now,
                 executionEndTimestamp = now.plus(1.seconds),
-                error = link.socket.ampere.agents.core.errors.ExecutionError.ToolError(
-                    message = "Failed 1",
-                    toolId = "write_code_file"
+                error = link.socket.ampere.agents.core.errors.ExecutionError(
+                    type = link.socket.ampere.agents.core.errors.ExecutionError.Type.TOOL_UNAVAILABLE,
+                    message = "Failed 1"
                 )
             ),
             ExecutionOutcome.CodeChanged.Failure(
@@ -1716,9 +1716,9 @@ actual class CodeWriterAgentTest {
                 taskId = "task-3",
                 executionStartTimestamp = now,
                 executionEndTimestamp = now.plus(1.seconds),
-                error = link.socket.ampere.agents.core.errors.ExecutionError.ToolError(
-                    message = "Failed 2",
-                    toolId = "write_code_file"
+                error = link.socket.ampere.agents.core.errors.ExecutionError(
+                    type = link.socket.ampere.agents.core.errors.ExecutionError.Type.TOOL_UNAVAILABLE,
+                    message = "Failed 2"
                 )
             )
         )


### PR DESCRIPTION
This commit implements the final piece of the cognitive loop by adding outcome evaluation that transforms execution results into learnings.

Key changes:
- Implemented runLLMToEvaluateOutcomes to analyze execution outcomes
- Added buildOutcomeAnalysisContext to extract patterns from outcomes
- Added buildOutcomeEvaluationPrompt to guide LLM analysis
- Added parseLearningsFromResponse to parse insights into Knowledge
- Added createLearningIdea to synthesize learnings into Ideas
- Added createFallbackLearningIdea for graceful error handling
- Updated extractKnowledgeFromOutcome with meaningful implementation
- Added comprehensive test coverage for all evaluation scenarios

The evaluation function:
- Analyzes success vs failure patterns
- Generates actionable insights with confidence levels
- Stores learnings as Knowledge.FromOutcome in agent memory
- Handles edge cases (empty, blank, mixed outcomes)
- Provides fallback statistics when LLM analysis fails

Tests validate:
- Success pattern identification
- Actionable advice generation
- Confidence levels correlating with evidence
- Learnings persistence in memory
- Mixed outcome handling
- Meta-pattern recognition
- Fallback behavior on errors
- High failure rate warnings

This closes the cognitive loop: perception → ideation → planning → execution → evaluation → enhanced perception (with learnings).

Closes #59 