### PR TITLE
Add Android actual implementations for expect declarations

### DIFF
--- a/ampere-core/src/androidMain/kotlin/link/socket/ampere/agents/environment/workspace/ExecutionWorkspace.android.kt
+++ b/ampere-core/src/androidMain/kotlin/link/socket/ampere/agents/environment/workspace/ExecutionWorkspace.android.kt
@@ -1,0 +1,14 @@
+package link.socket.ampere.agents.environment.workspace
+
+import java.io.File
+
+/** The default workspace path in the user's home directory, returns "~/.ampere/Workspaces/Ampere" */
+private fun defaultWorkspacePath(): String {
+    val homeDir = System.getProperty("user.home") ?: System.getProperty("user.dir") ?: "."
+    return File(homeDir, ".ampere/Workspaces/Ampere").absolutePath
+}
+
+actual fun defaultWorkspace(): ExecutionWorkspace =
+    ExecutionWorkspace(
+        baseDirectory = defaultWorkspacePath(),
+    )

--- a/ampere-core/src/androidMain/kotlin/link/socket/ampere/agents/execution/tools/ToolAskHuman.android.kt
+++ b/ampere-core/src/androidMain/kotlin/link/socket/ampere/agents/execution/tools/ToolAskHuman.android.kt
@@ -1,0 +1,60 @@
+package link.socket.ampere.agents.execution.tools
+
+import kotlin.time.Duration.Companion.minutes
+import kotlinx.datetime.Clock
+import link.socket.ampere.agents.domain.outcome.ExecutionOutcome
+import link.socket.ampere.agents.events.utils.generateUUID
+import link.socket.ampere.agents.execution.request.ExecutionContext
+import link.socket.ampere.agents.execution.tools.human.GlobalHumanResponseRegistry
+
+actual suspend fun executeAskHuman(
+    context: ExecutionContext.NoChanges,
+): ExecutionOutcome.NoChanges {
+    val executionStartTimestamp = Clock.System.now()
+    val requestId = generateUUID()
+
+    // Display the question to console (will also be visible in CLI dashboard through events)
+    println(
+        """
+        ════════════════════════════════════════
+        🤔 HUMAN INPUT REQUIRED
+        ════════════════════════════════════════
+        Request ID: $requestId
+        Executor: ${context.executorId}
+        Ticket: ${context.ticket.id}
+        Task: ${context.task.id}
+
+        Question: ${context.instructions}
+
+        To respond, use:
+        ./ampere-cli/ampere respond $requestId "<your response>"
+        ════════════════════════════════════════
+        """.trimIndent(),
+    )
+
+    // Wait for human response (blocks agent execution)
+    val humanResponse = GlobalHumanResponseRegistry.instance.waitForResponse(
+        requestId = requestId,
+        timeout = 30.minutes,
+    )
+
+    return if (humanResponse != null) {
+        ExecutionOutcome.NoChanges.Success(
+            executorId = context.executorId,
+            ticketId = context.ticket.id,
+            taskId = context.task.id,
+            executionStartTimestamp = executionStartTimestamp,
+            executionEndTimestamp = Clock.System.now(),
+            message = "Human response: $humanResponse",
+        )
+    } else {
+        ExecutionOutcome.NoChanges.Failure(
+            executorId = context.executorId,
+            ticketId = context.ticket.id,
+            taskId = context.task.id,
+            executionStartTimestamp = executionStartTimestamp,
+            executionEndTimestamp = Clock.System.now(),
+            message = "Human input request timed out after 30 minutes",
+        )
+    }
+}

--- a/ampere-core/src/androidMain/kotlin/link/socket/ampere/agents/tools/mcp/connection/HttpMcpConnection.android.kt
+++ b/ampere-core/src/androidMain/kotlin/link/socket/ampere/agents/tools/mcp/connection/HttpMcpConnection.android.kt
@@ -1,0 +1,96 @@
+package link.socket.ampere.agents.tools.mcp.connection
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.isSuccess
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Android implementation of HttpClientHandler using Ktor.
+ *
+ * Uses OkHttp engine for HTTP communication.
+ */
+actual class HttpClientHandler {
+    private var httpClient: HttpClient? = null
+
+    actual suspend fun validateEndpoint(
+        url: String,
+        authToken: String?,
+        timeoutMs: Long,
+    ): Result<Unit> = withContext(Dispatchers.IO) {
+        runCatching {
+            // Create HTTP client if not already created
+            if (httpClient == null) {
+                httpClient = HttpClient(OkHttp) {
+                    engine {
+                        config {
+                            connectTimeout(timeoutMs, TimeUnit.MILLISECONDS)
+                            readTimeout(timeoutMs, TimeUnit.MILLISECONDS)
+                        }
+                    }
+                }
+            }
+
+            // Send a simple GET request to validate accessibility
+            val response: HttpResponse = httpClient!!.get(url) {
+                if (authToken != null) {
+                    header(HttpHeaders.Authorization, "Bearer $authToken")
+                }
+            }
+
+            // Check for successful response
+            if (!response.status.isSuccess()) {
+                throw McpConnectionException(
+                    "Endpoint validation failed: ${response.status.value} ${response.status.description}",
+                )
+            }
+        }
+    }
+
+    actual suspend fun sendRequest(
+        url: String,
+        body: String,
+        authToken: String?,
+        timeoutMs: Long,
+    ): Result<String> = withContext(Dispatchers.IO) {
+        runCatching {
+            val client = httpClient ?: throw McpConnectionException("Client not initialized")
+
+            // Send POST request with JSON body
+            val response: HttpResponse = client.post(url) {
+                header(HttpHeaders.ContentType, ContentType.Application.Json)
+                if (authToken != null) {
+                    header(HttpHeaders.Authorization, "Bearer $authToken")
+                }
+                setBody(body)
+            }
+
+            // Check for successful response
+            if (!response.status.isSuccess()) {
+                throw McpConnectionException(
+                    "HTTP request failed: ${response.status.value} ${response.status.description}",
+                )
+            }
+
+            // Return response body
+            response.bodyAsText()
+        }
+    }
+
+    actual suspend fun close(): Result<Unit> = withContext(Dispatchers.IO) {
+        runCatching {
+            httpClient?.close()
+            httpClient = null
+        }
+    }
+}

--- a/ampere-core/src/androidMain/kotlin/link/socket/ampere/agents/tools/mcp/connection/StdioMcpConnection.android.kt
+++ b/ampere-core/src/androidMain/kotlin/link/socket/ampere/agents/tools/mcp/connection/StdioMcpConnection.android.kt
@@ -1,0 +1,75 @@
+package link.socket.ampere.agents.tools.mcp.connection
+
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Android implementation of StdioProcessHandler using ProcessBuilder.
+ *
+ * Spawns a child process and communicates via stdin/stdout using buffered streams.
+ */
+actual class StdioProcessHandler {
+    private var process: Process? = null
+    private var reader: BufferedReader? = null
+    private var writer: BufferedWriter? = null
+
+    actual suspend fun startProcess(executablePath: String): Result<Unit> = withContext(Dispatchers.IO) {
+        runCatching {
+            // Spawn the process
+            val processBuilder = ProcessBuilder(executablePath)
+                .redirectErrorStream(false) // Keep stderr separate for debugging
+
+            process = processBuilder.start()
+
+            // Set up I/O streams
+            reader = BufferedReader(InputStreamReader(process!!.inputStream))
+            writer = BufferedWriter(OutputStreamWriter(process!!.outputStream))
+
+            // Verify process started successfully
+            if (!process!!.isAlive) {
+                throw McpConnectionException("Process failed to start: $executablePath")
+            }
+        }
+    }
+
+    actual suspend fun sendMessage(message: String): Result<Unit> = withContext(Dispatchers.IO) {
+        runCatching {
+            val w = writer ?: throw McpConnectionException("Process not started")
+
+            // Write message with newline delimiter
+            w.write(message)
+            w.newLine()
+            w.flush()
+        }
+    }
+
+    actual suspend fun receiveMessage(): String = withContext(Dispatchers.IO) {
+        val r = reader ?: throw McpConnectionException("Process not started")
+
+        // Read a single line (newline-delimited message)
+        r.readLine() ?: throw McpConnectionException("Process terminated or stream closed")
+    }
+
+    actual suspend fun stopProcess(): Result<Unit> = withContext(Dispatchers.IO) {
+        runCatching {
+            // Close streams first
+            writer?.close()
+            reader?.close()
+
+            // Terminate the process
+            process?.destroy()
+
+            // Wait for termination (with timeout)
+            process?.waitFor()
+
+            // Clear references
+            writer = null
+            reader = null
+            process = null
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds Android-specific implementations for expect declarations that were missing
- Provides implementations for `ExecutionWorkspace`, `ToolAskHuman`, `HttpMcpConnection`, and `StdioMcpConnection`
- These implementations mirror the JVM versions since Android supports the same Java APIs

## Files Added
- `ExecutionWorkspace.android.kt` - default workspace path using Java File API
- `ToolAskHuman.android.kt` - human input handling with GlobalHumanResponseRegistry  
- `HttpMcpConnection.android.kt` - HTTP client using Ktor with OkHttp engine
- `StdioMcpConnection.android.kt` - process handling using ProcessBuilder

## Test plan
- [x] `./gradlew :ampere-core:compileDebugKotlinAndroid` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)