### PR TITLE
Refresh UI terminology: Spark → Stack

### DIFF
--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/help/CommandRegistry.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/help/CommandRegistry.kt
@@ -116,9 +116,9 @@ object CommandRegistry {
             usage = "<id>",
         ),
         CommandDefinition(
-            name = "sparks",
-            aliases = listOf("spark", "cognitive"),
-            description = "Inspect agent's Spark stack and cognitive context",
+            name = "stack",
+            aliases = listOf("sparks", "spark", "cognitive"),
+            description = "Inspect agent's context stack and cognitive state",
             usage = "[agent-name]",
         ),
         CommandDefinition(

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/watch/CommandExecutor.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/watch/CommandExecutor.kt
@@ -47,7 +47,7 @@ class CommandExecutor(
             "issues" -> executeIssues(arg)
             "ticket" -> executeTicket(arg)
             "thread" -> executeThread(arg)
-            "sparks", "spark", "cognitive" -> executeSparks(arg)
+            "stack", "sparks", "spark", "cognitive" -> executeSparks(arg)
             "quit", "q", "exit" -> CommandResult.Quit
             else -> CommandResult.Error("Unknown command: $command\nType :help for available commands")
         }
@@ -283,7 +283,7 @@ class CommandExecutor(
     }
 
     /**
-     * Execute the :sparks command to inspect an agent's cognitive context.
+     * Execute the :stack command to inspect an agent's context stack.
      */
     private fun executeSparks(agentNameOrId: String?): CommandResult {
         val viewState = presenter.getViewState()
@@ -322,7 +322,7 @@ class CommandExecutor(
                 appendLine("║                                                               ║")
                 appendLine("╚══════════════════════════════════════════════════════════════╝")
                 appendLine()
-                appendLine("Use :sparks <agent-name> for detailed view of a specific agent.")
+                appendLine("Use :stack <agent-name> for detailed view of a specific agent.")
             }
 
             return CommandResult.Success(output)
@@ -355,7 +355,7 @@ class CommandExecutor(
 
         val output = buildString {
             appendLine("╔══════════════════════════════════════════════════════════════╗")
-            appendLine("║ COGNITIVE CONTEXT: ${agent.displayName}".padEnd(64) + "║")
+            appendLine("║ CONTEXT STACK: ${agent.displayName}".padEnd(64) + "║")
             appendLine("╠══════════════════════════════════════════════════════════════╣")
             appendLine("║                                                               ║")
 
@@ -364,9 +364,9 @@ class CommandExecutor(
             appendLine("║ Affinity: $affinityName".padEnd(64) + "║")
             appendLine("║                                                               ║")
 
-            // Spark stack section
+            // Context stack section
             appendLine("╠══════════════════════════════════════════════════════════════╣")
-            appendLine("║ SPARK STACK                                                   ║")
+            appendLine("║ STACK                                                        ║")
             appendLine("║                                                               ║")
 
             val sparkNames = agent.sparkNames.ifEmpty { cognitiveState?.sparkNames ?: emptyList() }
@@ -377,7 +377,7 @@ class CommandExecutor(
                     val isActive = index == sparkNames.lastIndex
                     val marker = if (isActive) " (ACTIVE)" else ""
                     val displayName = SparkNameFormatter.format(sparkName)
-                    val line = "║ [${index + 1}] $displayName$marker"
+                    val line = "║  → $displayName$marker"
                     appendLine(line.padEnd(64) + "║")
                 }
             }
@@ -387,7 +387,7 @@ class CommandExecutor(
             // History section
             if (history.isNotEmpty()) {
                 appendLine("╠══════════════════════════════════════════════════════════════╣")
-                appendLine("║ RECENT TRANSITIONS                                            ║")
+                appendLine("║ STACK HISTORY                                                 ║")
                 appendLine("║                                                               ║")
 
                 history.reversed().forEach { transition ->

--- a/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/renderer/EventRendererTest.kt
+++ b/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/renderer/EventRendererTest.kt
@@ -404,4 +404,95 @@ class EventRendererTest {
             System.setOut(originalOut)
         }
     }
+
+    @Test
+    fun `render SparkAppliedEvent shows StackApplied type name`() {
+        val output = captureTerminalOutput { _, renderer ->
+            renderer.render(sparkAppliedEvent())
+        }
+
+        assertContains(output, "StackApplied")
+    }
+
+    @Test
+    fun `render SparkRemovedEvent shows StackRemoved type name`() {
+        val output = captureTerminalOutput { _, renderer ->
+            renderer.render(sparkRemovedEvent())
+        }
+
+        assertContains(output, "StackRemoved")
+    }
+
+    @Test
+    fun `render CognitiveStateSnapshot shows StackSnapshot type name`() {
+        val output = captureTerminalOutput { _, renderer ->
+            renderer.render(snapshotEvent())
+        }
+
+        assertContains(output, "StackSnapshot")
+    }
+
+    @Test
+    fun `render SparkAppliedEvent summary shows Stack push with name and depth`() {
+        val output = captureTerminalOutput { _, renderer ->
+            renderer.render(
+                sparkAppliedEvent(
+                    sparkName = "Role:Developer",
+                    stackDepth = 3
+                )
+            )
+        }
+
+        assertContains(output, "Stack push: Role:Developer")
+        assertContains(output, "(depth: 3)")
+    }
+
+    @Test
+    fun `render SparkRemovedEvent summary shows Stack pop with name and depth`() {
+        val output = captureTerminalOutput { _, renderer ->
+            renderer.render(
+                sparkRemovedEvent(
+                    previousSparkName = "Task:Implement",
+                    stackDepth = 2
+                )
+            )
+        }
+
+        assertContains(output, "Stack pop: Task:Implement")
+        assertContains(output, "(depth: 2)")
+    }
+
+    @Test
+    fun `render CognitiveStateSnapshot summary shows Stack snapshot with affinity and layers`() {
+        val output = captureTerminalOutput { _, renderer ->
+            renderer.render(
+                snapshotEvent(
+                    affinity = "ANALYTICAL",
+                    sparkNames = listOf("Project:ampere", "Role:Code"),
+                    effectivePromptLength = 1500
+                )
+            )
+        }
+
+        assertContains(output, "Stack snapshot: [ANALYTICAL]")
+        assertContains(output, "+ 2 layer(s)")
+        assertContains(output, "(prompt: 1500 chars)")
+    }
+
+    @Test
+    fun `render CognitiveStateSnapshot without layers omits layer count`() {
+        val output = captureTerminalOutput { _, renderer ->
+            renderer.render(
+                snapshotEvent(
+                    affinity = "OPERATIONAL",
+                    sparkNames = emptyList(),
+                    effectivePromptLength = 800
+                )
+            )
+        }
+
+        assertContains(output, "Stack snapshot: [OPERATIONAL]")
+        assertTrue(!output.contains("layer(s)"))
+        assertContains(output, "(prompt: 800 chars)")
+    }
 }


### PR DESCRIPTION
Update user-facing CLI terminology to use Stack instead of Spark for improved clarity. Maintains internal Spark naming. Adds comprehensive test coverage for Stack event formatting and description parsing.