### PR TITLE
Fix CharBuffer import in TopologyRendererTest

### DIFF
--- a/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/cli/coordination/TopologyRendererTest.kt
+++ b/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/cli/coordination/TopologyRendererTest.kt
@@ -2,6 +2,7 @@ package link.socket.ampere.cli.coordination
 
 import kotlin.test.Test
 import kotlin.test.assertTrue
+import link.socket.ampere.cli.coordination.CharBuffer
 import link.socket.ampere.coordination.InteractionType
 
 class TopologyRendererTest {


### PR DESCRIPTION
Add explicit import for CharBuffer class to resolve compilation error. The class is in the same package but different source set (jvmMain vs jvmTest), so an explicit import is required.