### PR TITLE
Implement contextual keyboard shortcuts in status bar during escalation

### DIFF
--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/JazzDemoCommand.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/JazzDemoCommand.kt
@@ -262,12 +262,24 @@ class JazzDemoCommand(
                         DemoInputHandler.DemoMode.AGENT_FOCUS -> "agent_focus"
                     }
                     val shortcuts = StatusBar.defaultShortcuts(activeMode)
+
+                    // Build escalation shortcuts when awaiting human input
+                    val escalationShortcuts = if (jazzPane.isAwaitingHuman && jazzPane.escalationOptions.isNotEmpty()) {
+                        StatusBar.escalationShortcuts(jazzPane.escalationOptions)
+                    } else {
+                        null
+                    }
+
+                    // Use inputHint only for non-escalation input modes (e.g., AWAITING_AGENT)
+                    val inputHintForStatusBar = if (escalationShortcuts != null) null else viewConfig.inputHint
+
                     val statusBarStr = statusBar.render(
                         width = terminal.info.width,
                         shortcuts = shortcuts,
                         status = systemStatus,
                         focusedAgent = viewConfig.focusedAgentIndex,
-                        inputHint = viewConfig.inputHint
+                        inputHint = inputHintForStatusBar,
+                        escalationShortcuts = escalationShortcuts
                     )
 
                     // Determine right pane based on mode

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/layout/JazzProgressPane.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/layout/JazzProgressPane.kt
@@ -219,6 +219,13 @@ class JazzProgressPane(
     val isAwaitingHuman: Boolean
         get() = state.isAwaitingHuman
 
+    /**
+     * Get the current escalation options, if any.
+     * Returns key-label pairs suitable for status bar display.
+     */
+    val escalationOptions: List<Pair<String, String>>
+        get() = state.escalation?.options?.map { it.key to it.label } ?: emptyList()
+
     override fun render(width: Int, height: Int): List<String> {
         frameCounter++
         val lines = mutableListOf<String>()

--- a/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/cli/layout/JazzProgressPaneTest.kt
+++ b/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/cli/layout/JazzProgressPaneTest.kt
@@ -160,4 +160,45 @@ class JazzProgressPaneTest {
         assertTrue(plainOutput.contains("PLAN"), "Should show PLAN phase")
         assertTrue(plainOutput.contains("creating plan..."), "Should show creating plan details")
     }
+
+    @Test
+    fun `escalationOptions returns empty list when no escalation`() {
+        val terminal = Terminal()
+        val pane = JazzProgressPane(terminal)
+
+        assertTrue(pane.escalationOptions.isEmpty(), "Should return empty list when no escalation")
+    }
+
+    @Test
+    fun `escalationOptions returns options as key-label pairs`() {
+        val terminal = Terminal()
+        val clock = FakeClock(Instant.parse("2024-01-01T00:00:00Z"))
+        val pane = JazzProgressPane(terminal, clock)
+
+        pane.setAwaitingHuman(
+            question = "Test question?",
+            options = listOf("A" to "option A", "B" to "option B")
+        )
+
+        val options = pane.escalationOptions
+        assertEquals(2, options.size)
+        assertEquals("A" to "option A", options[0])
+        assertEquals("B" to "option B", options[1])
+    }
+
+    @Test
+    fun `escalationOptions clears after clearAwaitingHuman`() {
+        val terminal = Terminal()
+        val clock = FakeClock(Instant.parse("2024-01-01T00:00:00Z"))
+        val pane = JazzProgressPane(terminal, clock)
+
+        pane.setAwaitingHuman(
+            question = "Test?",
+            options = listOf("X" to "test")
+        )
+        assertEquals(1, pane.escalationOptions.size)
+
+        pane.clearAwaitingHuman()
+        assertTrue(pane.escalationOptions.isEmpty(), "Should be empty after clearing")
+    }
 }

--- a/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/cli/layout/StatusBarTest.kt
+++ b/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/cli/layout/StatusBarTest.kt
@@ -1,0 +1,158 @@
+package link.socket.ampere.cli.layout
+
+import com.github.ajalt.mordant.terminal.Terminal
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class StatusBarTest {
+
+    private fun stripAnsi(text: String): String {
+        return text.replace(Regex("\u001B\\[[0-9;]*[a-zA-Z]"), "")
+    }
+
+    @Test
+    fun `escalationShortcuts creates shortcuts from options`() {
+        val options = listOf(
+            "A" to "Option A",
+            "B" to "Option B"
+        )
+
+        val shortcuts = StatusBar.escalationShortcuts(options)
+
+        assertEquals(3, shortcuts.size, "Should have 3 shortcuts (2 options + ESC)")
+        assertEquals("A", shortcuts[0].key)
+        assertEquals("Option A", shortcuts[0].label)
+        assertEquals("B", shortcuts[1].key)
+        assertEquals("Option B", shortcuts[1].label)
+        assertEquals("ESC", shortcuts[2].key)
+        assertEquals("skip", shortcuts[2].label)
+    }
+
+    @Test
+    fun `escalationShortcuts always adds ESC skip at end`() {
+        val options = listOf("X" to "Single option")
+
+        val shortcuts = StatusBar.escalationShortcuts(options)
+
+        assertEquals(2, shortcuts.size)
+        assertEquals("ESC", shortcuts.last().key)
+        assertEquals("skip", shortcuts.last().label)
+    }
+
+    @Test
+    fun `escalationShortcuts handles empty options`() {
+        val shortcuts = StatusBar.escalationShortcuts(emptyList())
+
+        assertEquals(1, shortcuts.size, "Should only have ESC shortcut")
+        assertEquals("ESC", shortcuts[0].key)
+        assertEquals("skip", shortcuts[0].label)
+    }
+
+    @Test
+    fun `render with escalation shortcuts displays them instead of normal shortcuts`() {
+        val terminal = Terminal()
+        val statusBar = StatusBar(terminal)
+
+        val normalShortcuts = StatusBar.defaultShortcuts("events")
+        val escalationShortcuts = listOf(
+            StatusBar.EscalationShortcut("A", "keep Verbose"),
+            StatusBar.EscalationShortcut("B", "add both"),
+            StatusBar.EscalationShortcut("ESC", "skip")
+        )
+
+        val output = statusBar.render(
+            width = 100,
+            shortcuts = normalShortcuts,
+            status = StatusBar.SystemStatus.WAITING,
+            escalationShortcuts = escalationShortcuts
+        )
+        val plainOutput = stripAnsi(output)
+
+        // Should show escalation shortcuts
+        assertTrue(plainOutput.contains("[A]"), "Should contain [A] shortcut")
+        assertTrue(plainOutput.contains("keep Verbose"), "Should contain 'keep Verbose' label")
+        assertTrue(plainOutput.contains("[B]"), "Should contain [B] shortcut")
+        assertTrue(plainOutput.contains("add both"), "Should contain 'add both' label")
+        assertTrue(plainOutput.contains("[ESC]"), "Should contain [ESC] shortcut")
+        assertTrue(plainOutput.contains("skip"), "Should contain 'skip' label")
+
+        // Should NOT show normal shortcuts
+        assertFalse(plainOutput.contains("[d]"), "Should not contain [d] shortcut")
+        assertFalse(plainOutput.contains("[e]"), "Should not contain [e] shortcut")
+        assertFalse(plainOutput.contains("[m]"), "Should not contain [m] shortcut")
+        assertFalse(plainOutput.contains("[q]"), "Should not contain [q] shortcut")
+    }
+
+    @Test
+    fun `render without escalation shortcuts shows normal shortcuts`() {
+        val terminal = Terminal()
+        val statusBar = StatusBar(terminal)
+
+        val normalShortcuts = StatusBar.defaultShortcuts("events")
+
+        val output = statusBar.render(
+            width = 100,
+            shortcuts = normalShortcuts,
+            status = StatusBar.SystemStatus.WORKING,
+            escalationShortcuts = null
+        )
+        val plainOutput = stripAnsi(output)
+
+        // Should show normal shortcuts
+        assertTrue(plainOutput.contains("[d]"), "Should contain [d] shortcut")
+        assertTrue(plainOutput.contains("[e]"), "Should contain [e] shortcut")
+        assertTrue(plainOutput.contains("[m]"), "Should contain [m] shortcut")
+        assertTrue(plainOutput.contains("[q]"), "Should contain [q] shortcut")
+
+        // Should NOT show escalation-style shortcuts
+        assertFalse(plainOutput.contains("[A]"), "Should not contain [A] shortcut")
+        assertFalse(plainOutput.contains("[B]"), "Should not contain [B] shortcut")
+    }
+
+    @Test
+    fun `render with escalation shortcuts shows WAITING status`() {
+        val terminal = Terminal()
+        val statusBar = StatusBar(terminal)
+
+        val escalationShortcuts = StatusBar.escalationShortcuts(listOf("A" to "opt A"))
+
+        val output = statusBar.render(
+            width = 100,
+            shortcuts = emptyList(),
+            status = StatusBar.SystemStatus.WAITING,
+            escalationShortcuts = escalationShortcuts
+        )
+        val plainOutput = stripAnsi(output)
+
+        assertTrue(plainOutput.contains("WAITING"), "Should contain WAITING status")
+    }
+
+    @Test
+    fun `render with empty escalation shortcuts list falls back to normal behavior`() {
+        val terminal = Terminal()
+        val statusBar = StatusBar(terminal)
+
+        val normalShortcuts = StatusBar.defaultShortcuts()
+
+        val output = statusBar.render(
+            width = 100,
+            shortcuts = normalShortcuts,
+            status = StatusBar.SystemStatus.IDLE,
+            escalationShortcuts = emptyList()
+        )
+        val plainOutput = stripAnsi(output)
+
+        // Empty list should be treated as null, showing normal shortcuts
+        assertTrue(plainOutput.contains("[d]"), "Should contain [d] shortcut with empty escalation list")
+    }
+
+    @Test
+    fun `EscalationShortcut data class stores key and label`() {
+        val shortcut = StatusBar.EscalationShortcut("A", "Test Label")
+
+        assertEquals("A", shortcut.key)
+        assertEquals("Test Label", shortcut.label)
+    }
+}


### PR DESCRIPTION
## Summary

Implements contextual keyboard shortcuts in the status bar during escalation workflow. When the agent is in AWAITING_HUMAN state, the status bar now displays escalation-specific shortcuts (`[A] Option A [B] Option B [ESC] skip`) instead of normal view mode shortcuts, creating a clearer visual hierarchy for the escalation moment.

## Changes

- Added `EscalationShortcut` data class to `StatusBar.kt` for escalation-specific shortcuts
- Enhanced `StatusBar.render()` to accept and display escalation shortcuts
- Added `escalationOptions` property to `JazzProgressPane` for accessing current escalation options
- Updated `JazzDemoCommand` render loop to pass escalation shortcuts when awaiting human input
- Added comprehensive test coverage: 8 tests in `StatusBarTest.kt` and 3 tests in `JazzProgressPaneTest.kt`

## Acceptance Criteria

- ✅ Escalation shortcuts appear during WAITING state
- ✅ Normal shortcuts restore after receiving a response
- ✅ No visual flickering or jarring transitions

Closes #310

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>