### PR TITLE
Fix documentation and imports for tool events refactoring

### DIFF
--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/execution/tools/invoke/README.md
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/execution/tools/invoke/README.md
@@ -82,8 +82,8 @@ val invoker = ToolInvoker(tool, eventApi)
 val result = invoker.invoke(request)
 
 // Events emitted:
-// 1. ToolExecutionEvent.Started - before execution
-// 2. ToolExecutionEvent.Completed - after execution (with success/failure/duration metadata)
+// 1. ToolEvent.ToolExecutionStarted - before execution
+// 2. ToolEvent.ToolExecutionCompleted - after execution (with success/failure/duration metadata)
 ```
 
 ### Code Context Tools
@@ -194,39 +194,39 @@ class MyAgent(
 
 ## Event Schema
 
-### ToolExecutionEvent.Started
+### ToolEvent.ToolExecutionStarted
 
 Emitted before tool execution begins.
 
 ```kotlin
-data class Started(
+data class ToolExecutionStarted(
     eventId: EventId,
     timestamp: Instant,
     eventSource: EventSource,
     urgency: Urgency,
-    invocationId: ToolInvocationId,  // Unique per invocation
+    invocationId: String,            // Unique per invocation
     toolId: ToolId,
     toolName: String
-)
+) : ToolEvent
 ```
 
-### ToolExecutionEvent.Completed
+### ToolEvent.ToolExecutionCompleted
 
 Emitted after tool execution finishes (success or failure).
 
 ```kotlin
-data class Completed(
+data class ToolExecutionCompleted(
     eventId: EventId,
     timestamp: Instant,
     eventSource: EventSource,
     urgency: Urgency,
-    invocationId: ToolInvocationId,  // Matches Started event
+    invocationId: String,            // Matches Started event
     toolId: ToolId,
     toolName: String,
     success: Boolean,                // true if succeeded, false if failed
     durationMs: Long,                // Execution duration in milliseconds
     errorMessage: String? = null     // Error message if failed, null if succeeded
-)
+) : ToolEvent
 ```
 
 ## Testing

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/execution/tools/invoke/ToolInvoker.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/execution/tools/invoke/ToolInvoker.kt
@@ -42,8 +42,8 @@ class ToolInvoker<C : ExecutionContext>(
      * Invoke the wrapped tool with the provided request.
      *
      * Handles validation, measures timing, and transforms tool outcomes
-     * into invocation results. Emits ToolExecutionEvent.Started and
-     * ToolExecutionEvent.Completed events if eventApi is provided.
+     * into invocation results. Emits ToolEvent.ToolExecutionStarted and
+     * ToolEvent.ToolExecutionCompleted events if eventApi is provided.
      *
      * The execution flow:
      * 1. Generate invocation ID and emit Started event

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/execution/tools/ToolExecutionWithEventsTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/execution/tools/ToolExecutionWithEventsTest.kt
@@ -21,6 +21,7 @@ import link.socket.ampere.agents.execution.request.ExecutionContext
 import link.socket.ampere.agents.execution.request.ExecutionRequest
 import link.socket.ampere.agents.domain.event.ToolEvent
 import link.socket.ampere.agents.execution.tools.invoke.ToolInvoker
+import link.socket.ampere.agents.execution.tools.invoke.ToolInvocationResult
 import link.socket.ampere.data.DEFAULT_JSON
 import link.socket.ampere.db.Database
 import kotlin.test.AfterTest
@@ -145,7 +146,7 @@ class ToolExecutionWithEventsTest {
         val result = invoker.invoke(request)
 
         // Verify the result
-        assertIs<link.socket.ampere.agents.execution.tools.invoke.ToolInvocationResult.Success>(result)
+        assertIs<ToolInvocationResult.Success>(result)
 
         // Allow events to be processed
         delay(100)
@@ -225,7 +226,7 @@ class ToolExecutionWithEventsTest {
         val result = invoker.invoke(request)
 
         // Verify the result is a failure
-        assertIs<link.socket.ampere.agents.execution.tools.invoke.ToolInvocationResult.Failed>(result)
+        assertIs<ToolInvocationResult.Failed>(result)
 
         // Allow events to be processed
         delay(100)
@@ -294,7 +295,7 @@ class ToolExecutionWithEventsTest {
         val result = invoker.invoke(request)
 
         // Verify the result
-        assertIs<link.socket.ampere.agents.execution.tools.invoke.ToolInvocationResult.Success>(result)
+        assertIs<ToolInvocationResult.Success>(result)
 
         // No events should be emitted (event repository should be empty or only have setup events)
         val events = eventRepository.getAllEvents().getOrNull()


### PR DESCRIPTION
Updates:
- Update ToolInvoker.kt documentation to reference ToolEvent.ToolExecutionStarted/Completed instead of deprecated ToolExecutionEvent names
- Update README.md event schema documentation to reflect new ToolEvent structure
- Add missing import for ToolInvocationResult in ToolExecutionWithEventsTest.kt
- Simplify test assertions to use imported type names instead of fully qualified names

These changes fix the CI build after the tool implementation refactoring that moved ToolExecutionEvent from the invoke package to ToolEvent in the events package.