### PR TITLE
Add arc registry for built-in configs

### DIFF
--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/arc/ArcRegistry.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/arc/ArcRegistry.kt
@@ -1,0 +1,99 @@
+package link.socket.ampere.domain.arc
+
+/**
+ * Registry of built-in arcs for Ampere.
+ */
+object ArcRegistry {
+
+    private const val DEFAULT_ARC_NAME = "startup-saas"
+
+    private val builtInArcs: List<ArcConfig> = listOf(
+        ArcConfig(
+            name = "startup-saas",
+            description = "PM -> Code -> QA pipeline for product tickets",
+            agents = listOf(
+                ArcAgentConfig(role = "pm"),
+                ArcAgentConfig(role = "code"),
+                ArcAgentConfig(role = "qa"),
+            ),
+            orchestration = OrchestrationConfig(
+                type = OrchestrationType.SEQUENTIAL,
+                order = listOf("pm", "code", "qa"),
+            ),
+        ),
+        ArcConfig(
+            name = "devops-pipeline",
+            description = "Infrastructure deployment and monitoring pipeline",
+            agents = listOf(
+                ArcAgentConfig(role = "planner"),
+                ArcAgentConfig(role = "executor"),
+                ArcAgentConfig(role = "monitor"),
+            ),
+            orchestration = OrchestrationConfig(
+                type = OrchestrationType.SEQUENTIAL,
+                order = listOf("planner", "executor", "monitor"),
+            ),
+        ),
+        ArcConfig(
+            name = "research-paper",
+            description = "Academic and technical writing pipeline",
+            agents = listOf(
+                ArcAgentConfig(role = "scholar"),
+                ArcAgentConfig(role = "writer"),
+                ArcAgentConfig(role = "critic"),
+            ),
+            orchestration = OrchestrationConfig(
+                type = OrchestrationType.SEQUENTIAL,
+                order = listOf("scholar", "writer", "critic"),
+            ),
+        ),
+        ArcConfig(
+            name = "data-pipeline",
+            description = "Data processing and validation pipeline",
+            agents = listOf(
+                ArcAgentConfig(role = "analyst"),
+                ArcAgentConfig(role = "engineer"),
+                ArcAgentConfig(role = "validator"),
+            ),
+            orchestration = OrchestrationConfig(
+                type = OrchestrationType.SEQUENTIAL,
+                order = listOf("analyst", "engineer", "validator"),
+            ),
+        ),
+        ArcConfig(
+            name = "security-audit",
+            description = "Security vulnerability detection and remediation pipeline",
+            agents = listOf(
+                ArcAgentConfig(role = "scanner"),
+                ArcAgentConfig(role = "analyst"),
+                ArcAgentConfig(role = "remediator"),
+            ),
+            orchestration = OrchestrationConfig(
+                type = OrchestrationType.SEQUENTIAL,
+                order = listOf("scanner", "analyst", "remediator"),
+            ),
+        ),
+        ArcConfig(
+            name = "content-creation",
+            description = "Content research, writing, and editing pipeline",
+            agents = listOf(
+                ArcAgentConfig(role = "researcher"),
+                ArcAgentConfig(role = "writer"),
+                ArcAgentConfig(role = "editor"),
+            ),
+            orchestration = OrchestrationConfig(
+                type = OrchestrationType.SEQUENTIAL,
+                order = listOf("researcher", "writer", "editor"),
+            ),
+        ),
+    )
+
+    private val arcsByName = builtInArcs.associateBy { it.name.lowercase() }
+
+    fun get(name: String): ArcConfig? = arcsByName[name.lowercase()]
+
+    fun getDefault(): ArcConfig =
+        arcsByName[DEFAULT_ARC_NAME] ?: error("Default arc '$DEFAULT_ARC_NAME' not found")
+
+    fun list(): List<ArcConfig> = builtInArcs.toList()
+}

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/domain/arc/ArcRegistryTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/domain/arc/ArcRegistryTest.kt
@@ -1,0 +1,43 @@
+package link.socket.ampere.domain.arc
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class ArcRegistryTest {
+
+    @Test
+    fun `list returns all built-in arcs`() {
+        val arcs = ArcRegistry.list()
+
+        val names = arcs.map { it.name }.toSet()
+        assertEquals(6, arcs.size)
+        assertTrue(names.containsAll(
+            listOf(
+                "startup-saas",
+                "devops-pipeline",
+                "research-paper",
+                "data-pipeline",
+                "security-audit",
+                "content-creation",
+            )
+        ))
+    }
+
+    @Test
+    fun `get returns arc by name case-insensitively`() {
+        val arc = ArcRegistry.get("Startup-SaaS")
+
+        assertNotNull(arc)
+        assertEquals("startup-saas", arc.name)
+        assertEquals(listOf("pm", "code", "qa"), arc.orchestration.order)
+    }
+
+    @Test
+    fun `getDefault returns startup-saas arc`() {
+        val arc = ArcRegistry.getDefault()
+
+        assertEquals("startup-saas", arc.name)
+    }
+}


### PR DESCRIPTION
Adds ArcRegistry for the six built-in arcs with default lookup and tests. Closes #295.