### PR TITLE
Link GitHub issues via gh API

### DIFF
--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/integrations/issues/BatchIssueCreator.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/integrations/issues/BatchIssueCreator.kt
@@ -89,6 +89,23 @@ class BatchIssueCreator(
             }
         }
 
+        // Link dependencies using provider-specific APIs (if supported).
+        for (issue in request.issues) {
+            if (issue.dependsOn.isNotEmpty()) {
+                val issueNumber = resolved[issue.localId] ?: continue
+                val dependencyNumbers = issue.dependsOn.mapNotNull { resolved[it] }
+
+                if (dependencyNumbers.isNotEmpty()) {
+                    // Best effort - dependency references already exist in the body.
+                    provider.linkDependencies(
+                        repository = request.repository,
+                        issueNumber = issueNumber,
+                        dependsOnIssueNumbers = dependencyNumbers,
+                    )
+                }
+            }
+        }
+
         // Add child summaries to parent issues
         // Find all unique parent issue numbers
         val parentNumbers = created

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/integrations/issues/IssueTrackerProvider.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/integrations/issues/IssueTrackerProvider.kt
@@ -67,6 +67,24 @@ interface IssueTrackerProvider {
     ): Result<Unit>
 
     /**
+     * Link issue dependencies in the tracking system.
+     *
+     * For example, in GitHub this can establish "blocked by" relationships
+     * using the Issue Dependencies API. Providers that do not support
+     * formal dependency links can leave this as a no-op.
+     *
+     * @param repository Repository identifier
+     * @param issueNumber Issue number that is blocked by dependencies
+     * @param dependsOnIssueNumbers Issue numbers that block the issue
+     * @return Success if dependencies were linked (or not needed), Failure otherwise
+     */
+    suspend fun linkDependencies(
+        repository: String,
+        issueNumber: Int,
+        dependsOnIssueNumbers: List<Int>,
+    ): Result<Unit> = Result.success(Unit)
+
+    /**
      * Query existing issues.
      *
      * Useful for duplicate detection, finding related work, and

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/integrations/issues/README.md
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/integrations/issues/README.md
@@ -23,6 +23,7 @@ Implementations must provide:
    - `updateIssue()`: Modify existing issues
    - `queryIssues()`: Search and retrieve issues
 4. **Relationships**: `setParentRelationship()` for hierarchical issues
+5. **Dependencies**: `linkDependencies()` for formal blocked-by links (if supported)
 
 ## Data Model
 
@@ -125,6 +126,18 @@ override suspend fun setParentRelationship(
 ): Result<Unit> {
     // Use Jira's parent field
     return jiraClient.setParent(childIssueNumber, parentIssueNumber)
+}
+```
+
+**GitHub**: Link dependencies with Issue Dependencies API
+```kotlin
+override suspend fun linkDependencies(
+    repository: String,
+    issueNumber: Int,
+    dependsOnIssueNumbers: List<Int>
+): Result<Unit> {
+    // Link "blocked by" relationships using the GitHub API
+    // No-op if the platform does not support formal dependency links
 }
 ```
 


### PR DESCRIPTION
Closes #291.\n\nAdds formal GitHub issue dependency and sub-issue linking using gh API, with batch linking support and tests.