### PR TITLE
Add ASCII banner fallback and sizing

### DIFF
--- a/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/repl/BannerRendererTest.kt
+++ b/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/repl/BannerRendererTest.kt
@@ -33,63 +33,62 @@ class BannerRendererTest {
     }
 
     @Test
-    fun `selectBanner returns compact banner for width 60 to 79`() {
+    fun `selectBanner returns standard banner for width 60 to 79`() {
         val banner60 = BannerRenderer.selectBanner(60)
         val banner70 = BannerRenderer.selectBanner(70)
         val banner79 = BannerRenderer.selectBanner(79)
 
-        assertEquals(BannerRenderer.getCompactBanner(), banner60)
-        assertEquals(BannerRenderer.getCompactBanner(), banner70)
-        assertEquals(BannerRenderer.getCompactBanner(), banner79)
+        assertEquals(BannerRenderer.getStandardBanner(), banner60)
+        assertEquals(BannerRenderer.getStandardBanner(), banner70)
+        assertEquals(BannerRenderer.getStandardBanner(), banner79)
     }
 
     @Test
-    fun `selectBanner returns minimal banner for width less than 60`() {
-        val banner59 = BannerRenderer.selectBanner(59)
+    fun `selectBanner returns compact banner for width 40 to 59`() {
         val banner40 = BannerRenderer.selectBanner(40)
-        val banner20 = BannerRenderer.selectBanner(20)
-
-        assertEquals(BannerRenderer.getMinimalBanner(), banner59)
-        assertEquals(BannerRenderer.getMinimalBanner(), banner40)
-        assertEquals(BannerRenderer.getMinimalBanner(), banner20)
-    }
-
-    @Test
-    fun `selectBanner handles edge case at full breakpoint boundary`() {
-        val banner79 = BannerRenderer.selectBanner(79)
-        val banner80 = BannerRenderer.selectBanner(80)
-
-        assertEquals(BannerRenderer.getCompactBanner(), banner79)
-        assertEquals(BannerRenderer.getFullBanner(), banner80)
-    }
-
-    @Test
-    fun `selectBanner handles edge case at compact breakpoint boundary`() {
+        val banner50 = BannerRenderer.selectBanner(50)
         val banner59 = BannerRenderer.selectBanner(59)
-        val banner60 = BannerRenderer.selectBanner(60)
 
-        assertEquals(BannerRenderer.getMinimalBanner(), banner59)
-        assertEquals(BannerRenderer.getCompactBanner(), banner60)
+        assertEquals(BannerRenderer.getCompactBanner(), banner40)
+        assertEquals(BannerRenderer.getCompactBanner(), banner50)
+        assertEquals(BannerRenderer.getCompactBanner(), banner59)
     }
 
     @Test
-    fun `selectBanner handles very small widths`() {
+    fun `selectBanner returns minimal banner for width less than 40`() {
+        val banner39 = BannerRenderer.selectBanner(39)
+        val banner20 = BannerRenderer.selectBanner(20)
         val banner0 = BannerRenderer.selectBanner(0)
-        val banner1 = BannerRenderer.selectBanner(1)
-        val banner10 = BannerRenderer.selectBanner(10)
 
+        assertEquals(BannerRenderer.getMinimalBanner(), banner39)
+        assertEquals(BannerRenderer.getMinimalBanner(), banner20)
         assertEquals(BannerRenderer.getMinimalBanner(), banner0)
-        assertEquals(BannerRenderer.getMinimalBanner(), banner1)
-        assertEquals(BannerRenderer.getMinimalBanner(), banner10)
     }
 
     @Test
-    fun `selectBanner handles very large widths`() {
-        val banner200 = BannerRenderer.selectBanner(200)
-        val banner1000 = BannerRenderer.selectBanner(1000)
+    fun `selectBanner handles breakpoint boundaries`() {
+        assertEquals(BannerRenderer.getMinimalBanner(), BannerRenderer.selectBanner(39))
+        assertEquals(BannerRenderer.getCompactBanner(), BannerRenderer.selectBanner(40))
+        assertEquals(BannerRenderer.getCompactBanner(), BannerRenderer.selectBanner(59))
+        assertEquals(BannerRenderer.getStandardBanner(), BannerRenderer.selectBanner(60))
+        assertEquals(BannerRenderer.getStandardBanner(), BannerRenderer.selectBanner(79))
+        assertEquals(BannerRenderer.getFullBanner(), BannerRenderer.selectBanner(80))
+    }
 
-        assertEquals(BannerRenderer.getFullBanner(), banner200)
-        assertEquals(BannerRenderer.getFullBanner(), banner1000)
+    @Test
+    fun `selectBanner returns consistent results for same width`() {
+        val width = 75
+        val banner1 = BannerRenderer.selectBanner(width)
+        val banner2 = BannerRenderer.selectBanner(width)
+
+        assertEquals(banner1, banner2)
+    }
+
+    @Test
+    fun `selectBanner returns ASCII banner when unicode is unsupported`() {
+        val banner = BannerRenderer.selectBanner(80, supportsUnicode = false)
+        assertAsciiOnly(banner)
+        assertTrue(banner.contains("AMPERE"))
     }
 
     // === Banner Variant Tests ===
@@ -101,14 +100,20 @@ class BannerRendererTest {
     }
 
     @Test
-    fun `getBannerVariant returns COMPACT for width 60 to 79`() {
-        assertEquals(BannerRenderer.BannerVariant.COMPACT, BannerRenderer.getBannerVariant(60))
-        assertEquals(BannerRenderer.BannerVariant.COMPACT, BannerRenderer.getBannerVariant(79))
+    fun `getBannerVariant returns STANDARD for width 60 to 79`() {
+        assertEquals(BannerRenderer.BannerVariant.STANDARD, BannerRenderer.getBannerVariant(60))
+        assertEquals(BannerRenderer.BannerVariant.STANDARD, BannerRenderer.getBannerVariant(79))
     }
 
     @Test
-    fun `getBannerVariant returns MINIMAL for width less than 60`() {
-        assertEquals(BannerRenderer.BannerVariant.MINIMAL, BannerRenderer.getBannerVariant(59))
+    fun `getBannerVariant returns COMPACT for width 40 to 59`() {
+        assertEquals(BannerRenderer.BannerVariant.COMPACT, BannerRenderer.getBannerVariant(40))
+        assertEquals(BannerRenderer.BannerVariant.COMPACT, BannerRenderer.getBannerVariant(59))
+    }
+
+    @Test
+    fun `getBannerVariant returns MINIMAL for width less than 40`() {
+        assertEquals(BannerRenderer.BannerVariant.MINIMAL, BannerRenderer.getBannerVariant(39))
         assertEquals(BannerRenderer.BannerVariant.MINIMAL, BannerRenderer.getBannerVariant(20))
     }
 
@@ -117,6 +122,13 @@ class BannerRendererTest {
     @Test
     fun `getFullBanner returns non-empty string`() {
         val banner = BannerRenderer.getFullBanner()
+        assertNotNull(banner)
+        assertTrue(banner.isNotEmpty())
+    }
+
+    @Test
+    fun `getStandardBanner returns non-empty string`() {
+        val banner = BannerRenderer.getStandardBanner()
         assertNotNull(banner)
         assertTrue(banner.isNotEmpty())
     }
@@ -143,6 +155,12 @@ class BannerRendererTest {
     }
 
     @Test
+    fun `standard banner contains AMPERE text`() {
+        val banner = BannerRenderer.getStandardBanner()
+        assertTrue(banner.contains("A M P E R E"))
+    }
+
+    @Test
     fun `compact banner contains AMPERE text`() {
         val banner = BannerRenderer.getCompactBanner()
         assertTrue(banner.contains("A M P E R E"))
@@ -157,20 +175,24 @@ class BannerRendererTest {
     @Test
     fun `all banners contain lightning bolt symbol`() {
         val fullBanner = BannerRenderer.getFullBanner()
+        val standardBanner = BannerRenderer.getStandardBanner()
         val compactBanner = BannerRenderer.getCompactBanner()
         val minimalBanner = BannerRenderer.getMinimalBanner()
 
         assertTrue(fullBanner.contains("⚡"))
+        assertTrue(standardBanner.contains("⚡"))
         assertTrue(compactBanner.contains("⚡"))
         assertTrue(minimalBanner.contains("⚡"))
     }
 
     @Test
-    fun `full and compact banners contain network node symbol`() {
+    fun `full standard and compact banners contain network node symbol`() {
         val fullBanner = BannerRenderer.getFullBanner()
+        val standardBanner = BannerRenderer.getStandardBanner()
         val compactBanner = BannerRenderer.getCompactBanner()
 
         assertTrue(fullBanner.contains("○"))
+        assertTrue(standardBanner.contains("○"))
         assertTrue(compactBanner.contains("○"))
     }
 
@@ -179,13 +201,15 @@ class BannerRendererTest {
     @Test
     fun `breakpoint constants have expected values`() {
         assertEquals(80, BannerRenderer.Breakpoints.FULL)
-        assertEquals(60, BannerRenderer.Breakpoints.COMPACT)
+        assertEquals(60, BannerRenderer.Breakpoints.STANDARD)
+        assertEquals(40, BannerRenderer.Breakpoints.COMPACT)
         assertEquals(40, BannerRenderer.Breakpoints.MINIMAL)
     }
 
     @Test
     fun `banner width constants have expected values`() {
         assertEquals(49, BannerRenderer.BannerWidths.FULL)
+        assertEquals(43, BannerRenderer.BannerWidths.STANDARD)
         assertEquals(40, BannerRenderer.BannerWidths.COMPACT)
         assertEquals(24, BannerRenderer.BannerWidths.MINIMAL)
     }
@@ -194,18 +218,12 @@ class BannerRendererTest {
 
     @Test
     fun `selectBanner without argument uses terminal capabilities`() {
-        // This tests the integration with TerminalFactory
         val banner = BannerRenderer.selectBanner()
         assertNotNull(banner)
         assertTrue(banner.isNotEmpty())
     }
 
-    @Test
-    fun `selectBanner returns consistent results for same width`() {
-        val width = 75
-        val banner1 = BannerRenderer.selectBanner(width)
-        val banner2 = BannerRenderer.selectBanner(width)
-
-        assertEquals(banner1, banner2)
+    private fun assertAsciiOnly(text: String) {
+        assertTrue(text.all { it.code < 128 })
     }
 }

--- a/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/repl/TerminalCapabilityTest.kt
+++ b/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/repl/TerminalCapabilityTest.kt
@@ -1,0 +1,99 @@
+package link.socket.ampere.repl
+
+import com.github.ajalt.mordant.rendering.AnsiLevel
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TerminalCapabilityTest {
+
+    @Test
+    fun `supportsUnicode returns true for UTF-8 encoding`() = withSystemAccess(
+        FakeSystemAccess(properties = mapOf("stdout.encoding" to "UTF-8"))
+    ) {
+        assertTrue(TerminalFactory.supportsUnicode())
+    }
+
+    @Test
+    fun `supportsUnicode returns false for non-UTF encoding`() = withSystemAccess(
+        FakeSystemAccess(properties = mapOf("stdout.encoding" to "US-ASCII"))
+    ) {
+        assertFalse(TerminalFactory.supportsUnicode())
+    }
+
+    @Test
+    fun `supportsUnicode falls back to LANG when encoding is missing`() = withSystemAccess(
+        FakeSystemAccess(env = mapOf("LANG" to "en_US.UTF-8"))
+    ) {
+        assertTrue(TerminalFactory.supportsUnicode())
+    }
+
+    @Test
+    fun `detectColorSupport returns NONE when NO_COLOR is set`() = withSystemAccess(
+        FakeSystemAccess(env = mapOf("NO_COLOR" to "1"), consoleAvailable = true)
+    ) {
+        assertEquals(AnsiLevel.NONE, TerminalFactory.detectColorSupport())
+    }
+
+    @Test
+    fun `detectColorSupport returns ANSI256 for 256color TERM`() = withSystemAccess(
+        FakeSystemAccess(env = mapOf("TERM" to "xterm-256color"), consoleAvailable = true)
+    ) {
+        assertEquals(AnsiLevel.ANSI256, TerminalFactory.detectColorSupport())
+    }
+
+    @Test
+    fun `detectColorSupport returns ANSI16 for basic TERM`() = withSystemAccess(
+        FakeSystemAccess(env = mapOf("TERM" to "xterm"), consoleAvailable = true)
+    ) {
+        assertEquals(AnsiLevel.ANSI16, TerminalFactory.detectColorSupport())
+    }
+
+    @Test
+    fun `detectColorSupport returns NONE for dumb TERM`() = withSystemAccess(
+        FakeSystemAccess(env = mapOf("TERM" to "dumb"), consoleAvailable = true)
+    ) {
+        assertEquals(AnsiLevel.NONE, TerminalFactory.detectColorSupport())
+    }
+
+    @Test
+    fun `isInteractive returns false when console is unavailable`() = withSystemAccess(
+        FakeSystemAccess(consoleAvailable = false)
+    ) {
+        assertFalse(TerminalFactory.isInteractive())
+    }
+
+    @Test
+    fun `terminal size falls back to defaults when unavailable`() = withSystemAccess(
+        FakeSystemAccess(sttySizeResult = null to null)
+    ) {
+        assertEquals(80, TerminalFactory.getTerminalWidth())
+        assertEquals(24, TerminalFactory.getTerminalHeight())
+    }
+
+    private fun withSystemAccess(access: TerminalFactory.SystemAccess, block: () -> Unit) {
+        TerminalFactory.reset()
+        TerminalFactory.systemAccess = access
+        try {
+            block()
+        } finally {
+            TerminalFactory.reset()
+        }
+    }
+
+    private class FakeSystemAccess(
+        private val properties: Map<String, String?> = emptyMap(),
+        private val env: Map<String, String?> = emptyMap(),
+        private val consoleAvailable: Boolean = true,
+        private val sttySizeResult: Pair<Int?, Int?> = null to null
+    ) : TerminalFactory.SystemAccess {
+        override fun getProperty(name: String): String? = properties[name]
+
+        override fun getEnv(name: String): String? = env[name]
+
+        override fun hasConsole(): Boolean = consoleAvailable
+
+        override fun sttySize(): Pair<Int?, Int?> = sttySizeResult
+    }
+}


### PR DESCRIPTION
Adds a standard banner size and ASCII fallbacks, plus testable terminal capability detection with coverage updates. Closes #279.