### PR TITLE
Show Spark context and affinity styling in CLI

### DIFF
--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/JazzDemoCommand.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/JazzDemoCommand.kt
@@ -190,7 +190,7 @@ class JazzDemoCommand(
                 while (isActive) {
                     // Update panes with current state
                     val watchState = presenter.getViewState()
-                    eventPane.updateEvents(watchState.recentSignificantEvents)
+                    eventPane.updateEvents(watchState.recentSignificantEvents, watchState.agentStates)
 
                     // Update memory pane with stats from agent state
                     memoryState = updateMemoryState(memoryState, watchState, jazzPane)
@@ -234,15 +234,17 @@ class JazzDemoCommand(
                             val focusedAgentId = viewConfig.focusedAgentIndex?.let { idx ->
                                 watchState.agentStates.keys.elementAtOrNull(idx - 1)
                             }
-                            agentFocusPane.updateState(
-                                AgentFocusPane.FocusState(
-                                    agentId = focusedAgentId,
-                                    agentIndex = viewConfig.focusedAgentIndex,
-                                    agentState = focusedAgentId?.let { watchState.agentStates[it] },
-                                    recentEvents = watchState.recentSignificantEvents,
-                                    cognitiveClusters = emptyList()
+                                agentFocusPane.updateState(
+                                    AgentFocusPane.FocusState(
+                                        agentId = focusedAgentId,
+                                        agentIndex = viewConfig.focusedAgentIndex,
+                                        agentState = focusedAgentId?.let { watchState.agentStates[it] },
+                                        recentEvents = watchState.recentSignificantEvents,
+                                        cognitiveClusters = emptyList(),
+                                        sparkHistory = focusedAgentId?.let { presenter.getSparkHistory(it, 20) }
+                                            ?: emptyList()
+                                    )
                                 )
-                            )
                             agentFocusPane
                         }
                         viewConfig.verboseMode -> logPane

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/RunCommand.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/RunCommand.kt
@@ -283,7 +283,7 @@ class RunCommand(
                         helpRenderer.render()
                     } else {
                         val watchState = presenter.getViewState()
-                        eventPane.updateEvents(watchState.recentSignificantEvents)
+                        eventPane.updateEvents(watchState.recentSignificantEvents, watchState.agentStates)
 
                         memoryState = updateMemoryState(memoryState, watchState, jazzPane)
                         memoryPane.updateState(memoryState)
@@ -330,7 +330,9 @@ class RunCommand(
                                         agentIndex = viewConfig.focusedAgentIndex,
                                         agentState = focusedAgentId?.let { watchState.agentStates[it] },
                                         recentEvents = watchState.recentSignificantEvents,
-                                        cognitiveClusters = emptyList()
+                                        cognitiveClusters = emptyList(),
+                                        sparkHistory = focusedAgentId?.let { presenter.getSparkHistory(it, 20) }
+                                            ?: emptyList()
                                     )
                                 )
                                 agentFocusPane

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/StartCommand.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/StartCommand.kt
@@ -231,7 +231,7 @@ class StartCommand(
                     } else {
                         // Normal TUI rendering
                         val watchState = presenter.getViewState()
-                        eventPane.updateEvents(watchState.recentSignificantEvents)
+                        eventPane.updateEvents(watchState.recentSignificantEvents, watchState.agentStates)
 
                         // Update memory state
                         memoryState = updateMemoryState(memoryState, watchState, jazzPane)
@@ -283,7 +283,9 @@ class StartCommand(
                                         agentIndex = viewConfig.focusedAgentIndex,
                                         agentState = focusedAgentId?.let { watchState.agentStates[it] },
                                         recentEvents = watchState.recentSignificantEvents,
-                                        cognitiveClusters = emptyList()
+                                        cognitiveClusters = emptyList(),
+                                        sparkHistory = focusedAgentId?.let { presenter.getSparkHistory(it, 20) }
+                                            ?: emptyList()
                                     )
                                 )
                                 agentFocusPane

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/help/CommandRegistry.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/help/CommandRegistry.kt
@@ -116,6 +116,12 @@ object CommandRegistry {
             usage = "<id>",
         ),
         CommandDefinition(
+            name = "sparks",
+            aliases = listOf("spark", "cognitive"),
+            description = "Inspect agent's Spark stack and cognitive context",
+            usage = "[agent-name]",
+        ),
+        CommandDefinition(
             name = "quit",
             aliases = listOf("q", "exit"),
             description = "Exit dashboard",

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/layout/PaneAdapters.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/layout/PaneAdapters.kt
@@ -13,6 +13,7 @@ import link.socket.ampere.cli.watch.presentation.AgentState
 import link.socket.ampere.cli.watch.presentation.EventSignificance
 import link.socket.ampere.cli.watch.presentation.SystemState
 import link.socket.ampere.cli.watch.presentation.WatchViewState
+import link.socket.ampere.renderer.SparkColors
 
 /**
  * Adapter that renders dashboard content as a pane.
@@ -109,10 +110,15 @@ class DashboardPaneAdapter(
             AgentState.WAITING -> TextColors.yellow
         }
 
-        val maxNameLen = (width - 20).coerceAtLeast(10)
+        val depthIndicator = if (state.sparkDepth > 0) {
+            " ${SparkColors.renderDepthIndicator(state.sparkDepth, SparkColors.DepthDisplayStyle.DOTS)}"
+        } else ""
+        val maxNameLen = (width - 20 - depthIndicator.length).coerceAtLeast(10)
         val name = state.displayName.take(maxNameLen).padEnd(maxNameLen)
+        val nameStyle = state.affinityName?.let { SparkColors.forAffinityName(it) } ?: TextColors.white
+        val depthRendered = if (depthIndicator.isNotEmpty()) terminal.render(dim(depthIndicator)) else ""
 
-        return "$indicator $name ${terminal.render(stateColor(state.currentState.displayText))}"
+        return "$indicator ${terminal.render(nameStyle(name))}$depthRendered ${terminal.render(stateColor(state.currentState.displayText))}"
     }
 
     private fun getAgentIndicator(state: AgentState, agentIndex: Int): String {

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/watch/presentation/AgentActivityState.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/watch/presentation/AgentActivityState.kt
@@ -11,7 +11,15 @@ data class AgentActivityState(
     val currentState: AgentState,
     val lastActivityTimestamp: Instant,
     val consecutiveCognitiveCycles: Int,
-    val isIdle: Boolean
+    val isIdle: Boolean,
+    /** The cognitive affinity name (e.g., "ANALYTICAL", "EXPLORATORY"). */
+    val affinityName: String? = null,
+    /** Names of Sparks currently on the stack, in order of application. */
+    val sparkNames: List<String> = emptyList(),
+    /** The current Spark stack depth. */
+    val sparkDepth: Int = 0,
+    /** Human-readable description of the current cognitive state. */
+    val cognitiveStateDescription: String? = null
 )
 
 /**

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/watch/presentation/SparkPresentation.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/watch/presentation/SparkPresentation.kt
@@ -1,0 +1,202 @@
+package link.socket.ampere.cli.watch.presentation
+
+import kotlinx.datetime.Instant
+
+/**
+ * Represents a Spark transition event for display purposes.
+ */
+data class SparkTransition(
+    val timestamp: Instant,
+    val sparkName: String,
+    val sparkType: String,
+    val direction: SparkTransitionDirection,
+    val resultingDepth: Int,
+    val agentId: String
+)
+
+/**
+ * Direction of a Spark transition.
+ */
+enum class SparkTransitionDirection {
+    /** A Spark was pushed onto the stack - context specialization. */
+    APPLIED,
+    /** A Spark was popped from the stack - context generalization. */
+    REMOVED
+}
+
+/**
+ * Complete cognitive state snapshot for display.
+ */
+data class CognitiveDisplayState(
+    val affinityName: String,
+    val sparkNames: List<String>,
+    val depth: Int,
+    val effectivePromptLength: Int?,
+    val availableToolCount: Int?,
+    val description: String
+)
+
+/**
+ * Collects and maintains Spark transition history per agent.
+ */
+class SparkHistoryCollector {
+    private val historyByAgent = mutableMapOf<String, MutableList<SparkTransition>>()
+    private val cognitiveStateByAgent = mutableMapOf<String, CognitiveDisplayState>()
+
+    /** Maximum history entries to keep per agent. */
+    private val maxHistoryPerAgent = 50
+
+    /**
+     * Record a Spark applied event.
+     */
+    fun recordApplied(
+        agentId: String,
+        timestamp: Instant,
+        sparkName: String,
+        sparkType: String,
+        stackDepth: Int,
+        stackDescription: String
+    ) {
+        val transition = SparkTransition(
+            timestamp = timestamp,
+            sparkName = sparkName,
+            sparkType = sparkType,
+            direction = SparkTransitionDirection.APPLIED,
+            resultingDepth = stackDepth,
+            agentId = agentId
+        )
+        addTransition(agentId, transition)
+
+        // Update cognitive state - extract spark names from description
+        updateCognitiveStateFromDescription(agentId, stackDescription, stackDepth)
+    }
+
+    /**
+     * Record a Spark removed event.
+     */
+    fun recordRemoved(
+        agentId: String,
+        timestamp: Instant,
+        previousSparkName: String,
+        stackDepth: Int,
+        stackDescription: String
+    ) {
+        val transition = SparkTransition(
+            timestamp = timestamp,
+            sparkName = previousSparkName,
+            sparkType = "unknown", // Not available in remove event
+            direction = SparkTransitionDirection.REMOVED,
+            resultingDepth = stackDepth,
+            agentId = agentId
+        )
+        addTransition(agentId, transition)
+
+        // Update cognitive state
+        updateCognitiveStateFromDescription(agentId, stackDescription, stackDepth)
+    }
+
+    /**
+     * Record a cognitive state snapshot.
+     */
+    fun recordSnapshot(
+        agentId: String,
+        affinity: String,
+        sparkNames: List<String>,
+        stackDepth: Int,
+        effectivePromptLength: Int,
+        availableToolCount: Int?,
+        stackDescription: String
+    ) {
+        cognitiveStateByAgent[agentId] = CognitiveDisplayState(
+            affinityName = affinity,
+            sparkNames = sparkNames,
+            depth = stackDepth,
+            effectivePromptLength = effectivePromptLength,
+            availableToolCount = availableToolCount,
+            description = stackDescription
+        )
+    }
+
+    /**
+     * Get recent transition history for an agent.
+     */
+    fun getHistory(agentId: String, limit: Int = 20): List<SparkTransition> {
+        return historyByAgent[agentId]?.takeLast(limit) ?: emptyList()
+    }
+
+    /**
+     * Get all recent transitions across all agents.
+     */
+    fun getAllRecentTransitions(limit: Int = 50): List<SparkTransition> {
+        return historyByAgent.values
+            .flatten()
+            .sortedByDescending { it.timestamp }
+            .take(limit)
+    }
+
+    /**
+     * Get the current cognitive state for an agent.
+     */
+    fun getCognitiveState(agentId: String): CognitiveDisplayState? {
+        return cognitiveStateByAgent[agentId]
+    }
+
+    /**
+     * Get spark names for an agent from the most recent state.
+     */
+    fun getSparkNames(agentId: String): List<String> {
+        return cognitiveStateByAgent[agentId]?.sparkNames ?: emptyList()
+    }
+
+    /**
+     * Get affinity name for an agent.
+     */
+    fun getAffinityName(agentId: String): String? {
+        return cognitiveStateByAgent[agentId]?.affinityName
+    }
+
+    /**
+     * Get spark depth for an agent.
+     */
+    fun getSparkDepth(agentId: String): Int {
+        return cognitiveStateByAgent[agentId]?.depth ?: 0
+    }
+
+    /**
+     * Clear history for an agent (when agent becomes inactive).
+     */
+    fun clearAgent(agentId: String) {
+        historyByAgent.remove(agentId)
+        cognitiveStateByAgent.remove(agentId)
+    }
+
+    private fun addTransition(agentId: String, transition: SparkTransition) {
+        val history = historyByAgent.getOrPut(agentId) { mutableListOf() }
+        history.add(transition)
+
+        // Trim to max size
+        while (history.size > maxHistoryPerAgent) {
+            history.removeAt(0)
+        }
+    }
+
+    private fun updateCognitiveStateFromDescription(agentId: String, description: String, depth: Int) {
+        // Description format: [AFFINITY] → [Spark1] → [Spark2] → ...
+        val parts = description.split(" → ")
+        if (parts.isEmpty()) return
+
+        val affinityName = parts[0].removeSurrounding("[", "]")
+        val sparkNames = parts.drop(1).map { it.removeSurrounding("[", "]") }
+
+        // Update or create the cognitive state
+        val existing = cognitiveStateByAgent[agentId]
+        cognitiveStateByAgent[agentId] = CognitiveDisplayState(
+            affinityName = affinityName,
+            sparkNames = sparkNames,
+            depth = depth,
+            effectivePromptLength = existing?.effectivePromptLength,
+            availableToolCount = existing?.availableToolCount,
+            description = description
+        )
+    }
+}

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/renderer/AgentFocusRenderer.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/renderer/AgentFocusRenderer.kt
@@ -77,7 +77,13 @@ class AgentFocusRenderer(
     }
 
     private fun StringBuilder.appendHeader(agentState: AgentActivityState, agentIndex: Int?) {
-        append(terminal.render(bold(TextColors.cyan("Agent Focus: ${agentState.displayName}"))))
+        val title = "Agent Focus: ${agentState.displayName}"
+        val affinityStyle = agentState.affinityName?.let { SparkColors.forAffinityName(it) } ?: TextColors.cyan
+        append(terminal.render(bold(affinityStyle(title))))
+        if (agentState.sparkDepth > 0) {
+            val depthIndicator = SparkColors.renderDepthIndicator(agentState.sparkDepth, SparkColors.DepthDisplayStyle.DOTS)
+            append(terminal.render(dim(" $depthIndicator")))
+        }
         if (agentIndex != null) {
             append(terminal.render(dim(" (press $agentIndex to return here)")))
         }

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/renderer/EventRenderer.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/renderer/EventRenderer.kt
@@ -23,7 +23,10 @@ import link.socket.ampere.agents.domain.event.MessageEvent
 import link.socket.ampere.agents.domain.event.NotificationEvent
 import link.socket.ampere.agents.domain.event.PlanEvent
 import link.socket.ampere.agents.domain.event.ProductEvent
+import link.socket.ampere.agents.domain.event.CognitiveStateSnapshot
+import link.socket.ampere.agents.domain.event.SparkAppliedEvent
 import link.socket.ampere.agents.domain.event.SparkEvent
+import link.socket.ampere.agents.domain.event.SparkRemovedEvent
 import link.socket.ampere.agents.domain.event.TicketEvent
 import link.socket.ampere.agents.domain.event.ToolEvent
 
@@ -131,7 +134,11 @@ class EventRenderer(
             is ProductEvent -> "💡" to green
             is TicketEvent -> "🎫" to green
             is ToolEvent -> "🔧" to yellow
-            is SparkEvent -> "⚡" to magenta
+            // Spark events have distinct icons based on type
+            is SparkAppliedEvent -> SparkColors.SparkIcons.APPLIED to cyan
+            is SparkRemovedEvent -> SparkColors.SparkIcons.REMOVED to gray
+            is CognitiveStateSnapshot -> SparkColors.SparkIcons.SNAPSHOT to magenta
+            is SparkEvent -> SparkColors.SparkIcons.APPLIED to magenta // fallback
         }
     }
 

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/renderer/SparkColors.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/renderer/SparkColors.kt
@@ -1,0 +1,116 @@
+package link.socket.ampere.renderer
+
+import com.github.ajalt.mordant.rendering.TextColors
+import com.github.ajalt.mordant.rendering.TextStyle
+import link.socket.ampere.agents.domain.cognition.CognitiveAffinity
+
+/**
+ * Consistent color theming based on cognitive affinity.
+ *
+ * Each affinity has a designated primary color:
+ * - ANALYTICAL: Cyan - Precision, logic, coolness
+ * - EXPLORATORY: Green - Growth, discovery, nature
+ * - OPERATIONAL: Yellow - Action, energy, urgency
+ * - INTEGRATIVE: Magenta - Synthesis, creativity, wholeness
+ *
+ * These colors are applied consistently across:
+ * - Agent name in agent pane
+ * - Affinity label in Spark stack
+ * - Agent attribution in events
+ * - Focus mode header/border
+ */
+object SparkColors {
+
+    /**
+     * Get the color for a cognitive affinity.
+     */
+    fun forAffinity(affinity: CognitiveAffinity): TextStyle = when (affinity) {
+        CognitiveAffinity.ANALYTICAL -> TextColors.cyan
+        CognitiveAffinity.EXPLORATORY -> TextColors.green
+        CognitiveAffinity.OPERATIONAL -> TextColors.yellow
+        CognitiveAffinity.INTEGRATIVE -> TextColors.magenta
+    }
+
+    /**
+     * Get the color for a cognitive affinity by name.
+     */
+    fun forAffinityName(affinityName: String): TextStyle = when (affinityName.uppercase()) {
+        "ANALYTICAL" -> TextColors.cyan
+        "EXPLORATORY" -> TextColors.green
+        "OPERATIONAL" -> TextColors.yellow
+        "INTEGRATIVE" -> TextColors.magenta
+        else -> TextColors.white
+    }
+
+    /**
+     * Get a symbol for each affinity type.
+     */
+    fun symbolForAffinity(affinity: CognitiveAffinity): String = when (affinity) {
+        CognitiveAffinity.ANALYTICAL -> "◆"
+        CognitiveAffinity.EXPLORATORY -> "◇"
+        CognitiveAffinity.OPERATIONAL -> "▶"
+        CognitiveAffinity.INTEGRATIVE -> "●"
+    }
+
+    /**
+     * Get the short description for each affinity.
+     */
+    fun shortDescription(affinity: CognitiveAffinity): String = when (affinity) {
+        CognitiveAffinity.ANALYTICAL -> "precision-focused"
+        CognitiveAffinity.EXPLORATORY -> "curiosity-driven"
+        CognitiveAffinity.OPERATIONAL -> "action-oriented"
+        CognitiveAffinity.INTEGRATIVE -> "holistic understanding"
+    }
+
+    /**
+     * Icons for Spark events.
+     */
+    object SparkIcons {
+        const val APPLIED = "⚡"      // Spark applied - context expansion
+        const val REMOVED = "↩"      // Spark removed - context contraction
+        const val SNAPSHOT = "🧠"    // Cognitive state snapshot
+        const val STACK_BRANCH = "├─"
+        const val STACK_LAST = "└─"
+        const val STACK_ROOT = "◆"
+    }
+
+    /**
+     * Render cognitive depth as a visual indicator.
+     *
+     * @param depth The current Spark stack depth
+     * @param style The display style to use
+     * @return A formatted string representing the depth
+     */
+    fun renderDepthIndicator(depth: Int, style: DepthDisplayStyle = DepthDisplayStyle.NUMERIC): String {
+        return when (style) {
+            DepthDisplayStyle.NUMERIC -> "depth: $depth"
+            DepthDisplayStyle.BARS -> {
+                val maxDepth = 5
+                val filled = "█".repeat(depth.coerceAtMost(maxDepth))
+                val empty = "░".repeat((maxDepth - depth).coerceAtLeast(0))
+                val overflow = if (depth > maxDepth) "+" else ""
+                "$filled$empty$overflow"
+            }
+            DepthDisplayStyle.DOTS -> {
+                val maxDepth = 5
+                val filled = "●".repeat(depth.coerceAtMost(maxDepth))
+                val empty = "○".repeat((maxDepth - depth).coerceAtLeast(0))
+                val overflow = if (depth > maxDepth) "+" else ""
+                "$filled$empty$overflow"
+            }
+            DepthDisplayStyle.ARROWS -> {
+                "▸".repeat(depth.coerceAtMost(7))
+            }
+        }
+    }
+
+    /**
+     * Display styles for cognitive depth indicator.
+     */
+    enum class DepthDisplayStyle {
+        NUMERIC,  // "depth: 3"
+        BARS,     // "███░░"
+        DOTS,     // "●●●○○"
+        ARROWS    // "▸▸▸"
+    }
+}

--- a/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/cli/watch/presentation/EventCategorizerTest.kt
+++ b/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/cli/watch/presentation/EventCategorizerTest.kt
@@ -8,6 +8,7 @@ import link.socket.ampere.agents.domain.event.Event
 import link.socket.ampere.agents.domain.event.EventSource
 import link.socket.ampere.agents.domain.event.MemoryEvent
 import link.socket.ampere.agents.domain.event.MessageEvent
+import link.socket.ampere.agents.domain.event.SparkAppliedEvent
 import link.socket.ampere.agents.domain.event.TicketEvent
 import link.socket.ampere.agents.domain.memory.MemoryContext
 import link.socket.ampere.agents.events.tickets.TicketPriority
@@ -192,6 +193,24 @@ class EventCategorizerTest {
         val significance = EventCategorizer.categorize(routineEvent)
         assertEquals(EventSignificance.ROUTINE, significance)
         assertEquals(false, significance.shouldDisplayByDefault)
+    }
+
+    @Test
+    fun `ROUTINE - SparkApplied events are routine`() {
+        val event = SparkAppliedEvent(
+            eventId = "evt-spark-1",
+            timestamp = Clock.System.now(),
+            eventSource = EventSource.Agent("agent-test"),
+            urgency = Urgency.LOW,
+            agentId = "agent-test",
+            stackDepth = 2,
+            stackDescription = "[ANALYTICAL] → [Project:ampere]",
+            sparkName = "Project:ampere",
+            sparkType = "ProjectSpark"
+        )
+
+        val significance = EventCategorizer.categorize(event)
+        assertEquals(EventSignificance.ROUTINE, significance)
     }
 
     @Test

--- a/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/cli/watch/presentation/SparkPresentationTest.kt
+++ b/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/cli/watch/presentation/SparkPresentationTest.kt
@@ -1,0 +1,105 @@
+package link.socket.ampere.cli.watch.presentation
+
+import kotlinx.datetime.Instant
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SparkPresentationTest {
+
+    @Test
+    fun `recordApplied updates history and cognitive state`() {
+        val collector = SparkHistoryCollector()
+        val agentId = "agent-1"
+        val timestamp = Instant.parse("2024-01-01T00:00:00Z")
+
+        collector.recordApplied(
+            agentId = agentId,
+            timestamp = timestamp,
+            sparkName = "Project:ampere",
+            sparkType = "ProjectSpark",
+            stackDepth = 2,
+            stackDescription = "[ANALYTICAL] → [Project:ampere]"
+        )
+
+        val history = collector.getHistory(agentId)
+        assertEquals(1, history.size)
+        val transition = history.first()
+        assertEquals(SparkTransitionDirection.APPLIED, transition.direction)
+        assertEquals("Project:ampere", transition.sparkName)
+        assertEquals(2, transition.resultingDepth)
+
+        val state = collector.getCognitiveState(agentId)
+        assertEquals("ANALYTICAL", state?.affinityName)
+        assertEquals(listOf("Project:ampere"), state?.sparkNames)
+        assertEquals(2, state?.depth)
+    }
+
+    @Test
+    fun `recordRemoved updates history and clears spark names`() {
+        val collector = SparkHistoryCollector()
+        val agentId = "agent-2"
+        val timestamp = Instant.parse("2024-01-01T00:01:00Z")
+
+        collector.recordRemoved(
+            agentId = agentId,
+            timestamp = timestamp,
+            previousSparkName = "Role:Code",
+            stackDepth = 0,
+            stackDescription = "[OPERATIONAL]"
+        )
+
+        val history = collector.getHistory(agentId)
+        assertEquals(1, history.size)
+        assertEquals(SparkTransitionDirection.REMOVED, history.first().direction)
+
+        val state = collector.getCognitiveState(agentId)
+        assertEquals("OPERATIONAL", state?.affinityName)
+        assertTrue(state?.sparkNames?.isEmpty() == true)
+        assertEquals(0, state?.depth)
+    }
+
+    @Test
+    fun `recordSnapshot stores effective constraints`() {
+        val collector = SparkHistoryCollector()
+        val agentId = "agent-3"
+        val timestamp = Instant.parse("2024-01-01T00:02:00Z")
+
+        collector.recordSnapshot(
+            agentId = agentId,
+            affinity = "INTEGRATIVE",
+            sparkNames = listOf("Project:ampere", "Role:Planning"),
+            stackDepth = 3,
+            effectivePromptLength = 1200,
+            availableToolCount = 7,
+            stackDescription = "[INTEGRATIVE] → [Project:ampere] → [Role:Planning]"
+        )
+
+        val state = collector.getCognitiveState(agentId)
+        assertEquals("INTEGRATIVE", state?.affinityName)
+        assertEquals(3, state?.depth)
+        assertEquals(1200, state?.effectivePromptLength)
+        assertEquals(7, state?.availableToolCount)
+    }
+
+    @Test
+    fun `clearAgent removes history and state`() {
+        val collector = SparkHistoryCollector()
+        val agentId = "agent-4"
+
+        collector.recordApplied(
+            agentId = agentId,
+            timestamp = Instant.parse("2024-01-01T00:03:00Z"),
+            sparkName = "Focus:QA",
+            sparkType = "FocusSpark",
+            stackDepth = 1,
+            stackDescription = "[EXPLORATORY] → [Focus:QA]"
+        )
+
+        collector.clearAgent(agentId)
+
+        assertTrue(collector.getHistory(agentId).isEmpty())
+        assertNull(collector.getCognitiveState(agentId))
+    }
+}

--- a/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/renderer/SparkColorsTest.kt
+++ b/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/renderer/SparkColorsTest.kt
@@ -1,0 +1,24 @@
+package link.socket.ampere.renderer
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class SparkColorsTest {
+
+    @Test
+    fun `renderDepthIndicator supports numeric style`() {
+        assertEquals("depth: 3", SparkColors.renderDepthIndicator(3, SparkColors.DepthDisplayStyle.NUMERIC))
+    }
+
+    @Test
+    fun `renderDepthIndicator supports bars style with overflow`() {
+        assertEquals("███░░", SparkColors.renderDepthIndicator(3, SparkColors.DepthDisplayStyle.BARS))
+        assertEquals("█████+", SparkColors.renderDepthIndicator(7, SparkColors.DepthDisplayStyle.BARS))
+    }
+
+    @Test
+    fun `renderDepthIndicator supports dots and arrows styles`() {
+        assertEquals("●●○○○", SparkColors.renderDepthIndicator(2, SparkColors.DepthDisplayStyle.DOTS))
+        assertEquals("▸▸▸", SparkColors.renderDepthIndicator(3, SparkColors.DepthDisplayStyle.ARROWS))
+    }
+}


### PR DESCRIPTION
Adds Spark stack context, transition history, and affinity-themed coloring across dashboard/event views. Includes Spark presentation utilities and tests for Spark rendering and categorization. Tests: 
[Incubating] Problems report is available at: file:///Users/miley/conductor/workspaces/Ampere/wellington/build/reports/problems/problems-report.html

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.13/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation. (fails: missing local.properties for ampere-core kotlinConfiguration).