### PR TITLE
Fix code style issues in CLI triple-pane layout

### DIFF
--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/JazzDemoCommand.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/JazzDemoCommand.kt
@@ -253,7 +253,7 @@ class JazzDemoCommand(
      */
     private fun updateMemoryState(
         current: AgentMemoryPane.AgentMemoryState,
-        watchState: link.socket.ampere.cli.watch.presentation.WatchViewState,
+        watchState: WatchViewState,
         jazzPane: JazzProgressPane
     ): AgentMemoryPane.AgentMemoryState {
         // Count memory events from summaries

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/layout/DemoInputHandler.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/layout/DemoInputHandler.kt
@@ -19,7 +19,7 @@ import org.jline.utils.NonBlockingReader
 class DemoInputHandler(
     private val terminal: Terminal
 ) {
-    private val jlineTerminal = org.jline.terminal.TerminalBuilder.terminal()
+    private val jlineTerminal = TerminalBuilder.terminal()
     private val reader: NonBlockingReader = jlineTerminal.reader()
 
     init {


### PR DESCRIPTION
- Remove fully qualified type name for WatchViewState in JazzDemoCommand.kt for consistency with imports
- Use imported TerminalBuilder instead of fully qualified name in DemoInputHandler.kt for consistency with existing code

These changes ensure the code follows consistent style patterns and should resolve CI failures.