### PR TITLE
Implement CLI UX polish epic (#189)

### DIFF
--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/layout/AgentFocusPane.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/layout/AgentFocusPane.kt
@@ -1,0 +1,217 @@
+package link.socket.ampere.cli.layout
+
+import com.github.ajalt.mordant.rendering.TextColors
+import com.github.ajalt.mordant.rendering.TextStyles.bold
+import com.github.ajalt.mordant.rendering.TextStyles.dim
+import com.github.ajalt.mordant.terminal.Terminal
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import link.socket.ampere.cli.watch.presentation.AgentActivityState
+import link.socket.ampere.cli.watch.presentation.AgentState
+import link.socket.ampere.cli.watch.presentation.CognitiveCluster
+import link.socket.ampere.cli.watch.presentation.EventSignificance
+import link.socket.ampere.cli.watch.presentation.SignificantEventSummary
+
+/**
+ * Agent focus as a drawer-style pane that can be rendered within the layout.
+ *
+ * Unlike the full-screen AgentFocusRenderer, this pane renders agent details
+ * in a constrained area that can be composed with other panes.
+ *
+ * Layout when agent focus is active:
+ * ┌────────────────────────────────────────┬────────────────────┐
+ * │   LEFT + MIDDLE (combined 75%)         │   AGENT FOCUS (25%)│
+ * │   Event stream + Cognitive cycle       │   Agent: CodeWriter│
+ * │                                        │   ───────────────  │
+ * │                                        │   Status: WORKING  │
+ * │                                        │   Cycles: 3        │
+ * │                                        │   ─── Activity ──  │
+ * │                                        │   ...events...     │
+ * └────────────────────────────────────────┴────────────────────┘
+ */
+class AgentFocusPane(
+    private val terminal: Terminal,
+    private val clock: Clock = Clock.System,
+    private val timeZone: TimeZone = TimeZone.currentSystemDefault()
+) : PaneRenderer {
+
+    /**
+     * Data needed to render the agent focus.
+     */
+    data class FocusState(
+        val agentId: String? = null,
+        val agentIndex: Int? = null,
+        val agentState: AgentActivityState? = null,
+        val recentEvents: List<SignificantEventSummary> = emptyList(),
+        val cognitiveClusters: List<CognitiveCluster> = emptyList()
+    )
+
+    private var state = FocusState()
+
+    fun updateState(newState: FocusState) {
+        state = newState
+    }
+
+    override fun render(width: Int, height: Int): List<String> {
+        val lines = mutableListOf<String>()
+
+        // Check if we have an agent to show
+        if (state.agentId == null || state.agentState == null) {
+            return renderNoAgentSelected(width, height)
+        }
+
+        val agentState = state.agentState!!
+
+        // Header with agent name and close hint
+        lines.addAll(renderDrawerHeader(agentState, state.agentIndex, width))
+
+        // Agent state section
+        lines.addAll(renderAgentState(agentState, width))
+
+        // Separator
+        lines.add("")
+
+        // Recent activity sub-header
+        lines.addAll(renderSubHeader("Activity", width, terminal))
+
+        // Recent events from this agent
+        lines.addAll(renderRecentEvents(width, height - lines.size - 3))
+
+        // Pad to height (reserve space for footer)
+        while (lines.size < height - 1) {
+            lines.add("")
+        }
+
+        // Footer hint
+        lines.add(terminal.render(dim("[ESC] close")))
+
+        return lines.take(height).map { it.fitToWidth(width) }
+    }
+
+    private fun renderDrawerHeader(
+        agentState: AgentActivityState,
+        agentIndex: Int?,
+        width: Int
+    ): List<String> {
+        val lines = mutableListOf<String>()
+
+        // Drawer title with close button hint
+        val stateIndicator = getStateIndicator(agentState.currentState)
+        val title = "Agent: ${agentState.displayName.take(width - 12)}"
+        lines.add(terminal.render(bold(TextColors.cyan(title))))
+
+        // Separator
+        lines.add(terminal.render(dim("─".repeat(width))))
+
+        // Agent index hint
+        if (agentIndex != null) {
+            lines.add(terminal.render(dim("press $agentIndex to return")))
+        }
+        lines.add("")
+
+        return lines
+    }
+
+    private fun renderAgentState(agentState: AgentActivityState, width: Int): List<String> {
+        val lines = mutableListOf<String>()
+
+        val stateColor = when (agentState.currentState) {
+            AgentState.WORKING -> TextColors.green
+            AgentState.THINKING -> TextColors.yellow
+            AgentState.IDLE -> TextColors.gray
+            AgentState.IN_MEETING -> TextColors.blue
+            AgentState.WAITING -> TextColors.yellow
+        }
+
+        val stateIndicator = getStateIndicator(agentState.currentState)
+        lines.add("$stateIndicator ${terminal.render(stateColor(agentState.currentState.displayText))}")
+
+        if (agentState.consecutiveCognitiveCycles > 0) {
+            lines.add("${terminal.render(dim("Cycles:"))} ${agentState.consecutiveCognitiveCycles}")
+        }
+
+        val timeSince = formatTimeSince(agentState.lastActivityTimestamp)
+        lines.add("${terminal.render(dim("Last:"))} $timeSince")
+
+        return lines
+    }
+
+    private fun renderRecentEvents(width: Int, maxLines: Int): List<String> {
+        val lines = mutableListOf<String>()
+
+        // Filter events from this agent
+        val agentEvents = state.recentEvents
+            .filter { it.sourceAgentName == state.agentState?.displayName }
+            .take(maxLines.coerceAtMost(8))
+
+        if (agentEvents.isEmpty()) {
+            lines.add(terminal.render(dim("No recent events")))
+            return lines
+        }
+
+        agentEvents.forEach { event ->
+            if (lines.size >= maxLines) return lines
+
+            val eventColor = when (event.significance) {
+                EventSignificance.CRITICAL -> TextColors.red
+                EventSignificance.SIGNIFICANT -> TextColors.white
+                EventSignificance.ROUTINE -> TextColors.gray
+            }
+
+            val timeStr = formatTime(event.timestamp)
+            val summary = IdFormatter.truncateUuidsInText(event.summaryText).take(width - 7)
+            lines.add("${terminal.render(dim(timeStr))} ${terminal.render(eventColor(summary))}")
+        }
+
+        return lines
+    }
+
+    private fun renderNoAgentSelected(width: Int, height: Int): List<String> {
+        val lines = mutableListOf<String>()
+
+        // Header
+        lines.addAll(renderSectionHeader("Agent Focus", width, terminal))
+
+        // No agent message
+        lines.add("")
+        lines.add(terminal.render(dim("No agent selected")))
+        lines.add("")
+        lines.add(terminal.render(dim("Press 1-9 to focus")))
+        lines.add(terminal.render(dim("on an active agent")))
+
+        // Pad to height
+        while (lines.size < height) {
+            lines.add("")
+        }
+
+        return lines.take(height).map { it.fitToWidth(width) }
+    }
+
+    private fun getStateIndicator(state: AgentState): String {
+        return when (state) {
+            AgentState.WORKING -> terminal.render(TextColors.green("●"))
+            AgentState.THINKING -> terminal.render(TextColors.yellow("◐"))
+            AgentState.IDLE -> terminal.render(dim("○"))
+            AgentState.IN_MEETING -> terminal.render(TextColors.blue("◆"))
+            AgentState.WAITING -> terminal.render(TextColors.yellow("◌"))
+        }
+    }
+
+    private fun formatTime(timestamp: Instant): String {
+        val local = timestamp.toLocalDateTime(timeZone)
+        return "${local.hour.toString().padStart(2, '0')}:${local.minute.toString().padStart(2, '0')}"
+    }
+
+    private fun formatTimeSince(timestamp: Instant): String {
+        val elapsed = clock.now().toEpochMilliseconds() - timestamp.toEpochMilliseconds()
+        return when {
+            elapsed < 1000 -> "just now"
+            elapsed < 60_000 -> "${elapsed / 1000}s ago"
+            elapsed < 3600_000 -> "${elapsed / 60_000}m ago"
+            elapsed < 86400_000 -> "${elapsed / 3600_000}h ago"
+            else -> "${elapsed / 86400_000}d ago"
+        }
+    }
+}

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/layout/AgentMemoryPane.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/layout/AgentMemoryPane.kt
@@ -64,9 +64,8 @@ class AgentMemoryPane(
         frameCounter++
         val lines = mutableListOf<String>()
 
-        // Header
-        lines.add(terminal.render(bold("AGENT")))
-        lines.add("")
+        // Header with separator and spacing
+        lines.addAll(renderSectionHeader("Agent", width, terminal))
 
         // Agent name and state
         val indicator = getStateIndicator(state.agentState)
@@ -88,9 +87,8 @@ class AgentMemoryPane(
         lines.add(state.currentPhase?.take(width - 1) ?: terminal.render(dim("...")))
         lines.add("")
 
-        // Memory section
-        lines.add(terminal.render(bold("MEMORY")))
-        lines.add("")
+        // Memory sub-section
+        lines.addAll(renderSubHeader("Memory", width, terminal))
 
         // Memory usage bar
         val barWidth = (width - 2).coerceAtLeast(5)
@@ -110,18 +108,26 @@ class AgentMemoryPane(
         lines.add("")
 
         // Activity sparkline
+        lines.add(terminal.render(dim("Activity:")))
         if (state.recentActivity.isNotEmpty()) {
-            lines.add(terminal.render(dim("Activity:")))
             lines.add(renderSparkline(state.recentActivity, width - 1))
-            lines.add("")
+        } else {
+            // Empty state for activity
+            lines.add(terminal.render(dim("  ┄ no activity yet ┄")))
         }
+        lines.add("")
 
         // Recent tags
+        lines.add(terminal.render(dim("Tags:")))
         if (state.recentTags.isNotEmpty()) {
-            lines.add(terminal.render(dim("Tags:")))
             state.recentTags.take(3).forEach { tag ->
                 lines.add(" ${tag.take(width - 2)}")
             }
+        } else {
+            // Empty state for tags
+            lines.add(terminal.render(dim("  Knowledge tags will")))
+            lines.add(terminal.render(dim("  appear here as the")))
+            lines.add(terminal.render(dim("  agent learns")))
         }
 
         // Pad to height

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/layout/IdFormatter.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/layout/IdFormatter.kt
@@ -1,0 +1,94 @@
+package link.socket.ampere.cli.layout
+
+/**
+ * Utilities for formatting IDs in a human-friendly way.
+ *
+ * Full UUIDs like `e80c6ea3-c092-4be2-bb1c-228d32e90f1d` consume valuable
+ * horizontal space without adding actionable information. This utility
+ * truncates UUIDs to a shorter format while preserving uniqueness.
+ */
+object IdFormatter {
+
+    private val UUID_REGEX = Regex(
+        "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+        RegexOption.IGNORE_CASE
+    )
+
+    /**
+     * Truncates a UUID to last N characters with ellipsis.
+     *
+     * Example: `e80c6ea3-c092-4be2-bb1c-228d32e90f1d` → `...32e90f1d`
+     *
+     * @param uuid The UUID string to truncate
+     * @param lastChars Number of trailing characters to keep (default 8)
+     * @return Truncated ID with ellipsis prefix
+     */
+    fun truncateUuid(uuid: String, lastChars: Int = 8): String {
+        val clean = uuid.replace("-", "")
+        return if (clean.length > lastChars) {
+            "...${clean.takeLast(lastChars)}"
+        } else {
+            clean
+        }
+    }
+
+    /**
+     * Formats a ticket ID for display.
+     *
+     * @param ticketId The full ticket ID
+     * @return Truncated ticket ID
+     */
+    fun formatTicketId(ticketId: String): String {
+        return truncateUuid(ticketId)
+    }
+
+    /**
+     * Formats an agent ID, preferring the agent name if available.
+     *
+     * If the agent ID looks like a UUID, truncates it. Otherwise keeps it as-is.
+     *
+     * @param agentId The full agent ID
+     * @param agentName Optional human-readable agent name
+     * @return Formatted agent identifier
+     */
+    fun formatAgentId(agentId: String, agentName: String? = null): String {
+        // Prefer human-readable name
+        if (!agentName.isNullOrBlank()) {
+            return agentName
+        }
+
+        // Check if it looks like a UUID
+        return if (UUID_REGEX.matches(agentId)) {
+            truncateUuid(agentId)
+        } else {
+            // Keep short agent names as-is
+            agentId.takeLast(20)
+        }
+    }
+
+    /**
+     * Replaces all UUIDs in a string with truncated versions.
+     *
+     * Useful for formatting event descriptions or messages that contain
+     * embedded UUIDs.
+     *
+     * @param text The text containing UUIDs
+     * @param lastChars Number of trailing characters to keep
+     * @return Text with all UUIDs truncated
+     */
+    fun truncateUuidsInText(text: String, lastChars: Int = 8): String {
+        return UUID_REGEX.replace(text) { match ->
+            truncateUuid(match.value, lastChars)
+        }
+    }
+
+    /**
+     * Formats a thread ID for display.
+     *
+     * @param threadId The full thread ID
+     * @return Truncated thread ID
+     */
+    fun formatThreadId(threadId: String): String {
+        return truncateUuid(threadId)
+    }
+}

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/layout/JazzProgressPane.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/layout/JazzProgressPane.kt
@@ -156,10 +156,8 @@ class JazzProgressPane(
         frameCounter++
         val lines = mutableListOf<String>()
 
-        // Header with title (3 lines)
-        lines.add(renderHeader(width))
-        lines.add("─".repeat(width))
-        lines.add("")
+        // Header with separator and spacing
+        lines.addAll(renderSectionHeader("The Jazz Test", width, terminal))
 
         // Elapsed time (2 lines)
         val elapsed = state.startTime?.let { formatElapsed(it) } ?: "0s"
@@ -167,61 +165,17 @@ class JazzProgressPane(
         lines.add("")
 
         // Ticket info - ALWAYS 3 lines (show placeholder if not set)
-        lines.add("${terminal.render(dim("Ticket:"))} ${state.ticketId?.take(20) ?: "..."}")
-        lines.add("${terminal.render(dim("Agent:"))} ${state.agentId?.takeLast(15) ?: "..."}")
+        val ticketDisplay = state.ticketId?.let { IdFormatter.formatTicketId(it) } ?: "..."
+        val agentDisplay = state.agentId?.let { IdFormatter.formatAgentId(it) } ?: "..."
+        lines.add("${terminal.render(dim("Ticket:"))} $ticketDisplay")
+        lines.add("${terminal.render(dim("Agent:"))} $agentDisplay")
         lines.add("")
 
-        // Cognitive cycle header (2 lines)
-        lines.add(terminal.render(bold("Cognitive Cycle")))
-        lines.add("")
+        // Cognitive cycle sub-header
+        lines.addAll(renderSubHeader("Cognitive Cycle", width, terminal))
 
-        // PERCEIVE phase - ALWAYS 3 lines
-        lines.addAll(renderPhaseRow(Phase.PERCEIVE, "PERCEIVE", "Analyzing state", width))
-        val perceiveDetail = if (state.phase.ordinal > Phase.PERCEIVE.ordinal && state.ideasGenerated > 0) {
-            val ideaName = state.ideaNames.firstOrNull()?.take(40) ?: ""
-            "   ${terminal.render(dim("Ideas: ${state.ideasGenerated}${if (ideaName.isNotEmpty()) " - $ideaName" else ""}"))}"
-        } else {
-            ""
-        }
-        lines.add(perceiveDetail)
-        lines.add("")
-
-        // PLAN phase - ALWAYS 4 lines (or 5 if approach shown)
-        lines.addAll(renderPhaseRow(Phase.PLAN, "PLAN", "Creating plan", width))
-        if (state.phase.ordinal > Phase.PLAN.ordinal && state.planSteps > 0) {
-            lines.add("   ${terminal.render(dim("Steps: ${state.planSteps}  Complexity: ${state.estimatedComplexity}"))}")
-            if (state.planApproach.isNotEmpty()) {
-                lines.add("   ${terminal.render(dim(state.planApproach.take(width - 6)))}")
-            } else {
-                lines.add("")
-            }
-        } else {
-            lines.add("")
-            lines.add("")
-        }
-        lines.add("")
-
-        // EXECUTE phase - ALWAYS 5 lines (phase + up to 3 files + blank)
-        lines.addAll(renderPhaseRow(Phase.EXECUTE, "EXECUTE", "Writing code", width))
-        val files = state.filesWritten.take(3)
-        for (i in 0 until 3) {
-            val fileLine = files.getOrNull(i)?.let { fileInfo ->
-                val fileName = fileInfo.path.substringAfterLast('/')
-                "   ${terminal.render(dim("→ $fileName (${fileInfo.lineCount} lines)"))}"
-            } ?: ""
-            lines.add(fileLine)
-        }
-        lines.add("")
-
-        // LEARN phase - ALWAYS 3 lines
-        lines.addAll(renderPhaseRow(Phase.LEARN, "LEARN", "Extracting knowledge", width))
-        val learnDetail = if (state.phase.ordinal > Phase.LEARN.ordinal && state.knowledgeStored.isNotEmpty()) {
-            "   ${terminal.render(dim("Stored: \"${state.knowledgeStored.firstOrNull()?.take(50) ?: ""}\""))}"
-        } else {
-            ""
-        }
-        lines.add(learnDetail)
-        lines.add("")
+        // Cognitive cycle tree view
+        lines.addAll(renderPhaseTree(width))
 
         // Status section - ALWAYS 3 lines
         lines.add("")
@@ -250,9 +204,132 @@ class JazzProgressPane(
         return lines.take(height).map { it.fitToWidth(width) }
     }
 
-    private fun renderHeader(width: Int): String {
-        val title = terminal.render(bold(TextColors.yellow("THE JAZZ TEST")))
-        return title
+    /**
+     * Render the cognitive cycle phases as a tree view.
+     *
+     * Format:
+     * ├─ PERCEIVE  ✓ Complete
+     * │    └─ Ideas: 3 - Fibonacci implementation
+     * ├─ PLAN      ◐ Creating plan... (5s)
+     * │    └─ Steps: 4  Complexity: medium
+     * ├─ EXECUTE   ○ Writing code
+     * │    └─ (pending)
+     * └─ LEARN     ○ Extracting knowledge
+     *      └─ (pending)
+     */
+    private fun renderPhaseTree(width: Int): List<String> {
+        val lines = mutableListOf<String>()
+        val phases = listOf(
+            Triple(Phase.PERCEIVE, "PERCEIVE", "Analyzing state"),
+            Triple(Phase.PLAN, "PLAN", "Creating plan"),
+            Triple(Phase.EXECUTE, "EXECUTE", "Writing code"),
+            Triple(Phase.LEARN, "LEARN", "Extracting knowledge")
+        )
+
+        phases.forEachIndexed { index, (phase, name, description) ->
+            val isLast = index == phases.lastIndex
+            val treeChar = if (isLast) "└─" else "├─"
+            val continueChar = if (isLast) "   " else "│  "
+
+            // Phase indicator
+            val indicator = when {
+                state.phase == phase -> getAnimatedIndicator()
+                state.phase.ordinal > phase.ordinal -> terminal.render(TextColors.green("✓"))
+                else -> terminal.render(dim("○"))
+            }
+
+            // Phase name color
+            val nameColor = when {
+                state.phase == phase -> TextColors.yellow
+                state.phase.ordinal > phase.ordinal -> TextColors.green
+                else -> TextColors.gray
+            }
+
+            // Phase status text
+            val statusText = when {
+                state.phase == phase -> {
+                    val phaseElapsed = state.phaseStartTime?.let { formatElapsed(it) } ?: ""
+                    if (state.phaseDetails.isNotEmpty()) {
+                        "${state.phaseDetails} ($phaseElapsed)"
+                    } else {
+                        "$description... ($phaseElapsed)"
+                    }
+                }
+                state.phase.ordinal > phase.ordinal -> "Complete"
+                else -> description
+            }
+
+            // Main phase line
+            val phaseLabel = terminal.render(nameColor(name.padEnd(10)))
+            lines.add("$treeChar $indicator $phaseLabel ${terminal.render(dim(statusText))}")
+
+            // Details for completed or active phases
+            val details = getPhaseDetails(phase, width - 6)
+            details.forEachIndexed { detailIdx, detail ->
+                val detailTreeChar = if (detailIdx == details.lastIndex) "└─" else "├─"
+                lines.add("$continueChar  $detailTreeChar ${terminal.render(dim(detail))}")
+            }
+
+            // Add spacing between phases (except the last)
+            if (!isLast) {
+                lines.add(terminal.render(dim(continueChar)))
+            }
+        }
+
+        return lines
+    }
+
+    /**
+     * Get detail lines for a phase based on current state.
+     */
+    private fun getPhaseDetails(phase: Phase, maxWidth: Int): List<String> {
+        return when (phase) {
+            Phase.PERCEIVE -> {
+                if (state.phase.ordinal > Phase.PERCEIVE.ordinal && state.ideasGenerated > 0) {
+                    val ideaName = state.ideaNames.firstOrNull()?.take(maxWidth - 15) ?: ""
+                    listOf("Ideas: ${state.ideasGenerated}${if (ideaName.isNotEmpty()) " - $ideaName" else ""}")
+                } else if (state.phase == Phase.PERCEIVE) {
+                    listOf("analyzing...")
+                } else {
+                    emptyList()
+                }
+            }
+            Phase.PLAN -> {
+                if (state.phase.ordinal > Phase.PLAN.ordinal && state.planSteps > 0) {
+                    val details = mutableListOf("Steps: ${state.planSteps}  Complexity: ${state.estimatedComplexity}")
+                    if (state.planApproach.isNotEmpty()) {
+                        details.add(state.planApproach.take(maxWidth))
+                    }
+                    details
+                } else if (state.phase == Phase.PLAN) {
+                    listOf("creating plan...")
+                } else {
+                    emptyList()
+                }
+            }
+            Phase.EXECUTE -> {
+                if (state.filesWritten.isNotEmpty()) {
+                    state.filesWritten.take(3).map { fileInfo ->
+                        val fileName = fileInfo.path.substringAfterLast('/')
+                        "→ $fileName (${fileInfo.lineCount} lines)"
+                    }
+                } else if (state.phase == Phase.EXECUTE) {
+                    listOf("writing code...")
+                } else {
+                    emptyList()
+                }
+            }
+            Phase.LEARN -> {
+                if (state.phase.ordinal > Phase.LEARN.ordinal && state.knowledgeStored.isNotEmpty()) {
+                    listOf("Stored: \"${state.knowledgeStored.firstOrNull()?.take(maxWidth - 10) ?: ""}\"")
+                } else if (state.phase == Phase.LEARN) {
+                    listOf("extracting knowledge...")
+                } else {
+                    emptyList()
+                }
+            }
+            else -> emptyList()
+        }
     }
 
     private fun renderPhaseRow(phase: Phase, name: String, description: String, width: Int): List<String> {

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/layout/PaneRenderer.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/layout/PaneRenderer.kt
@@ -1,5 +1,10 @@
 package link.socket.ampere.cli.layout
 
+import com.github.ajalt.mordant.rendering.TextColors
+import com.github.ajalt.mordant.rendering.TextStyles.bold
+import com.github.ajalt.mordant.rendering.TextStyles.dim
+import com.github.ajalt.mordant.terminal.Terminal
+
 /**
  * Interface for renderers that can work within constrained dimensions.
  *
@@ -76,4 +81,47 @@ fun List<String>.fitToHeight(height: Int, width: Int): List<String> {
         this.size > height -> this.take(height)
         else -> this
     }
+}
+
+/**
+ * Renders a section header with separator and spacing.
+ *
+ * Format:
+ * ```
+ * SECTION TITLE
+ * ────────────────────────
+ *
+ * ```
+ *
+ * @param title The section title (rendered in uppercase with cyan color)
+ * @param width Available width in characters
+ * @param terminal Terminal instance for rendering styled text
+ * @return List of 3 lines: title, separator, blank line
+ */
+fun renderSectionHeader(title: String, width: Int, terminal: Terminal): List<String> {
+    val header = terminal.render(bold(TextColors.cyan(title.uppercase())))
+    val separator = terminal.render(dim("─".repeat(width)))
+    return listOf(header, separator, "")
+}
+
+/**
+ * Renders a sub-section header with lighter styling.
+ *
+ * Format:
+ * ```
+ * ─── Sub Title ───────
+ *
+ * ```
+ *
+ * @param title The sub-section title
+ * @param width Available width in characters
+ * @param terminal Terminal instance for rendering styled text
+ * @return List of 2 lines: styled title, blank line
+ */
+fun renderSubHeader(title: String, width: Int, terminal: Terminal): List<String> {
+    val prefix = "─── "
+    val suffix = " "
+    val remainingDashes = (width - prefix.length - suffix.length - title.length).coerceAtLeast(3)
+    val line = terminal.render(dim("$prefix$title$suffix${"─".repeat(remainingDashes)}"))
+    return listOf(line, "")
 }


### PR DESCRIPTION
## Summary

This PR implements all 9 tickets from the CLI UX Polish epic (#189):

- **#190**: Fix token count leak below TUI - `LogCapture` now suppresses stdout/stderr during TUI mode
- **#192**: Sync status bar with task lifecycle - Added THINKING, WAITING, COMPLETED states
- **#194**: Add section header separators and spacing - Consistent `renderSectionHeader`/`renderSubHeader` utilities
- **#195**: Implement UUID and ID truncation - New `IdFormatter` utility truncates UUIDs to last 8 chars
- **#193**: Implement agent focus as drawer panel - `AgentFocusPane` replaces full-screen focus
- **#196**: Improve event stream entry formatting - Significance dots, relative timestamps, separators
- **#197**: Refine status bar layout and shortcuts - Grouped shortcuts with visual separators
- **#198**: Enhance right pane empty states - Contextual hints and suggested actions
- **#199**: Implement cognitive cycle tree view - Hierarchical tree with nested details

## Key Changes

### New Files
- `AgentFocusPane.kt` - Drawer-style agent focus as right pane instead of full-screen
- `IdFormatter.kt` - UUID/ID truncation utilities for readability

### Modified Files
- `LogCapture.kt` - Suppress original stdout during TUI mode to prevent leaks
- `StatusBar.kt` - New status states, grouped shortcuts, status indicators
- `PaneRenderer.kt` - Section header utilities
- `RichEventPane.kt` - Enhanced empty states, significance indicators, relative times
- `AgentMemoryPane.kt` - Section headers, better empty states
- `JazzProgressPane.kt` - Cognitive cycle tree view with phase details
- `*Command.kt` - Updated to use AgentFocusPane and new status mappings

## Test plan

- [ ] Run `./ampere-cli/ampere run --demo jazz` and verify:
  - No text appears below the TUI boundary
  - Status bar shows THINKING during PERCEIVE/PLAN phases
  - Status bar shows COMPLETED when Jazz Test finishes
  - Cognitive cycle renders as tree with ├─ └─ characters
  - Pressing 1-9 shows agent focus in right pane (not full-screen)
- [ ] Run with `--verbose` flag and verify logs appear in right pane
- [ ] Verify section headers have separators and consistent spacing
- [ ] Verify UUIDs in events are truncated (e.g., `...32e90f1d`)

Closes #189, #190, #192, #193, #194, #195, #196, #197, #198, #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)