### PR TITLE
Replace Fibonacci demo with ObservabilitySpark dogfooding task

### DIFF
--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/JazzDemoCommand.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/JazzDemoCommand.kt
@@ -55,7 +55,7 @@ import link.socket.ampere.repl.TerminalFactory
 /**
  * Jazz Test Demo with 3-column interactive visualization.
  *
- * This demo runs the Jazz Test (autonomous agent adding the `ampere task create` CLI command)
+ * This demo runs the Jazz Test (autonomous agent adding a new ObservabilitySpark to the Spark system)
  * with a 3-column layout showing:
  * - Left pane (35%): Event stream
  * - Middle pane (40%): Cognitive cycle progress
@@ -80,7 +80,7 @@ class JazzDemoCommand(
         Run the Jazz Test demo with 3-column interactive visualization.
 
         The Jazz Test demonstrates autonomous agent behavior by having
-        an agent add the `ampere task create` CLI command to the AMPERE framework. This command
+        an agent add a new ObservabilitySpark to the AMPERE Spark system. This command
         shows the execution with a 3-column layout:
 
         Left pane:   Event stream (filtered by significance)
@@ -433,27 +433,36 @@ class JazzDemoCommand(
         jazzPane.setPhase(JazzProgressPane.Phase.INITIALIZING, "Creating ticket...")
 
         val ticketSpec = TicketBuilder()
-            .withTitle("Add `ampere task create` CLI command")
+            .withTitle("Add ObservabilitySpark to AMPERE Spark system")
             .withDescription("""
-                Create a new CLI command that lets a human publish a TaskCreated event from the terminal.
+                Create a new Spark type that provides guidance about visibility, monitoring, and progress reporting.
 
                 Requirements:
-                * Create `ampere-cli/src/jvmMain/kotlin/link/socket/ampere/TaskCommand.kt` with a `task` command and a `create` subcommand.
-                * `ampere task create "<description>"` accepts:
-                  * `--id <taskId>` (optional; generate if omitted)
-                  * `--urgency <low|medium|high>` (default: medium)
-                  * `--assign <agentId>` (optional)
-                * On execution, publish `TaskCreated` via `AgentEventApi` (use `AmpereContext.environmentService.createEventApi("human-cli")`) and print a one-line confirmation.
-                * Register the new command in `AmpereCommand`.
+                * Create `ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/cognition/sparks/ObservabilitySpark.kt` with a sealed class hierarchy.
+                * The Spark should guide agents on how to emit events, report progress, and make their work visible.
+                * Include a `Verbose` data object variant that encourages detailed status updates and progress emission.
+                * Use `@Serializable` and `@SerialName("ObservabilitySpark.Verbose")` for polymorphic serialization.
+                * Set `allowedTools` and `fileAccessScope` to `null` (non-restrictive, inherits from parent Sparks).
+                * The `promptContribution` should guide the agent to emit frequent status updates.
 
-                Uncertainty moment:
+                Reference pattern (from PhaseSpark.kt):
+                ```kotlin
+                @Serializable
+                sealed class PhaseSpark : Spark {
+                    abstract val phase: CognitivePhase
+                    override val allowedTools: Set<ToolId>? = null
+                    override val fileAccessScope: FileAccessScope? = null
 
-                * Add a short code comment noting any assumption (e.g., ID generation or default urgency) before proceeding.
+                    @Serializable
+                    @SerialName("PhaseSpark.Perceive")
+                    data object Perceive : PhaseSpark() { ... }
+                }
+                ```
 
                 Constraints:
-
-                * Keep scope tight, Kotlin only, no new dependencies or tests.
-                * Follow the context-provider pattern used by other CLI commands (e.g., `WorkCommand`).
+                * Keep scope tight: one sealed class with one `Verbose` data object.
+                * Kotlin only, no new dependencies.
+                * Follow the existing Spark patterns in the sparks/ directory.
             """.trimIndent())
             .ofType(TicketType.TASK)
             .withPriority(TicketPriority.HIGH)

--- a/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/JazzDemoCommandTest.kt
+++ b/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/JazzDemoCommandTest.kt
@@ -7,11 +7,11 @@ import kotlin.test.assertContains
 class JazzDemoCommandTest {
 
     @Test
-    fun `jazz demo help text mentions task create command`() {
+    fun `jazz demo help text mentions ObservabilitySpark task`() {
         val command = JazzDemoCommand { error("context should not be needed for help output") }
         val result = command.test("--help")
 
         assertContains(result.output, "Jazz Test demo")
-        assertContains(result.output, "ampere task create")
+        assertContains(result.output, "ObservabilitySpark")
     }
 }

--- a/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/demo/JazzTestRunnerTest.kt
+++ b/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/demo/JazzTestRunnerTest.kt
@@ -10,7 +10,7 @@ import kotlin.test.assertNull
 class JazzTestRunnerTest {
 
     @Test
-    fun `findGeneratedJazzFiles returns null when task command missing`() {
+    fun `findGeneratedJazzFiles returns null when observability spark missing`() {
         val tempDir = createTempDirectory("jazz-test").toFile()
         try {
             val result = findGeneratedJazzFiles(tempDir)
@@ -21,27 +21,18 @@ class JazzTestRunnerTest {
     }
 
     @Test
-    fun `findGeneratedJazzFiles detects task command and optional ampere command`() {
+    fun `findGeneratedJazzFiles detects observability spark file`() {
         val tempDir = createTempDirectory("jazz-test").toFile()
         try {
-            val baseDir = File(tempDir, "ampere-cli/src/jvmMain/kotlin/link/socket/ampere")
+            val baseDir = File(tempDir, "ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/cognition/sparks")
             baseDir.mkdirs()
 
-            val taskCommandFile = File(baseDir, "TaskCommand.kt")
-            taskCommandFile.writeText("class TaskCommand")
+            val sparkFile = File(baseDir, "ObservabilitySpark.kt")
+            sparkFile.writeText("sealed class ObservabilitySpark : Spark")
 
-            val withoutAmpere = findGeneratedJazzFiles(tempDir)
-            assertNotNull(withoutAmpere)
-            assertEquals(taskCommandFile.absolutePath, withoutAmpere.taskCommand.absolutePath)
-            assertNull(withoutAmpere.ampereCommand)
-
-            val ampereCommandFile = File(baseDir, "AmpereCommand.kt")
-            ampereCommandFile.writeText("class AmpereCommand")
-
-            val withAmpere = findGeneratedJazzFiles(tempDir)
-            assertNotNull(withAmpere)
-            assertEquals(taskCommandFile.absolutePath, withAmpere.taskCommand.absolutePath)
-            assertEquals(ampereCommandFile.absolutePath, withAmpere.ampereCommand?.absolutePath)
+            val result = findGeneratedJazzFiles(tempDir)
+            assertNotNull(result)
+            assertEquals(sparkFile.absolutePath, result.observabilitySpark.absolutePath)
         } finally {
             tempDir.deleteRecursively()
         }


### PR DESCRIPTION
Update the Jazz demo to have the agent implement a new Spark type (ObservabilitySpark) instead of a CLI command. This demonstrates AMPERE's ability to extend its own cognitive capabilities through self-improvement. Updated task descriptions, file paths, validation checks, and tests accordingly.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
