### PR TITLE
Add runtime LLM provider configuration

### DIFF
--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/AmpereContext.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/AmpereContext.kt
@@ -37,6 +37,7 @@ import link.socket.ampere.config.AmpereConfig
 import link.socket.ampere.data.DEFAULT_JSON
 import link.socket.ampere.db.Database
 import link.socket.ampere.domain.ai.configuration.AIConfiguration
+import link.socket.ampere.domain.llm.LlmProvider
 
 /**
  * Context that provides dependencies for CLI commands.
@@ -76,6 +77,8 @@ class AmpereContext(
     val userConfig: AmpereConfig? = null,
     /** AI configuration derived from user config or default */
     val aiConfiguration: AIConfiguration? = null,
+    /** Custom LLM provider for bypassing built-in providers, useful for testing and custom integrations */
+    val llmProvider: LlmProvider? = null,
 ) {
     /**
      * Database driver for SQLite operations.

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/Main.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/Main.kt
@@ -85,6 +85,7 @@ fun main(args: Array<String>) {
         issueTrackerProvider = issueTrackerProvider,
         repository = repository,
         aiConfiguration = aiConfiguration,
+        llmProvider = context.llmProvider,
     )
 
     // Create agents based on team configuration (or defaults if no config)

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/config/AgentConfiguration.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/config/AgentConfiguration.kt
@@ -1,12 +1,16 @@
 package link.socket.ampere.agents.config
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 import link.socket.ampere.domain.agent.bundled.AgentDefinition
 import link.socket.ampere.domain.ai.configuration.AIConfiguration
+import link.socket.ampere.domain.llm.LlmProvider
 
 @Serializable
 data class AgentConfiguration(
     val agentDefinition: AgentDefinition,
     val aiConfiguration: AIConfiguration,
     val cognitiveConfig: CognitiveConfig = CognitiveConfig(),
+    @Transient
+    val llmProvider: LlmProvider? = null,
 )

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/AgentFactory.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/AgentFactory.kt
@@ -22,6 +22,7 @@ import link.socket.ampere.agents.execution.tools.ToolWriteCodeFile
 import link.socket.ampere.domain.agent.bundled.WriteCodeAgent
 import link.socket.ampere.domain.ai.configuration.AIConfiguration
 import link.socket.ampere.domain.ai.configuration.AIConfigurationFactory
+import link.socket.ampere.domain.llm.LlmProvider
 import link.socket.ampere.integrations.issues.IssueTrackerProvider
 
 enum class AgentType {
@@ -66,6 +67,7 @@ class AgentFactory(
     private val projectSpark: ProjectSpark? = null,
     private val toolWriteCodeFileOverride: Tool<ExecutionContext.Code.WriteCode>? = null,
     private val cognitiveConfig: CognitiveConfig = CognitiveConfig(),
+    private val llmProvider: LlmProvider? = null,
 ) {
     private val toolWriteCodeFile: Tool<ExecutionContext.Code.WriteCode> =
         toolWriteCodeFileOverride ?: ToolWriteCodeFile(AgentActionAutonomy.ASK_BEFORE_ACTION)
@@ -84,6 +86,7 @@ class AgentFactory(
             agentDefinition = WriteCodeAgent,
             aiConfiguration = effectiveAiConfiguration,
             cognitiveConfig = cognitiveConfig,
+            llmProvider = llmProvider,
         )
 
     /**

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/reasoning/AgentLLMService.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/reasoning/AgentLLMService.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import link.socket.ampere.agents.config.AgentConfiguration
+import link.socket.ampere.domain.llm.LlmProvider
 import link.socket.ampere.domain.util.toClientModelId
 import link.socket.ampere.util.logWith
 
@@ -17,9 +18,27 @@ import link.socket.ampere.util.logWith
  *
  * This service provides:
  * - Consistent LLM calling patterns across all agent types
+ * - Support for custom LLM providers for testing and integration
  * - Automatic response cleaning and JSON parsing
  * - Token usage logging for monitoring
  * - Configurable temperature and token limits
+ *
+ * ## Custom Provider Support
+ *
+ * When a custom [LlmProvider] is configured, all LLM calls are routed
+ * through it instead of the built-in OpenAI client. The system message
+ * and user prompt are combined into a single string:
+ *
+ * ```
+ * System: <system message>
+ *
+ * User: <user prompt>
+ * ```
+ *
+ * This enables:
+ * - Testing with mock responses
+ * - Integration with custom LLM backends
+ * - Prompt interception and transformation
  *
  * Usage:
  * ```kotlin
@@ -28,7 +47,7 @@ import link.socket.ampere.util.logWith
  * val jsonObj = response.asObject()
  * ```
  *
- * @property agentConfiguration The agent's configuration containing AI provider and model
+ * @property agentConfiguration The agent's configuration containing AI provider, model, and optional custom provider
  */
 class AgentLLMService(
     private val agentConfiguration: AgentConfiguration,
@@ -38,6 +57,9 @@ class AgentLLMService(
 
     /**
      * Calls the LLM with a prompt and returns the raw response text.
+     *
+     * If a custom [LlmProvider] is configured, the call is routed through it.
+     * Otherwise, the built-in OpenAI client is used.
      *
      * @param prompt The user prompt to send
      * @param systemMessage Optional system message to set context
@@ -51,6 +73,16 @@ class AgentLLMService(
         temperature: Double = DEFAULT_TEMPERATURE,
         maxTokens: Int = DEFAULT_MAX_TOKENS,
     ): String {
+        // Route through custom provider if configured
+        agentConfiguration.llmProvider?.let { provider ->
+            logger.d { "[LLM] Using custom provider" }
+            val combinedPrompt = buildCombinedPrompt(systemMessage, prompt)
+            return withContext(Dispatchers.IO) {
+                provider(combinedPrompt)
+            }
+        }
+
+        // Fall back to built-in provider
         val client = agentConfiguration.aiConfiguration.provider.client
         val model = agentConfiguration.aiConfiguration.model
 
@@ -164,6 +196,28 @@ class AgentLLMService(
 
         const val JSON_SYSTEM_MESSAGE =
             "You are an autonomous agent component. Respond only with valid JSON, no explanations or markdown."
+
+        /**
+         * Builds a combined prompt from system message and user prompt.
+         *
+         * Format:
+         * ```
+         * System: <system message>
+         *
+         * User: <user prompt>
+         * ```
+         *
+         * @param systemMessage The system context message
+         * @param prompt The user's prompt
+         * @return Combined prompt string
+         */
+        fun buildCombinedPrompt(systemMessage: String, prompt: String): String {
+            return """
+                |System: $systemMessage
+                |
+                |User: $prompt
+            """.trimMargin()
+        }
     }
 }
 

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/llm/LlmProvider.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/llm/LlmProvider.kt
@@ -1,0 +1,23 @@
+package link.socket.ampere.domain.llm
+
+/**
+ * Type alias for a custom LLM provider function.
+ *
+ * This allows external systems to inject their own LLM implementation
+ * at runtime, enabling:
+ * - Testing with mock responses
+ * - Integration with custom LLM backends
+ * - Prompt interception and transformation
+ *
+ * The prompt parameter contains the complete context including any
+ * system message, formatted as:
+ * ```
+ * System: <system message>
+ *
+ * User: <user prompt>
+ * ```
+ *
+ * @param prompt The complete prompt including system context and user message
+ * @return The LLM response as a string
+ */
+typealias LlmProvider = suspend (prompt: String) -> String

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/llm/CustomLlmProviderIntegrationTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/llm/CustomLlmProviderIntegrationTest.kt
@@ -1,0 +1,211 @@
+package link.socket.ampere.llm
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertContains
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import link.socket.ampere.agents.config.AgentConfiguration
+import link.socket.ampere.agents.config.CognitiveConfig
+import link.socket.ampere.agents.domain.reasoning.AgentLLMService
+import link.socket.ampere.domain.agent.bundled.WriteCodeAgent
+import link.socket.ampere.domain.ai.configuration.AIConfiguration
+import link.socket.ampere.domain.ai.model.AIModel
+import link.socket.ampere.domain.ai.model.AIModel_OpenAI
+import link.socket.ampere.domain.ai.provider.AIProvider
+import link.socket.ampere.domain.llm.LlmProvider
+
+/**
+ * Integration tests for custom LLM provider functionality.
+ *
+ * These tests verify:
+ * 1. Custom provider is called when configured
+ * 2. Prompts contain expected content (system message + user prompt)
+ * 3. Fallback to built-in provider when no custom provider is configured
+ * 4. Combined prompt format is correct
+ */
+class CustomLlmProviderIntegrationTest {
+
+    /**
+     * Fake AI configuration for testing that doesn't make real API calls.
+     */
+    private class FakeAIConfiguration : AIConfiguration {
+        override val provider: AIProvider<*, *>
+            get() = throw NotImplementedError("Provider should not be called when custom provider is set")
+        override val model: AIModel
+            get() = AIModel_OpenAI.GPT_4_1
+
+        override fun getAvailableModels(): List<Pair<AIProvider<*, *>, AIModel>> = emptyList()
+    }
+
+    /**
+     * Test that custom provider is called when configured.
+     */
+    @Test
+    fun `custom provider is called when configured`() = runTest {
+        var providerCalled = false
+        var receivedPrompt: String? = null
+
+        val customProvider: LlmProvider = { prompt ->
+            providerCalled = true
+            receivedPrompt = prompt
+            "Mock response from custom provider"
+        }
+
+        val config = AgentConfiguration(
+            agentDefinition = WriteCodeAgent,
+            aiConfiguration = FakeAIConfiguration(),
+            cognitiveConfig = CognitiveConfig(),
+            llmProvider = customProvider,
+        )
+
+        val llmService = AgentLLMService(config)
+
+        val response = llmService.call(
+            prompt = "What is 2 + 2?",
+            systemMessage = "You are a calculator.",
+        )
+
+        assertTrue(providerCalled, "Custom provider should have been called")
+        assertEquals("Mock response from custom provider", response)
+        assertContains(receivedPrompt!!, "You are a calculator.")
+        assertContains(receivedPrompt!!, "What is 2 + 2?")
+    }
+
+    /**
+     * Test that combined prompt format is correct.
+     */
+    @Test
+    fun `combined prompt has correct format`() = runTest {
+        var receivedPrompt: String? = null
+
+        val customProvider: LlmProvider = { prompt ->
+            receivedPrompt = prompt
+            "Response"
+        }
+
+        val config = AgentConfiguration(
+            agentDefinition = WriteCodeAgent,
+            aiConfiguration = FakeAIConfiguration(),
+            cognitiveConfig = CognitiveConfig(),
+            llmProvider = customProvider,
+        )
+
+        val llmService = AgentLLMService(config)
+
+        llmService.call(
+            prompt = "Hello world",
+            systemMessage = "Be helpful",
+        )
+
+        // Verify format: System: ... \n\n User: ...
+        assertTrue(receivedPrompt!!.startsWith("System: Be helpful"))
+        assertTrue(receivedPrompt!!.contains("\n\nUser: Hello world"))
+    }
+
+    /**
+     * Test buildCombinedPrompt utility function directly.
+     */
+    @Test
+    fun `buildCombinedPrompt creates correct format`() {
+        val combined = AgentLLMService.buildCombinedPrompt(
+            systemMessage = "You are helpful",
+            prompt = "What time is it?",
+        )
+
+        assertEquals(
+            """
+            |System: You are helpful
+            |
+            |User: What time is it?
+            """.trimMargin(),
+            combined,
+        )
+    }
+
+    /**
+     * Test that prompts contain expected content for JSON calls.
+     */
+    @Test
+    fun `callForJson includes JSON system message`() = runTest {
+        var receivedPrompt: String? = null
+
+        val customProvider: LlmProvider = { prompt ->
+            receivedPrompt = prompt
+            """{"result": "success"}"""
+        }
+
+        val config = AgentConfiguration(
+            agentDefinition = WriteCodeAgent,
+            aiConfiguration = FakeAIConfiguration(),
+            cognitiveConfig = CognitiveConfig(),
+            llmProvider = customProvider,
+        )
+
+        val llmService = AgentLLMService(config)
+
+        val jsonResponse = llmService.callForJson(
+            prompt = "Return status",
+        )
+
+        // Verify JSON system message was used
+        assertContains(receivedPrompt!!, "valid JSON")
+
+        // Verify response was parsed
+        val obj = jsonResponse.asObject()
+        assertEquals("success", obj["result"]?.toString()?.trim('"'))
+    }
+
+    /**
+     * Test that custom provider can return different responses based on prompt.
+     */
+    @Test
+    fun `custom provider can implement conditional logic`() = runTest {
+        val customProvider: LlmProvider = { prompt ->
+            when {
+                prompt.contains("greeting") -> "Hello!"
+                prompt.contains("farewell") -> "Goodbye!"
+                else -> "Unknown request"
+            }
+        }
+
+        val config = AgentConfiguration(
+            agentDefinition = WriteCodeAgent,
+            aiConfiguration = FakeAIConfiguration(),
+            cognitiveConfig = CognitiveConfig(),
+            llmProvider = customProvider,
+        )
+
+        val llmService = AgentLLMService(config)
+
+        assertEquals("Hello!", llmService.call("Say a greeting"))
+        assertEquals("Goodbye!", llmService.call("Say a farewell"))
+        assertEquals("Unknown request", llmService.call("Do something else"))
+    }
+
+    /**
+     * Test that null provider falls back to built-in (would fail without real API).
+     * This test verifies the code path, not the actual API call.
+     */
+    @Test
+    fun `null provider attempts to use built-in provider`() = runTest {
+        val config = AgentConfiguration(
+            agentDefinition = WriteCodeAgent,
+            aiConfiguration = FakeAIConfiguration(),
+            cognitiveConfig = CognitiveConfig(),
+            llmProvider = null, // No custom provider
+        )
+
+        val llmService = AgentLLMService(config)
+
+        // This will throw because FakeAIConfiguration throws on provider access
+        // This verifies the fallback path is taken
+        try {
+            llmService.call("Test prompt")
+            assertTrue(false, "Should have thrown when accessing fake provider")
+        } catch (e: NotImplementedError) {
+            // Expected - the fake provider throws this
+            assertContains(e.message ?: "", "Provider should not be called")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Enable AMPERE consumers to inject custom LLM providers at runtime, allowing integration with enterprise/internal LLM endpoints and improved testing with mock providers.

## Changes
- Define `LlmProvider` type alias for custom LLM completion functions
- Add `llmProvider` parameter through the entry point chain (AmpereContext → AgentFactory → AgentConfiguration → AgentLLMService)
- Route cognitive function calls through custom provider when configured, with fallback to built-in providers
- Add comprehensive integration tests verifying custom provider behavior

## Test Plan
- ✅ All 6 new integration tests pass, verifying custom provider routing and prompt formatting
- ✅ All existing tests pass (no regressions)
- ✅ Compilation succeeds without errors

Closes #329 #330 #331 #332