### PR TITLE
Refresh Jazz demo docs to reference task create command

### DIFF
--- a/ampere-cli/README.md
+++ b/ampere-cli/README.md
@@ -57,7 +57,7 @@ JAVA_HOME=$(/usr/libexec/java_home -v 21) ampere-cli/build/install/ampere-cli-jv
 # Run an agent with a custom goal (with TUI)
 ./ampere-cli/ampere run --goal "Implement FizzBuzz"
 
-# Run the Jazz demo (with TUI)
+# Run the Jazz demo (task create command, with TUI)
 ./ampere-cli/ampere run --demo jazz
 
 # Work on GitHub issues (with TUI)
@@ -113,7 +113,7 @@ Run agents with active work while visualizing progress in real-time:
 ./ampere-cli/ampere run -g "Add authentication to API"
 
 # Run preset demos
-./ampere-cli/ampere run --demo jazz          # Task-create command demo
+./ampere-cli/ampere run --demo jazz          # Task create command demo (`ampere task create`)
 
 # Work on GitHub issues
 ./ampere-cli/ampere run --issues             # Continuous issue work
@@ -252,7 +252,7 @@ Launch an interactive REPL session:
 Run headless tests for automated validation (CI/CD):
 
 ```bash
-./ampere-cli/ampere test jazz                          # Headless Jazz test (task-create command)
+./ampere-cli/ampere test jazz                          # Headless Jazz test (task create command)
 ./ampere-cli/ampere test ticket                        # Headless issue creation test
 ```
 

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/TestCommand.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/TestCommand.kt
@@ -14,7 +14,7 @@ import com.github.ajalt.clikt.core.subcommands
  *   ampere run --demo jazz
  *
  * Available tests:
- * - jazz: Autonomous agent test (CodeWriterAgent + task-create CLI command) - headless
+ * - jazz: Autonomous agent test (CodeWriterAgent + `ampere task create` command) - headless
  * - ticket: Issue creation test (GitHub issue management) - headless
  *
  * Usage:
@@ -36,7 +36,7 @@ class TestCommand : CliktCommand(
           ampere run --demo <name>
 
         Available tests:
-          jazz      Headless autonomous agent test (task-create CLI command)
+          jazz      Headless autonomous agent test (`ampere task create` command)
           ticket    Headless GitHub issue creation test
 
         These tests validate AMPERE functionality and are designed for


### PR DESCRIPTION
## Summary
Update CLI documentation and help text to accurately describe the `ampere task create` command demo, addressing issue #260.

## Changes
- Updated README.md with clearer references to the task create command
- Updated TestCommand.kt help text to reference `ampere task create` command
- Removed outdated "task-create" references and replaced with consistent terminology

## Test Plan
- Existing unit tests pass (JazzDemoCommandTest)
- No CoordinationSpark references remain in ampere-cli documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)