### PR TITLE
Add CoordinationSpark and update Jazz demo

### DIFF
--- a/ampere-cli/README.md
+++ b/ampere-cli/README.md
@@ -113,7 +113,7 @@ Run agents with active work while visualizing progress in real-time:
 ./ampere-cli/ampere run -g "Add authentication to API"
 
 # Run preset demos
-./ampere-cli/ampere run --demo jazz          # Fibonacci demo
+./ampere-cli/ampere run --demo jazz          # CoordinationSpark demo
 
 # Work on GitHub issues
 ./ampere-cli/ampere run --issues             # Continuous issue work
@@ -252,7 +252,7 @@ Launch an interactive REPL session:
 Run headless tests for automated validation (CI/CD):
 
 ```bash
-./ampere-cli/ampere test jazz                          # Headless Jazz test (Fibonacci)
+./ampere-cli/ampere test jazz                          # Headless Jazz test (CoordinationSpark)
 ./ampere-cli/ampere test ticket                        # Headless issue creation test
 ```
 

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/JazzDemoCommand.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/JazzDemoCommand.kt
@@ -55,7 +55,7 @@ import link.socket.ampere.repl.TerminalFactory
 /**
  * Jazz Test Demo with 3-column interactive visualization.
  *
- * This demo runs the Jazz Test (autonomous agent writing Fibonacci code)
+ * This demo runs the Jazz Test (autonomous agent adding a new Spark type)
  * with a 3-column layout showing:
  * - Left pane (35%): Event stream
  * - Middle pane (40%): Cognitive cycle progress
@@ -80,7 +80,7 @@ class JazzDemoCommand(
         Run the Jazz Test demo with 3-column interactive visualization.
 
         The Jazz Test demonstrates autonomous agent behavior by having
-        an agent write a Fibonacci function in Kotlin. This command
+        an agent add a new CoordinationSpark type to the AMPERE framework. This command
         shows the execution with a 3-column layout:
 
         Left pane:   Event stream (filtered by significance)
@@ -434,20 +434,25 @@ class JazzDemoCommand(
         jazzPane.setPhase(JazzProgressPane.Phase.INITIALIZING, "Creating ticket...")
 
         val ticketSpec = TicketBuilder()
-            .withTitle("Implement Fibonacci function")
+            .withTitle("Add CoordinationSpark.Handoff")
             .withDescription("""
-                Create a SINGLE Kotlin file with a Fibonacci function.
+                Add a new Spark type that improves agent handoffs and coordination.
 
                 Requirements:
-                - Function name: fibonacci
-                - Input: n (Int) - the position in the Fibonacci sequence
-                - Output: Long - the Fibonacci number at position n
-                - Use an efficient iterative approach
-                - Handle edge cases (n = 0, n = 1)
+                - Create a new Kotlin file at:
+                  ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/cognition/sparks/CoordinationSpark.kt
+                - Define a sealed class CoordinationSpark : Spark
+                - Include a data object Handoff with:
+                  - @Serializable + @SerialName("CoordinationSpark.Handoff")
+                  - name = "Coordination:Handoff"
+                  - promptContribution: markdown guidance for explicit ownership,
+                    handoff summaries, and event-driven coordination
+                  - allowedTools = null, fileAccessScope = null
+                - Update AmpereProjectSpark's Spark list to include CoordinationSpark
 
                 IMPORTANT:
-                - Create ONLY ONE file named Fibonacci.kt
-                - Do NOT create additional utility files
+                - Keep scope tight and changes minimal
+                - Do NOT add unrelated files
             """.trimIndent())
             .ofType(TicketType.TASK)
             .withPriority(TicketPriority.HIGH)

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/JazzSubcommand.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/JazzSubcommand.kt
@@ -11,7 +11,7 @@ import com.github.ajalt.clikt.core.CliktCommand
  * The Jazz Test demonstrates:
  * 1. Starting the AMPERE environment
  * 2. Creating a CodeWriterAgent
- * 3. Assigning a ticket (Fibonacci function implementation)
+ * 3. Assigning a ticket (CoordinationSpark implementation)
  * 4. Agent autonomously running through PROPEL cognitive cycle
  * 5. Generating working Kotlin code
  *
@@ -32,8 +32,8 @@ class JazzSubcommand : CliktCommand(
         - Agent executes code writing
         - Agent learns from the outcome
 
-        The agent will generate a Fibonacci function in Kotlin and save it to:
-          ~/.ampere/jazz-test-output/Fibonacci.kt
+        The agent will generate a new CoordinationSpark and save it to:
+          ~/.ampere/jazz-test-output/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/cognition/sparks/CoordinationSpark.kt
 
         To observe the agent's cognitive cycle in real-time, run the dashboard
         in another terminal:

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/RunCommand.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/RunCommand.kt
@@ -183,7 +183,7 @@ class RunCommand(
                     }
                 }
                 demo == "jazz" -> {
-                    // Run the Jazz demo (Fibonacci task)
+                    // Run the Jazz demo (CoordinationSpark task)
                     runJazzDemo(context, agentScope, jazzPane, memoryPane, logPane)
                 }
                 demo != null -> {
@@ -587,7 +587,7 @@ class RunCommand(
         // TODO: Implement full Jazz demo logic here
         // For now, just show a placeholder
         delay(1000)
-        jazzPane.setPhase(JazzProgressPane.Phase.PERCEIVE, "Analyzing Fibonacci task...")
+        jazzPane.setPhase(JazzProgressPane.Phase.PERCEIVE, "Analyzing CoordinationSpark task...")
         delay(2000)
         jazzPane.setPhase(JazzProgressPane.Phase.PLAN, "Creating implementation plan...")
         delay(2000)

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/TestCommand.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/TestCommand.kt
@@ -14,7 +14,7 @@ import com.github.ajalt.clikt.core.subcommands
  *   ampere run --demo jazz
  *
  * Available tests:
- * - jazz: Autonomous agent test (CodeWriterAgent + Fibonacci task) - headless
+ * - jazz: Autonomous agent test (CodeWriterAgent + CoordinationSpark task) - headless
  * - ticket: Issue creation test (GitHub issue management) - headless
  *
  * Usage:
@@ -36,7 +36,7 @@ class TestCommand : CliktCommand(
           ampere run --demo <name>
 
         Available tests:
-          jazz      Headless autonomous agent test (Fibonacci task)
+          jazz      Headless autonomous agent test (CoordinationSpark task)
           ticket    Headless GitHub issue creation test
 
         These tests validate AMPERE functionality and are designed for

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/layout/JazzProgressPane.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/layout/JazzProgressPane.kt
@@ -209,7 +209,7 @@ class JazzProgressPane(
      *
      * Format:
      * ├─ PERCEIVE  ✓ Complete
-     * │    └─ Ideas: 3 - Fibonacci implementation
+     * │    └─ Ideas: 3 - CoordinationSpark implementation
      * ├─ PLAN      ◐ Creating plan... (5s)
      * │    └─ Steps: 4  Complexity: medium
      * ├─ EXECUTE   ○ Writing code

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/demo/JazzTestRunner.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/demo/JazzTestRunner.kt
@@ -46,7 +46,7 @@ import link.socket.ampere.domain.ai.provider.AIProvider_Anthropic
  * This program:
  * 1. Starts the AMPERE environment
  * 2. Creates a CodeWriterAgent that listens for ticket events
- * 3. Creates a ticket: "Implement Fibonacci function in Kotlin"
+ * 3. Creates a ticket: "Add CoordinationSpark.Handoff"
  * 4. Assigns the ticket to the agent
  * 5. The agent autonomously runs through the PROPEL cognitive cycle
  * 6. All events are emitted and observable via the CLI dashboard
@@ -158,27 +158,31 @@ fun main() {
             delay(500)
 
             println("─".repeat(80))
-            println("CREATING FIBONACCI TICKET")
+            println("CREATING SPARK TICKET")
             println("─".repeat(80))
             println()
 
             // Build the ticket specification
             val ticketSpec = TicketBuilder()
-                .withTitle("Implement Fibonacci function")
+                .withTitle("Add CoordinationSpark.Handoff")
                 .withDescription("""
-                    Create a SINGLE Kotlin file with a Fibonacci function.
+                    Add a new Spark type that improves agent handoffs and coordination.
 
                     Requirements:
-                    - Function name: fibonacci
-                    - Input: n (Int) - the position in the Fibonacci sequence
-                    - Output: Long - the Fibonacci number at position n
-                    - Use an efficient iterative approach
-                    - Handle edge cases (n = 0, n = 1)
+                    - Create a new Kotlin file at:
+                      ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/cognition/sparks/CoordinationSpark.kt
+                    - Define a sealed class CoordinationSpark : Spark
+                    - Include a data object Handoff with:
+                      - @Serializable + @SerialName("CoordinationSpark.Handoff")
+                      - name = "Coordination:Handoff"
+                      - promptContribution: markdown guidance for explicit ownership,
+                        handoff summaries, and event-driven coordination
+                      - allowedTools = null, fileAccessScope = null
+                    - Update AmpereProjectSpark's Spark list to include CoordinationSpark
 
                     IMPORTANT:
-                    - Create ONLY ONE file named Fibonacci.kt
-                    - Do NOT create additional utility files, test files, or helper classes
-                    - Keep the implementation simple and self-contained
+                    - Keep scope tight and changes minimal
+                    - Do NOT add unrelated files
                 """.trimIndent())
                 .ofType(TicketType.TASK)
                 .withPriority(TicketPriority.HIGH)
@@ -242,37 +246,40 @@ fun main() {
                 delay(1.seconds)
                 elapsedSeconds++
 
-                // Check if code was generated (search recursively for Fibonacci.kt)
-                val fibonacciFile = outputDir.walkTopDown()
-                    .firstOrNull { it.name == "Fibonacci.kt" && it.isFile }
+                // Check if code was generated (search recursively for CoordinationSpark.kt)
+                val sparkFile = outputDir.walkTopDown()
+                    .firstOrNull { it.name == "CoordinationSpark.kt" && it.isFile }
 
-                if (fibonacciFile != null && fibonacciFile.exists()) {
+                if (sparkFile != null && sparkFile.exists()) {
                     println()
                     println("═".repeat(80))
                     println("✅ SUCCESS! Agent completed the task in ${elapsedSeconds} seconds")
                     println("═".repeat(80))
                     println()
-                    println("📄 Generated file: ${fibonacciFile.absolutePath}")
+                    println("📄 Generated file: ${sparkFile.absolutePath}")
                     println()
                     println("File contents:")
                     println("─".repeat(80))
-                    println(fibonacciFile.readText())
+                    println(sparkFile.readText())
                     println("─".repeat(80))
                     println()
 
                     // Basic validation
-                    val content = fibonacciFile.readText()
-                    val hasFunction = content.contains("fun fibonacci")
-                    val hasTypes = content.contains("Int") || content.contains("Long")
+                    val content = sparkFile.readText()
+                    val hasSpark = content.contains("CoordinationSpark")
+                    val hasHandoff = content.contains("Handoff")
+                    val hasSerialName = content.contains("CoordinationSpark.Handoff")
 
-                    if (hasFunction && hasTypes) {
+                    if (hasSpark && hasHandoff && hasSerialName) {
                         println("✅ Code validation passed")
-                        println("   ✓ Contains fibonacci function")
-                        println("   ✓ Uses appropriate types")
+                        println("   ✓ Contains CoordinationSpark")
+                        println("   ✓ Defines Handoff spark")
+                        println("   ✓ Serial name present")
                     } else {
                         println("⚠️  Code validation warnings:")
-                        if (!hasFunction) println("   - Missing 'fun fibonacci'")
-                        if (!hasTypes) println("   - Missing type annotations")
+                        if (!hasSpark) println("   - Missing CoordinationSpark")
+                        if (!hasHandoff) println("   - Missing Handoff spark")
+                        if (!hasSerialName) println("   - Missing serial name annotation")
                     }
 
                     println()

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/cognition/sparks/AmpereProjectSpark.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/cognition/sparks/AmpereProjectSpark.kt
@@ -103,7 +103,8 @@ specializes through accumulated Spark layers:
 1. CognitiveAffinity: Base thinking approach (ANALYTICAL, EXPLORATORY, OPERATIONAL, INTEGRATIVE)
 2. ProjectSpark: Project context and conventions
 3. RoleSpark: Capability focus (Code, Research, Operations, Planning)
-4. TaskSpark: Current task context (applied/removed with task lifecycle)
+4. CoordinationSpark: Handoff and coordination focus (optional, when needed)
+5. TaskSpark: Current task context (applied/removed with task lifecycle)
 """
 
     private const val AMPERE_CONVENTIONS = """

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/cognition/sparks/CoordinationSpark.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/cognition/sparks/CoordinationSpark.kt
@@ -1,0 +1,51 @@
+package link.socket.ampere.agents.domain.cognition.sparks
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import link.socket.ampere.agents.domain.cognition.FileAccessScope
+import link.socket.ampere.agents.domain.cognition.Spark
+import link.socket.ampere.agents.domain.cognition.ToolId
+
+/**
+ * A Spark that focuses on explicit coordination and handoffs between agents.
+ *
+ * CoordinationSparks narrow the agent's focus to collaboration mechanics:
+ * - Clear ownership and task boundaries
+ * - Explicit handoff summaries
+ * - Visible, event-driven state changes
+ */
+@Serializable
+sealed class CoordinationSpark : Spark {
+
+    /**
+     * Coordination context for handoffs between agents.
+     */
+    @Serializable
+    @SerialName("CoordinationSpark.Handoff")
+    data object Handoff : CoordinationSpark() {
+
+        override val name: String = "Coordination:Handoff"
+
+        override val promptContribution: String = """
+## Coordination: Handoff
+
+You are specializing in **agent-to-agent handoffs and coordination**.
+
+### Goals
+- Make ownership explicit (who owns the task now).
+- Convert ambiguity into crisp handoff steps.
+- Emit and reference coordination events when possible (TaskCreated, TaskAssigned, StatusChanged).
+- Ask for missing information instead of guessing.
+
+### Operating Guidelines
+- Summarize context, decisions, open questions, and next steps during handoffs.
+- Keep handoff notes concise and structured.
+- Identify a single primary owner when multiple agents are involved.
+- Prefer observable state changes over implicit assumptions.
+        """.trimIndent()
+
+        override val allowedTools: Set<ToolId>? = null // Inherit from role/tool context
+
+        override val fileAccessScope: FileAccessScope? = null // No additional file restrictions
+    }
+}


### PR DESCRIPTION
Adds a CoordinationSpark.Handoff type to the core cognition model and updates the Jazz demo task copy to dogfood it. README and CLI help text now reflect the new demo focus. This aligns the demo with a self-improving, observable agent story.