### PR TITLE
Add spinner and lightning pulse sequences

### DIFF
--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/animation/LightningAnimator.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/animation/LightningAnimator.kt
@@ -96,6 +96,28 @@ object LightningAnimator {
     )
 
     /**
+     * Standard spinner sequence for general async operations.
+     */
+    val STANDARD_SPINNER = listOf(
+        DischargeFrame("◐", Glow.NORMAL, 150),
+        DischargeFrame("◓", Glow.NORMAL, 150),
+        DischargeFrame("◑", Glow.NORMAL, 150),
+        DischargeFrame("◒", Glow.NORMAL, 150)
+    )
+
+    /**
+     * Lightning pulse sequence for high-intensity operations.
+     */
+    val LIGHTNING_PULSE = listOf(
+        DischargeFrame("·", Glow.DIM, 120),
+        DischargeFrame("˙", Glow.DIM, 80),
+        DischargeFrame("⁝", Glow.NORMAL, 70),
+        DischargeFrame("⚡", Glow.FLASH, 100),
+        DischargeFrame("✧", Glow.NORMAL, 80),
+        DischargeFrame("·", Glow.DIM, 150)
+    )
+
+    /**
      * Generates glow levels for each character position.
      * Brightness falls off with distance from center.
      *

--- a/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/cli/animation/LightningAnimatorTest.kt
+++ b/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/cli/animation/LightningAnimatorTest.kt
@@ -11,6 +11,8 @@ class LightningAnimatorTest {
     fun `test discharge sequences are non-empty`() {
         assertTrue(LightningAnimator.DISCHARGE_SEQUENCE.isNotEmpty())
         assertTrue(LightningAnimator.COMPACT_SEQUENCE.isNotEmpty())
+        assertTrue(LightningAnimator.STANDARD_SPINNER.isNotEmpty())
+        assertTrue(LightningAnimator.LIGHTNING_PULSE.isNotEmpty())
     }
 
     @Test
@@ -21,6 +23,32 @@ class LightningAnimatorTest {
         LightningAnimator.COMPACT_SEQUENCE.forEach { frame ->
             assertTrue(frame.durationMs > 0, "Frame ${frame.symbol} should have positive duration")
         }
+        LightningAnimator.STANDARD_SPINNER.forEach { frame ->
+            assertTrue(frame.durationMs > 0, "Frame ${frame.symbol} should have positive duration")
+        }
+        LightningAnimator.LIGHTNING_PULSE.forEach { frame ->
+            assertTrue(frame.durationMs > 0, "Frame ${frame.symbol} should have positive duration")
+        }
+    }
+
+    @Test
+    fun `test standard spinner sequence matches spec`() {
+        val expectedSymbols = listOf("◐", "◓", "◑", "◒")
+        val expectedDurations = listOf(150L, 150L, 150L, 150L)
+        val sequence = LightningAnimator.STANDARD_SPINNER
+        assertEquals(expectedSymbols, sequence.map { it.symbol })
+        assertEquals(expectedDurations, sequence.map { it.durationMs })
+        assertEquals(600L, sequence.sumOf { it.durationMs })
+    }
+
+    @Test
+    fun `test lightning pulse sequence matches spec`() {
+        val expectedSymbols = listOf("·", "˙", "⁝", "⚡", "✧", "·")
+        val expectedDurations = listOf(120L, 80L, 70L, 100L, 80L, 150L)
+        val sequence = LightningAnimator.LIGHTNING_PULSE
+        assertEquals(expectedSymbols, sequence.map { it.symbol })
+        assertEquals(expectedDurations, sequence.map { it.durationMs })
+        assertEquals(600L, sequence.sumOf { it.durationMs })
     }
 
     @Test


### PR DESCRIPTION
Adds standard spinner and lightning pulse sequences with timing tests. Closes #273.