### PR TITLE
Add --auto-respond flag for scripted demos (#307)

### DIFF
--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/layout/JazzProgressPane.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/layout/JazzProgressPane.kt
@@ -53,7 +53,8 @@ class JazzProgressPane(
     data class EscalationInfo(
         val question: String,
         val options: List<EscalationOption>,
-        val startTime: Instant
+        val startTime: Instant,
+        val autoRespondSecondsRemaining: Int? = null
     )
 
     /**
@@ -199,6 +200,17 @@ class JazzProgressPane(
      */
     fun clearAwaitingHuman() {
         state = state.copy(escalation = null)
+    }
+
+    /**
+     * Update the auto-respond countdown timer display.
+     * @param secondsRemaining Seconds until auto-respond, or null to clear countdown
+     */
+    fun setAutoRespondCountdown(secondsRemaining: Int?) {
+        val currentEscalation = state.escalation ?: return
+        state = state.copy(
+            escalation = currentEscalation.copy(autoRespondSecondsRemaining = secondsRemaining)
+        )
     }
 
     /**
@@ -368,6 +380,10 @@ class JazzProgressPane(
                             "[${option.key}] ${option.label}"
                         }
                         details.add("Press $optionsStr".take(maxWidth))
+                    }
+                    // Show auto-respond countdown if active
+                    escalation.autoRespondSecondsRemaining?.let { seconds ->
+                        details.add("Auto-responding with [A] in ${seconds}s...")
                     }
                     details
                 } else if (state.phase.ordinal > Phase.PLAN.ordinal && state.planSteps > 0) {


### PR DESCRIPTION
## Summary
Add a command-line flag to automatically respond to escalations after a 3-second pause, enabling recorded demos and GIFs to run without manual intervention.

## Implementation
- Added `--auto-respond` flag to `JazzDemoCommand` using Clikt options
- Implemented 3-second countdown with visual display in escalation UI
- Auto-responds with Option A (default/minimal scope choice)
- Enhanced logging to distinguish auto-respond from human responses

## Testing
All JVM tests pass with the new implementation.

Closes #307