### PR TITLE
Add configurable phase sparks

### DIFF
--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/layout/AgentFocusPane.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/layout/AgentFocusPane.kt
@@ -16,6 +16,7 @@ import link.socket.ampere.cli.watch.presentation.SignificantEventSummary
 import link.socket.ampere.cli.watch.presentation.SparkTransition
 import link.socket.ampere.cli.watch.presentation.SparkTransitionDirection
 import link.socket.ampere.renderer.SparkColors
+import link.socket.ampere.renderer.SparkNameFormatter
 
 /**
  * Agent focus as a drawer-style pane that can be rendered within the layout.
@@ -183,7 +184,7 @@ class AgentFocusPane(
 
             // Truncate spark name to fit width
             val maxSparkNameLength = width - prefix.length - 12
-            val displayName = sparkName.take(maxSparkNameLength)
+            val displayName = SparkNameFormatter.format(sparkName).take(maxSparkNameLength)
 
             lines.add("$prefix $displayName$activeMarker")
         }
@@ -227,7 +228,7 @@ class AgentFocusPane(
             }
 
             val maxNameLength = width - 12
-            val name = transition.sparkName.take(maxNameLength)
+            val name = SparkNameFormatter.format(transition.sparkName).take(maxNameLength)
             lines.add("${terminal.render(dim(time))} $icon ${terminal.render(color("$prefix$name"))}")
         }
 

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/watch/CommandExecutor.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/watch/CommandExecutor.kt
@@ -9,6 +9,7 @@ import link.socket.ampere.data.DEFAULT_JSON
 import link.socket.ampere.integrations.issues.BatchIssueCreator
 import link.socket.ampere.integrations.issues.github.GitHubCliProvider
 import link.socket.ampere.renderer.SparkColors
+import link.socket.ampere.renderer.SparkNameFormatter
 import java.io.File
 
 /**
@@ -309,7 +310,9 @@ class CommandExecutor(
                     }
 
                     if (agent.sparkNames.isNotEmpty()) {
-                        val stackPreview = agent.sparkNames.joinToString(" → ").take(50)
+                        val stackPreview = agent.sparkNames
+                            .joinToString(" → ") { SparkNameFormatter.format(it) }
+                            .take(50)
                         appendLine("║   Stack: $stackPreview".padEnd(64) + "║")
                     } else {
                         appendLine("║   Stack: (no specialization)".padEnd(64) + "║")
@@ -373,7 +376,8 @@ class CommandExecutor(
                 sparkNames.forEachIndexed { index, sparkName ->
                     val isActive = index == sparkNames.lastIndex
                     val marker = if (isActive) " (ACTIVE)" else ""
-                    val line = "║ [${index + 1}] $sparkName$marker"
+                    val displayName = SparkNameFormatter.format(sparkName)
+                    val line = "║ [${index + 1}] $displayName$marker"
                     appendLine(line.padEnd(64) + "║")
                 }
             }
@@ -392,7 +396,7 @@ class CommandExecutor(
                         SparkTransitionDirection.APPLIED -> "+"
                         SparkTransitionDirection.REMOVED -> "-"
                     }
-                    val line = "║   $time  $icon ${transition.sparkName.take(40)}"
+                    val line = "║   $time  $icon ${SparkNameFormatter.format(transition.sparkName).take(40)}"
                     appendLine(line.padEnd(64) + "║")
                 }
 

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/renderer/SparkNameFormatter.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/renderer/SparkNameFormatter.kt
@@ -1,0 +1,18 @@
+package link.socket.ampere.renderer
+
+object SparkNameFormatter {
+    private const val PHASE_PREFIX = "Phase:"
+
+    fun format(name: String): String {
+        if (!name.startsWith(PHASE_PREFIX)) {
+            return name
+        }
+
+        val phase = name.removePrefix(PHASE_PREFIX).trim()
+        return if (phase.isBlank()) {
+            "[Phase]"
+        } else {
+            "[Phase] $phase"
+        }
+    }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/config/AgentConfiguration.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/config/AgentConfiguration.kt
@@ -8,4 +8,5 @@ import link.socket.ampere.domain.ai.configuration.AIConfiguration
 data class AgentConfiguration(
     val agentDefinition: AgentDefinition,
     val aiConfiguration: AIConfiguration,
+    val cognitiveConfig: CognitiveConfig = CognitiveConfig(),
 )

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/config/CognitiveConfig.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/config/CognitiveConfig.kt
@@ -1,0 +1,24 @@
+package link.socket.ampere.agents.config
+
+import kotlinx.serialization.Serializable
+import link.socket.ampere.agents.domain.cognition.sparks.CognitivePhase
+
+/**
+ * Configuration for cognitive-loop behavior and related prompt shaping.
+ */
+@Serializable
+data class CognitiveConfig(
+    val phaseSparks: PhaseSparkConfig = PhaseSparkConfig(),
+)
+
+/**
+ * Configuration for optional PhaseSparks during the PROPEL cycle.
+ *
+ * @property enabled Enables phase-specific Sparks when true.
+ * @property phases The phases that should receive PhaseSparks when enabled.
+ */
+@Serializable
+data class PhaseSparkConfig(
+    val enabled: Boolean = false,
+    val phases: Set<CognitivePhase> = enumValues<CognitivePhase>().toSet(),
+)

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/AgentFactory.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/AgentFactory.kt
@@ -3,6 +3,7 @@ package link.socket.ampere.agents.definition
 import kotlinx.coroutines.CoroutineScope
 import link.socket.ampere.agents.config.AgentActionAutonomy
 import link.socket.ampere.agents.config.AgentConfiguration
+import link.socket.ampere.agents.config.CognitiveConfig
 import link.socket.ampere.agents.domain.cognition.sparks.AmpereProjectSpark
 import link.socket.ampere.agents.domain.cognition.sparks.LanguageSpark
 import link.socket.ampere.agents.domain.cognition.sparks.ProjectSpark
@@ -64,6 +65,7 @@ class AgentFactory(
     private val aiConfiguration: AIConfiguration? = null,
     private val projectSpark: ProjectSpark? = null,
     private val toolWriteCodeFileOverride: Tool<ExecutionContext.Code.WriteCode>? = null,
+    private val cognitiveConfig: CognitiveConfig = CognitiveConfig(),
 ) {
     private val toolWriteCodeFile: Tool<ExecutionContext.Code.WriteCode> =
         toolWriteCodeFileOverride ?: ToolWriteCodeFile(AgentActionAutonomy.ASK_BEFORE_ACTION)
@@ -81,6 +83,7 @@ class AgentFactory(
         get() = AgentConfiguration(
             agentDefinition = WriteCodeAgent,
             aiConfiguration = effectiveAiConfiguration,
+            cognitiveConfig = cognitiveConfig,
         )
 
     /**

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/AutonomousAgent.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/AutonomousAgent.kt
@@ -249,7 +249,7 @@ abstract class AutonomousAgent<S : AgentState> : Agent<S>, NeuralAgent<S> {
     private var agentRuntimeLoopJob: Job? = null
     @Transient
     private val phaseSparkManager: PhaseSparkManager<S> by lazy(LazyThreadSafetyMode.NONE) {
-        PhaseSparkManager.create(this)
+        PhaseSparkManager.create(this, agentConfiguration.cognitiveConfig.phaseSparks)
     }
 
     // ==================== Agent Runtime ====================

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/cognition/sparks/PhaseSpark.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/cognition/sparks/PhaseSpark.kt
@@ -198,6 +198,7 @@ Produce insights and knowledge that improve future performance.
 /**
  * Enum representing the four cognitive phases in the PROPEL cycle.
  */
+@Serializable
 enum class CognitivePhase {
     PERCEIVE,
     PLAN,

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/domain/cognition/sparks/PhaseSparkManagerTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/domain/cognition/sparks/PhaseSparkManagerTest.kt
@@ -1,0 +1,116 @@
+package link.socket.ampere.agents.domain.cognition.sparks
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import kotlinx.datetime.Clock
+import link.socket.ampere.agents.config.AgentConfiguration
+import link.socket.ampere.agents.config.CognitiveConfig
+import link.socket.ampere.agents.config.PhaseSparkConfig
+import link.socket.ampere.agents.definition.AgentId
+import link.socket.ampere.agents.definition.AutonomousAgent
+import link.socket.ampere.agents.domain.knowledge.Knowledge
+import link.socket.ampere.agents.domain.outcome.ExecutionOutcome
+import link.socket.ampere.agents.domain.outcome.Outcome
+import link.socket.ampere.agents.domain.reasoning.Idea
+import link.socket.ampere.agents.domain.reasoning.Perception
+import link.socket.ampere.agents.domain.reasoning.Plan
+import link.socket.ampere.agents.domain.state.AgentState
+import link.socket.ampere.agents.domain.task.Task
+import link.socket.ampere.agents.execution.request.ExecutionRequest
+import link.socket.ampere.agents.execution.tools.Tool
+import link.socket.ampere.stubAgentConfiguration
+
+private val stubOutcome = ExecutionOutcome.NoChanges.Success(
+    executorId = "test-executor",
+    ticketId = "test-ticket",
+    taskId = "test-task",
+    executionStartTimestamp = Clock.System.now(),
+    executionEndTimestamp = Clock.System.now(),
+    message = "ok",
+)
+
+class PhaseSparkManagerTest {
+
+    private class TestAgent(
+        override val agentConfiguration: AgentConfiguration = stubAgentConfiguration(),
+    ) : AutonomousAgent<AgentState>() {
+        override val id: AgentId = "test-agent"
+        override val initialState: AgentState = AgentState()
+
+        override val runLLMToEvaluatePerception: (Perception<AgentState>) -> Idea = { Idea.blank }
+        override val runLLMToPlan: (Task, List<Idea>) -> Plan = { _, _ -> Plan.blank }
+        override val runLLMToExecuteTask: (Task) -> Outcome = { stubOutcome }
+        override val runLLMToExecuteTool: (Tool<*>, ExecutionRequest<*>) -> ExecutionOutcome = { _, _ -> stubOutcome }
+        override val runLLMToEvaluateOutcomes: (List<Outcome>) -> Idea = { Idea.blank }
+
+        override fun extractKnowledgeFromOutcome(outcome: Outcome, task: Task, plan: Plan): Knowledge {
+            return Knowledge.FromOutcome(
+                outcomeId = outcome.id,
+                approach = "test approach",
+                learnings = "test learnings",
+                timestamp = Clock.System.now(),
+            )
+        }
+    }
+
+    @Test
+    fun `enterPhase applies and switches phase sparks`() {
+        val agent = TestAgent()
+        val manager = PhaseSparkManager(agent, enabled = true)
+
+        manager.enterPhase(CognitivePhase.PERCEIVE)
+        assertEquals(1, agent.sparkDepth)
+        assertTrue(agent.cognitiveState.contains("[Phase:Perceive]"))
+
+        manager.enterPhase(CognitivePhase.PLAN)
+        assertEquals(1, agent.sparkDepth)
+        assertTrue(agent.cognitiveState.contains("[Phase:Plan]"))
+        assertFalse(agent.cognitiveState.contains("Phase:Perceive"))
+    }
+
+    @Test
+    fun `withPhase restores previous phase spark`() = runBlocking {
+        val agent = TestAgent()
+        val manager = PhaseSparkManager(agent, enabled = true)
+
+        manager.enterPhase(CognitivePhase.PERCEIVE)
+        manager.withPhase(CognitivePhase.PLAN) {
+            assertTrue(agent.cognitiveState.contains("[Phase:Plan]"))
+        }
+
+        assertTrue(agent.cognitiveState.contains("[Phase:Perceive]"))
+    }
+
+    @Test
+    fun `create honors configured phases`() {
+        val phaseConfig = PhaseSparkConfig(
+            enabled = true,
+            phases = setOf(CognitivePhase.PLAN),
+        )
+        val agent = TestAgent(
+            agentConfiguration = stubAgentConfiguration().copy(
+                cognitiveConfig = CognitiveConfig(phaseSparks = phaseConfig),
+            ),
+        )
+        val manager = PhaseSparkManager.create(agent, phaseConfig)
+
+        manager.enterPhase(CognitivePhase.PERCEIVE)
+        assertEquals(0, agent.sparkDepth)
+
+        manager.enterPhase(CognitivePhase.PLAN)
+        assertEquals(1, agent.sparkDepth)
+        assertTrue(agent.cognitiveState.contains("[Phase:Plan]"))
+    }
+
+    @Test
+    fun `disabled manager leaves spark stack unchanged`() {
+        val agent = TestAgent()
+        val manager = PhaseSparkManager(agent, enabled = false)
+
+        manager.enterPhase(CognitivePhase.PERCEIVE)
+        assertEquals(0, agent.sparkDepth)
+    }
+}

--- a/docs/AGENT_LIFECYCLE.md
+++ b/docs/AGENT_LIFECYCLE.md
@@ -72,6 +72,23 @@ Agents in Ampere follow a continuous cycle:
 
 ---
 
+## Phase Sparks (Optional)
+
+PhaseSparks add lightweight, phase-specific guidance to the system prompt during
+PERCEIVE, PLAN, EXECUTE, and LEARN. They are transient: applied at phase entry and
+removed at phase exit.
+
+Enable PhaseSparks in one of two ways:
+- Set `AgentConfiguration.cognitiveConfig.phaseSparks.enabled = true`
+  - Optionally restrict to a subset with `phaseSparks.phases`
+- Or set `AMPERE_PHASE_SPARKS=true` to enable globally (all phases)
+
+Trade-offs:
+- Pros: clearer phase focus, more consistent reasoning at each step
+- Cons: larger prompts (more tokens/latency) and more context to review in logs
+
+---
+
 ## Complete Example: Authentication Feature
 
 > **Note:** Some of the code examples below show the planned high-level API that is currently in development. For accurate details of the current API implementation, see the [CLI Guide](ampere-cli/README.md) and [CLAUDE.md](CLAUDE.md).


### PR DESCRIPTION
Adds per-agent PhaseSpark configuration, wiring it into agent runtime and factories.\nImproves CLI spark display and documents enablement, with tests for PhaseSparkManager.