### PR TITLE
Clarify Jazz demo task-create copy

### DIFF
--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/JazzDemoCommand.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/JazzDemoCommand.kt
@@ -55,7 +55,7 @@ import link.socket.ampere.repl.TerminalFactory
 /**
  * Jazz Test Demo with 3-column interactive visualization.
  *
- * This demo runs the Jazz Test (autonomous agent adding a new CLI task-create command)
+ * This demo runs the Jazz Test (autonomous agent adding the `ampere task create` CLI command)
  * with a 3-column layout showing:
  * - Left pane (35%): Event stream
  * - Middle pane (40%): Cognitive cycle progress
@@ -80,7 +80,7 @@ class JazzDemoCommand(
         Run the Jazz Test demo with 3-column interactive visualization.
 
         The Jazz Test demonstrates autonomous agent behavior by having
-        an agent add a new CLI task-create command to the AMPERE framework. This command
+        an agent add the `ampere task create` CLI command to the AMPERE framework. This command
         shows the execution with a 3-column layout:
 
         Left pane:   Event stream (filtered by significance)
@@ -433,29 +433,27 @@ class JazzDemoCommand(
         jazzPane.setPhase(JazzProgressPane.Phase.INITIALIZING, "Creating ticket...")
 
         val ticketSpec = TicketBuilder()
-            .withTitle("Add ampere task create CLI command")
+            .withTitle("Add `ampere task create` CLI command")
             .withDescription("""
-                Create a new CLI command that lets a human publish a TaskCreated event.
+                Create a new CLI command that lets a human publish a TaskCreated event from the terminal.
 
                 Requirements:
-                - Create `ampere-cli/src/jvmMain/kotlin/link/socket/ampere/TaskCommand.kt`
-                  with a `task` command and a `create` subcommand.
-                - `ampere task create "<description>"` accepts:
-                  - `--id <taskId>` (optional; generate if omitted)
-                  - `--urgency <low|medium|high>` (default: medium)
-                  - `--assign <agentId>` (optional)
-                - On execution, publish TaskCreated via AgentEventApi
-                  (use AmpereContext.environmentService.createEventApi("human-cli"))
-                  and print a one-line confirmation.
-                - Register the new command in AmpereCommand.
+                * Create `ampere-cli/src/jvmMain/kotlin/link/socket/ampere/TaskCommand.kt` with a `task` command and a `create` subcommand.
+                * `ampere task create "<description>"` accepts:
+                  * `--id <taskId>` (optional; generate if omitted)
+                  * `--urgency <low|medium|high>` (default: medium)
+                  * `--assign <agentId>` (optional)
+                * On execution, publish `TaskCreated` via `AgentEventApi` (use `AmpereContext.environmentService.createEventApi("human-cli")`) and print a one-line confirmation.
+                * Register the new command in `AmpereCommand`.
 
                 Uncertainty moment:
-                - Add a short code comment noting any assumption (e.g., ID generation
-                  or default urgency) before proceeding.
 
-                IMPORTANT:
-                - Keep scope tight and changes minimal
-                - Do NOT add unrelated files
+                * Add a short code comment noting any assumption (e.g., ID generation or default urgency) before proceeding.
+
+                Constraints:
+
+                * Keep scope tight, Kotlin only, no new dependencies or tests.
+                * Follow the context-provider pattern used by other CLI commands (e.g., `WorkCommand`).
             """.trimIndent())
             .ofType(TicketType.TASK)
             .withPriority(TicketPriority.HIGH)

--- a/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/JazzDemoCommandTest.kt
+++ b/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/JazzDemoCommandTest.kt
@@ -1,0 +1,17 @@
+package link.socket.ampere
+
+import com.github.ajalt.clikt.testing.test
+import kotlin.test.Test
+import kotlin.test.assertContains
+
+class JazzDemoCommandTest {
+
+    @Test
+    fun `jazz demo help text mentions task create command`() {
+        val command = JazzDemoCommand { error("context should not be needed for help output") }
+        val result = command.test("--help")
+
+        assertContains(result.output, "Jazz Test demo")
+        assertContains(result.output, "ampere task create")
+    }
+}


### PR DESCRIPTION
Align Jazz demo text with the  command wording and update the Jazz ticket spec copy. Add a CLI help test to ensure the help output mentions the task-create command. Tests: 
[Incubating] Problems report is available at: file:///Users/miley/conductor/workspaces/Ampere/walla-walla/build/reports/problems/problems-report.html

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.13/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation. (fails in this workspace: KotlinJvmTest task creation error).