### PR TITLE
Fix TUI rendering suppressed by LogCapture

### DIFF
--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/JazzDemoCommand.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/JazzDemoCommand.kt
@@ -168,8 +168,10 @@ class JazzDemoCommand(
                                 // Verbose mode just controls LogPane visibility
                                 if (viewConfig.verboseMode != wasVerbose) {
                                     // Clear screen to prevent artifacts when toggling
-                                    print("\u001B[2J\u001B[H")
-                                    System.out.flush()
+                                    // Use original stdout to bypass LogCapture
+                                    val out = LogCapture.getOriginalOut() ?: System.out
+                                    out.print("\u001B[2J\u001B[H")
+                                    out.flush()
                                 }
                             }
                             is DemoInputHandler.KeyResult.ExecuteCommand -> {
@@ -249,8 +251,10 @@ class JazzDemoCommand(
 
                     // Render the 3-column layout
                     val output = layout.render(eventPane, jazzPane, rightPane, statusBarStr)
-                    print(output)
-                    System.out.flush()
+                    // Use original stdout to bypass LogCapture suppression
+                    val out = LogCapture.getOriginalOut() ?: System.out
+                    out.print(output)
+                    out.flush()
 
                     delay(250) // 4 FPS
                 }

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/RunCommand.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/RunCommand.kt
@@ -245,8 +245,10 @@ class RunCommand(
                                     // Verbose mode just controls LogPane visibility
                                     if (viewConfig.verboseMode != wasVerbose) {
                                         // Clear screen to prevent artifacts when toggling
-                                        print("\u001B[2J\u001B[H")
-                                        System.out.flush()
+                                        // Use original stdout to bypass LogCapture
+                                        val out = LogCapture.getOriginalOut() ?: System.out
+                                        out.print("\u001B[2J\u001B[H")
+                                        out.flush()
                                     }
 
                                     lastRenderedOutput = null
@@ -342,8 +344,10 @@ class RunCommand(
                     }
 
                     if (output != lastRenderedOutput) {
-                        print(output)
-                        System.out.flush()
+                        // Use original stdout to bypass LogCapture suppression
+                        val out = LogCapture.getOriginalOut() ?: System.out
+                        out.print(output)
+                        out.flush()
                         lastRenderedOutput = output
                     }
 
@@ -359,10 +363,12 @@ class RunCommand(
             // Clean shutdown
             throw e
         } catch (e: Exception) {
-            print("\u001B[2J\u001B[H")
-            println("Error: ${e.message}")
-            e.printStackTrace()
-            System.out.flush()
+            // Use original stdout to bypass LogCapture
+            val out = LogCapture.getOriginalOut() ?: System.out
+            out.print("\u001B[2J\u001B[H")
+            out.println("Error: ${e.message}")
+            e.printStackTrace(out)
+            out.flush()
             throw e
         } finally {
             LogCapture.stop()

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/StartCommand.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/StartCommand.kt
@@ -188,8 +188,10 @@ class StartCommand(
                                     // Verbose mode just controls LogPane visibility
                                     if (viewConfig.verboseMode != wasVerbose) {
                                         // Clear screen to prevent artifacts when toggling
-                                        print("\u001B[2J\u001B[H")
-                                        System.out.flush()
+                                        // Use original stdout to bypass LogCapture
+                                        val out = LogCapture.getOriginalOut() ?: System.out
+                                        out.print("\u001B[2J\u001B[H")
+                                        out.flush()
                                     }
 
                                     lastRenderedOutput = null  // Force re-render
@@ -296,8 +298,10 @@ class StartCommand(
 
                     // Only flush to terminal if output changed
                     if (output != lastRenderedOutput) {
-                        print(output)
-                        System.out.flush()
+                        // Use original stdout to bypass LogCapture suppression
+                        val out = LogCapture.getOriginalOut() ?: System.out
+                        out.print(output)
+                        out.flush()
                         lastRenderedOutput = output
                     }
 
@@ -313,11 +317,12 @@ class StartCommand(
             // Clean shutdown
             throw e
         } catch (e: Exception) {
-            // Show error on screen
-            print("\u001B[2J\u001B[H")  // Clear screen
-            println("Error: ${e.message}")
-            e.printStackTrace()
-            System.out.flush()
+            // Show error on screen - use original stdout to bypass LogCapture
+            val out = LogCapture.getOriginalOut() ?: System.out
+            out.print("\u001B[2J\u001B[H")  // Clear screen
+            out.println("Error: ${e.message}")
+            e.printStackTrace(out)
+            out.flush()
             throw e
         } finally {
             LogCapture.stop() // Stop capturing logs

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/layout/LogCapture.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/layout/LogCapture.kt
@@ -70,6 +70,16 @@ object LogCapture {
     fun isCapturing(): Boolean = isCapturing
 
     /**
+     * Get the original stdout stream for direct TUI rendering.
+     * Returns null if not currently capturing.
+     *
+     * Use this for TUI rendering output that should bypass log capture
+     * and go directly to the terminal. This prevents the TUI from
+     * being suppressed while still capturing other stdout/stderr.
+     */
+    fun getOriginalOut(): PrintStream? = originalOut
+
+    /**
      * PrintStream that captures output and sends to LogPane.
      *
      * @param original The original PrintStream to optionally forward to


### PR DESCRIPTION
## Summary
Fixed the CLI showing no output by restoring TUI rendering that was being suppressed by LogCapture. The fix exposes the original stdout stream so TUI commands can render directly to the terminal while still capturing other output to the LogPane.

## Changes
- Added `getOriginalOut()` method to LogCapture to expose the original stdout
- Updated StartCommand, RunCommand, and JazzDemoCommand to use original stdout for TUI rendering
- This allows the TUI to display while still preventing token counts and other noise from leaking below

## Test plan
- [x] CLI status command shows output
- [x] CLI watch command shows output
- [x] Rendering works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)