### PR TITLE
Add hybrid dashboard renderer with animation accents

### DIFF
--- a/ampere-cli/src/main/kotlin/link/socket/ampere/cli/hybrid/HybridCellBuffer.kt
+++ b/ampere-cli/src/main/kotlin/link/socket/ampere/cli/hybrid/HybridCellBuffer.kt
@@ -1,0 +1,177 @@
+package link.socket.ampere.cli.hybrid
+
+import link.socket.ampere.cli.layout.ParsedCell
+
+/**
+ * A single cell in the hybrid buffer.
+ */
+data class HybridCell(
+    val char: Char = ' ',
+    val ansiColor: String? = null,
+    val layer: Int = 0
+)
+
+private const val ANSI_RESET = "\u001B[0m"
+
+/**
+ * Double-buffered cell buffer that supports layer compositing and differential rendering.
+ *
+ * Layers (higher values overwrite lower):
+ *   0 - SUBSTRATE: Dim background density glyphs
+ *   1 - PANE_CONTENT: PaneRenderer output (overrides substrate completely)
+ *   2 - ACCENT: Sparse particles/flow in non-pane areas
+ *   3 - STATUS: Status bar content
+ *
+ * @property width Buffer width in characters
+ * @property height Buffer height in rows
+ */
+class HybridCellBuffer(
+    val width: Int,
+    val height: Int
+) {
+    private var currentBuffer: Array<Array<HybridCell>> = createBuffer()
+    private var previousBuffer: Array<Array<HybridCell>>? = null
+
+    private var firstFrame = true
+
+    private fun createBuffer(): Array<Array<HybridCell>> {
+        return Array(height) { Array(width) { HybridCell() } }
+    }
+
+    /**
+     * Clear the current buffer to empty spaces at layer 0.
+     */
+    fun clear() {
+        for (y in 0 until height) {
+            for (x in 0 until width) {
+                currentBuffer[y][x] = HybridCell()
+            }
+        }
+    }
+
+    /**
+     * Write a single character at a position with optional color.
+     * Only overwrites if the new layer is >= the existing layer.
+     */
+    fun writeChar(x: Int, y: Int, char: Char, ansiColor: String? = null, layer: Int = 0) {
+        if (x < 0 || x >= width || y < 0 || y >= height) return
+        val existing = currentBuffer[y][x]
+        if (layer >= existing.layer) {
+            currentBuffer[y][x] = HybridCell(char, ansiColor, layer)
+        }
+    }
+
+    /**
+     * Write a plain string at a position. Each character gets the same color and layer.
+     */
+    fun writeString(x: Int, y: Int, text: String, ansiColor: String? = null, layer: Int = 0) {
+        for (i in text.indices) {
+            writeChar(x + i, y, text[i], ansiColor, layer)
+        }
+    }
+
+    /**
+     * Write parsed pane content into a rectangular region of the buffer.
+     *
+     * @param startX Left column of the region
+     * @param startY Top row of the region
+     * @param rows Parsed cell rows from AnsiCellParser
+     * @param layer Layer priority for this content
+     */
+    fun writePaneRegion(
+        startX: Int,
+        startY: Int,
+        rows: List<List<ParsedCell>>,
+        layer: Int = 1
+    ) {
+        for ((rowIdx, cells) in rows.withIndex()) {
+            val y = startY + rowIdx
+            if (y >= height) break
+            for ((colIdx, cell) in cells.withIndex()) {
+                val x = startX + colIdx
+                if (x >= width) break
+                writeChar(x, y, cell.char, cell.ansiPrefix, layer)
+            }
+        }
+    }
+
+    /**
+     * Generate full ANSI output using row-based cursor positioning.
+     */
+    fun renderFull(): String {
+        return buildString {
+            for (y in 0 until height) {
+                // Position cursor at start of row (1-based)
+                append("\u001B[${y + 1};1H")
+                var lastColor: String? = null
+
+                for (x in 0 until width) {
+                    val cell = currentBuffer[y][x]
+                    if (cell.ansiColor != lastColor) {
+                        if (lastColor != null) {
+                            append(ANSI_RESET)
+                        }
+                        if (cell.ansiColor != null) {
+                            append(cell.ansiColor)
+                        }
+                        lastColor = cell.ansiColor
+                    }
+                    append(cell.char)
+                }
+                if (lastColor != null) {
+                    append(ANSI_RESET)
+                }
+                append("\u001B[K") // Clear rest of line
+            }
+        }
+    }
+
+    /**
+     * Generate differential ANSI output.
+     * Compares current buffer against previous buffer,
+     * emits cursor-positioned writes only for changed cells.
+     *
+     * Falls back to renderFull on first frame or if no previous buffer exists.
+     */
+    fun renderDiff(): String {
+        val prev = previousBuffer ?: return renderFull()
+
+        return buildString {
+            for (y in 0 until height) {
+                for (x in 0 until width) {
+                    val newCell = currentBuffer[y][x]
+                    val oldCell = prev[y][x]
+
+                    if (newCell != oldCell) {
+                        append("\u001B[${y + 1};${x + 1}H")
+                        if (newCell.ansiColor != null) {
+                            append(newCell.ansiColor)
+                            append(newCell.char)
+                            append(ANSI_RESET)
+                        } else {
+                            append(newCell.char)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Swap buffers: save current as previous for the next diff comparison.
+     */
+    fun swapBuffers() {
+        // Deep copy current to previous
+        previousBuffer = Array(height) { y ->
+            Array(width) { x -> currentBuffer[y][x] }
+        }
+    }
+
+    /**
+     * Get the cell at a specific position (for testing).
+     */
+    fun getCell(x: Int, y: Int): HybridCell {
+        if (x < 0 || x >= width || y < 0 || y >= height) return HybridCell()
+        return currentBuffer[y][x]
+    }
+}

--- a/ampere-cli/src/main/kotlin/link/socket/ampere/cli/hybrid/HybridDashboardRenderer.kt
+++ b/ampere-cli/src/main/kotlin/link/socket/ampere/cli/hybrid/HybridDashboardRenderer.kt
@@ -1,0 +1,297 @@
+package link.socket.ampere.cli.hybrid
+
+import com.github.ajalt.mordant.terminal.Terminal
+import link.socket.ampere.cli.animation.particle.ParticleSystem
+import link.socket.ampere.cli.animation.render.AmperePalette
+import link.socket.ampere.cli.animation.render.CompositeRenderer
+import link.socket.ampere.cli.animation.substrate.SubstrateAnimator
+import link.socket.ampere.cli.animation.substrate.SubstrateGlyphs
+import link.socket.ampere.cli.animation.substrate.SubstrateState
+import link.socket.ampere.cli.layout.AnsiCellParser
+import link.socket.ampere.cli.layout.PaneRenderer
+import link.socket.ampere.cli.layout.fitToHeight
+import link.socket.ampere.cli.layout.fitToWidth
+import link.socket.ampere.cli.watch.presentation.WatchViewState
+import kotlin.math.roundToInt
+
+/**
+ * Configuration for the hybrid dashboard renderer.
+ */
+data class HybridConfig(
+    val enableSubstrate: Boolean = true,
+    val enableParticles: Boolean = true,
+    val substrateOpacity: Float = 0.15f,
+    val particleMaxCount: Int = 30,
+    val useColor: Boolean = CompositeRenderer.supports256Colors(),
+    val useUnicode: Boolean = CompositeRenderer.supportsUnicode(),
+    val leftRatio: Float = 0.35f,
+    val middleRatio: Float = 0.40f,
+    val rightRatio: Float = 0.25f
+)
+
+/**
+ * Hybrid dashboard renderer that composites animated substrate and particle accents
+ * underneath the standard three-column layout.
+ *
+ * Animation appears ONLY in "accent areas" (divider columns, left/right margins)
+ * and never obscures pane content.
+ *
+ * Render pipeline per frame:
+ *   1. Bridge updates animation state from WatchViewState
+ *   2. Substrate ambient animation step
+ *   3. Particle physics step
+ *   4. Clear cell buffer
+ *   5. Write substrate glyphs to accent areas at layer 0
+ *   6. Parse pane output and write at layer 1
+ *   7. Write divider characters at divider columns
+ *   8. Write particle glyphs at layer 2 (accent areas only)
+ *   9. Write status bar
+ *  10. Return differential output
+ */
+class HybridDashboardRenderer(
+    private val terminal: Terminal?,
+    private val config: HybridConfig = HybridConfig(),
+    private val explicitWidth: Int? = null,
+    private val explicitHeight: Int? = null
+) {
+    private lateinit var buffer: HybridCellBuffer
+    private lateinit var substrate: SubstrateState
+    private lateinit var substrateAnimator: SubstrateAnimator
+    private lateinit var particles: ParticleSystem
+    private lateinit var bridge: WatchStateAnimationBridge
+
+    private var initialized = false
+    private var frameCount = 0L
+
+    // Column layout (mirrors ThreeColumnLayout calculations)
+    private var totalWidth = 0
+    private var totalHeight = 0
+    private var contentHeight = 0
+    private var leftWidth = 0
+    private var middleWidth = 0
+    private var rightWidth = 0
+    private var divider1Col = 0
+    private var divider2Col = 0
+    private var accentColumns = setOf<Int>()
+
+    /**
+     * Initialize renderer with current terminal dimensions.
+     * Must be called before first render.
+     */
+    fun initialize() {
+        totalWidth = (explicitWidth ?: terminal?.info?.width ?: 80).coerceAtLeast(40)
+        totalHeight = (explicitHeight ?: terminal?.info?.height ?: 24).coerceAtLeast(10)
+        contentHeight = totalHeight - 2
+
+        // Replicate ThreeColumnLayout width calculations
+        val availableWidth = totalWidth - 2 // Account for 2 dividers
+        leftWidth = (availableWidth * config.leftRatio).toInt()
+        rightWidth = (availableWidth * config.rightRatio).toInt()
+        middleWidth = availableWidth - leftWidth - rightWidth
+
+        divider1Col = leftWidth
+        divider2Col = leftWidth + 1 + middleWidth
+
+        // Accent areas: first column, divider columns, last column
+        accentColumns = buildSet {
+            add(0)                      // Left margin
+            add(divider1Col)            // First divider
+            add(divider2Col)            // Second divider
+            if (totalWidth > 0) {
+                add(totalWidth - 1)     // Right margin
+            }
+        }
+
+        buffer = HybridCellBuffer(totalWidth, totalHeight)
+
+        substrate = SubstrateState.create(totalWidth, totalHeight, baseDensity = 0.2f)
+        substrateAnimator = SubstrateAnimator(
+            baseDensity = 0.2f,
+            noiseAmplitude = 0.15f,
+            timeScale = 0.03f
+        )
+        particles = ParticleSystem(
+            maxParticles = config.particleMaxCount,
+            drag = 0.2f,
+            lifeDecayRate = 0.8f
+        )
+
+        bridge = WatchStateAnimationBridge(
+            substrateAnimator = substrateAnimator,
+            particles = particles,
+            accentColumns = accentColumns,
+            height = contentHeight,
+            maxParticles = config.particleMaxCount
+        )
+
+        initialized = true
+    }
+
+    /**
+     * Render one frame of the hybrid dashboard.
+     *
+     * @param leftPane Left pane renderer (event stream)
+     * @param middlePane Middle pane renderer (main interaction)
+     * @param rightPane Right pane renderer (agent/memory)
+     * @param statusBar Status bar text
+     * @param viewState Current watch view state (null-safe)
+     * @param deltaSeconds Time since last frame
+     * @return ANSI string to write to terminal
+     */
+    fun render(
+        leftPane: PaneRenderer,
+        middlePane: PaneRenderer,
+        rightPane: PaneRenderer,
+        statusBar: String,
+        viewState: WatchViewState? = null,
+        deltaSeconds: Float = 0.033f
+    ): String {
+        if (!initialized) initialize()
+
+        // Detect terminal resize (only when using live terminal, not explicit dimensions)
+        if (explicitWidth == null && terminal != null) {
+            val currentWidth = terminal.info.width
+            val currentHeight = terminal.info.height
+            if (currentWidth != totalWidth || currentHeight != totalHeight) {
+                initialize()
+            }
+        }
+
+        // 1. Bridge updates animation from watch state
+        substrate = bridge.update(viewState, substrate, deltaSeconds)
+
+        // 2-3. (ambient + particle updates handled inside bridge.update)
+
+        // 4. Clear buffer
+        buffer.clear()
+
+        // 5. Write substrate glyphs to accent areas only (layer 0)
+        if (config.enableSubstrate) {
+            renderSubstrateAccents()
+        }
+
+        // 6. Parse and write pane content (layer 1)
+        renderPaneContent(leftPane, middlePane, rightPane)
+
+        // 7. Write divider characters
+        renderDividers()
+
+        // 8. Write particle glyphs in accent areas (layer 2)
+        if (config.enableParticles) {
+            renderParticleAccents()
+        }
+
+        // 9. Write status bar
+        renderStatusBar(statusBar)
+
+        // 10. Generate output
+        val output = if (frameCount == 0L) {
+            buffer.renderFull()
+        } else {
+            buffer.renderDiff()
+        }
+
+        buffer.swapBuffers()
+        frameCount++
+
+        return output
+    }
+
+    private fun renderSubstrateAccents() {
+        for (y in 0 until contentHeight) {
+            for (x in accentColumns) {
+                if (x >= totalWidth) continue
+                val density = substrate.getDensity(x, y)
+                val glyph = SubstrateGlyphs.forDensity(density, config.useUnicode)
+                val color = if (config.useColor) {
+                    AmperePalette.forDensity(density * config.substrateOpacity)
+                } else null
+
+                buffer.writeChar(x, y, glyph, color, layer = 0)
+            }
+        }
+    }
+
+    private fun renderPaneContent(
+        leftPane: PaneRenderer,
+        middlePane: PaneRenderer,
+        rightPane: PaneRenderer
+    ) {
+        // Render each pane
+        val leftLines = leftPane.render(leftWidth, contentHeight)
+            .fitToHeight(contentHeight, leftWidth)
+            .map { it.fitToWidth(leftWidth) }
+
+        val middleLines = middlePane.render(middleWidth, contentHeight)
+            .fitToHeight(contentHeight, middleWidth)
+            .map { it.fitToWidth(middleWidth) }
+
+        val rightLines = rightPane.render(rightWidth, contentHeight)
+            .fitToHeight(contentHeight, rightWidth)
+            .map { it.fitToWidth(rightWidth) }
+
+        // Parse ANSI and write into buffer
+        val leftParsed = leftLines.map { AnsiCellParser.parseLineToWidth(it, leftWidth) }
+        val middleParsed = middleLines.map { AnsiCellParser.parseLineToWidth(it, middleWidth) }
+        val rightParsed = rightLines.map { AnsiCellParser.parseLineToWidth(it, rightWidth) }
+
+        // Write at correct column offsets (layer 1)
+        buffer.writePaneRegion(0, 0, leftParsed, layer = 1)
+        buffer.writePaneRegion(divider1Col + 1, 0, middleParsed, layer = 1)
+        buffer.writePaneRegion(divider2Col + 1, 0, rightParsed, layer = 1)
+    }
+
+    private fun renderDividers() {
+        val dividerChar = if (config.useUnicode) '│' else '|'
+        for (y in 0 until contentHeight) {
+            // Tint dividers with substrate density color
+            val density1 = substrate.getDensity(divider1Col, y)
+            val density2 = substrate.getDensity(divider2Col, y)
+            val color1 = if (config.useColor) AmperePalette.forDensity(density1) else null
+            val color2 = if (config.useColor) AmperePalette.forDensity(density2) else null
+
+            buffer.writeChar(divider1Col, y, dividerChar, color1, layer = 1)
+            buffer.writeChar(divider2Col, y, dividerChar, color2, layer = 1)
+        }
+    }
+
+    private fun renderParticleAccents() {
+        for (particle in particles.getParticles()) {
+            val x = particle.position.x.roundToInt()
+            val y = particle.position.y.roundToInt()
+
+            // Only render in accent areas
+            if (x !in accentColumns) continue
+            if (y < 0 || y >= contentHeight) continue
+
+            val color = if (config.useColor) {
+                when {
+                    particle.life > 0.7f -> AmperePalette.SPARK_ACCENT
+                    particle.life > 0.4f -> AmperePalette.SUBSTRATE_BRIGHT
+                    else -> AmperePalette.SUBSTRATE_MID
+                }
+            } else null
+
+            buffer.writeChar(x, y, particle.glyph, color, layer = 2)
+        }
+    }
+
+    private fun renderStatusBar(statusBar: String) {
+        val dividerRow = contentHeight
+        val statusRow = contentHeight + 1
+        val horizontalDivider = if (config.useUnicode) '─' else '-'
+
+        // Horizontal divider line
+        val dividerColor = if (config.useColor) AmperePalette.SUBSTRATE_DIM else null
+        for (x in 0 until totalWidth) {
+            buffer.writeChar(x, dividerRow, horizontalDivider, dividerColor, layer = 3)
+        }
+
+        // Status bar text (parse ANSI to preserve color styling)
+        val statusCells = AnsiCellParser.parseLineToWidth(statusBar, totalWidth)
+        buffer.writePaneRegion(0, statusRow, listOf(statusCells), layer = 3)
+    }
+
+    fun hideCursor(): String = "\u001B[?25l"
+    fun showCursor(): String = "\u001B[?25h"
+}

--- a/ampere-cli/src/main/kotlin/link/socket/ampere/cli/hybrid/WatchStateAnimationBridge.kt
+++ b/ampere-cli/src/main/kotlin/link/socket/ampere/cli/hybrid/WatchStateAnimationBridge.kt
@@ -1,0 +1,161 @@
+package link.socket.ampere.cli.hybrid
+
+import link.socket.ampere.cli.animation.particle.BurstEmitter
+import link.socket.ampere.cli.animation.particle.EmitterConfig
+import link.socket.ampere.cli.animation.particle.ParticleSystem
+import link.socket.ampere.cli.animation.particle.ParticleType
+import link.socket.ampere.cli.animation.substrate.Point
+import link.socket.ampere.cli.animation.substrate.SubstrateAnimator
+import link.socket.ampere.cli.animation.substrate.SubstrateState
+import link.socket.ampere.cli.animation.substrate.Vector2
+import link.socket.ampere.cli.watch.presentation.AgentState
+import link.socket.ampere.cli.watch.presentation.EventSignificance
+import link.socket.ampere.cli.watch.presentation.WatchViewState
+
+/**
+ * Bridges WatchViewState into animation model updates.
+ *
+ * Converts agent activity, events, and system state into:
+ * - Substrate density hotspots (near active agents)
+ * - Particle bursts (on significant events)
+ *
+ * All effects are subtle so they enhance pane content rather than competing with it.
+ *
+ * @property substrateAnimator The animator for substrate density effects
+ * @property particles The particle system for event accents
+ * @property accentColumns The column positions where animation is visible (dividers, margins)
+ * @property height The buffer height for positioning effects
+ */
+class WatchStateAnimationBridge(
+    private val substrateAnimator: SubstrateAnimator,
+    private val particles: ParticleSystem,
+    private val accentColumns: Set<Int>,
+    private val height: Int,
+    private val maxParticles: Int = 30
+) {
+    private var previousEventCount = 0
+    private var previousAgentStates = mapOf<String, AgentState>()
+    private val burstEmitter = BurstEmitter()
+
+    /**
+     * Update animation state based on current watch state.
+     *
+     * @param viewState Current snapshot from WatchPresenter (null-safe for graceful degradation)
+     * @param substrate Current substrate state
+     * @param deltaSeconds Time since last frame
+     * @return Updated substrate state
+     */
+    fun update(
+        viewState: WatchViewState?,
+        substrate: SubstrateState,
+        deltaSeconds: Float
+    ): SubstrateState {
+        if (viewState == null) {
+            return substrateAnimator.updateAmbient(substrate, deltaSeconds)
+        }
+
+        // Update substrate hotspots based on active agents
+        var result = updateHotspotsFromAgentActivity(viewState, substrate)
+
+        // Detect new significant events and spawn particles
+        detectNewEvents(viewState)
+
+        // Detect agent state transitions and trigger pulses
+        detectStateTransitions(viewState, result)?.let { result = it }
+
+        // Apply ambient animation
+        result = substrateAnimator.updateAmbient(result, deltaSeconds)
+
+        // Update particle physics
+        particles.update(deltaSeconds)
+
+        // Track state for next frame
+        previousEventCount = viewState.recentSignificantEvents.size
+        previousAgentStates = viewState.agentStates.mapValues { it.value.currentState }
+
+        return result
+    }
+
+    private fun updateHotspotsFromAgentActivity(
+        viewState: WatchViewState,
+        substrate: SubstrateState
+    ): SubstrateState {
+        val activeCount = viewState.agentStates.count { !it.value.isIdle }
+        if (activeCount == 0) return substrate
+
+        // Place hotspots at accent column positions, distributed vertically
+        val hotspots = accentColumns.flatMapIndexed { idx, col ->
+            if (idx < activeCount) {
+                val y = (height * (idx + 1)) / (activeCount + 1)
+                listOf(Point(col, y.coerceIn(0, substrate.height - 1)))
+            } else {
+                emptyList()
+            }
+        }
+
+        return substrate.withHotspots(hotspots)
+    }
+
+    private fun detectNewEvents(viewState: WatchViewState) {
+        val currentCount = viewState.recentSignificantEvents.size
+        if (currentCount <= previousEventCount) return
+
+        // New events arrived - check significance
+        val newEvents = viewState.recentSignificantEvents.take(currentCount - previousEventCount)
+        val hasSignificant = newEvents.any {
+            it.significance == EventSignificance.CRITICAL || it.significance == EventSignificance.SIGNIFICANT
+        }
+
+        if (hasSignificant && particles.count < maxParticles) {
+            spawnEventParticles(
+                if (newEvents.any { it.significance == EventSignificance.CRITICAL }) 3 else 2
+            )
+        }
+    }
+
+    private fun detectStateTransitions(
+        viewState: WatchViewState,
+        substrate: SubstrateState
+    ): SubstrateState? {
+        var result: SubstrateState? = null
+
+        for ((agentId, agentState) in viewState.agentStates) {
+            val previousState = previousAgentStates[agentId]
+            val currentState = agentState.currentState
+
+            // Trigger a pulse when an agent transitions to WORKING or THINKING
+            if (previousState != null && previousState != currentState &&
+                (currentState == AgentState.WORKING || currentState == AgentState.THINKING)
+            ) {
+                val pulseCenter = pickAccentPosition()
+                result = substrateAnimator.pulse(
+                    result ?: substrate,
+                    pulseCenter,
+                    intensity = 0.3f,
+                    radius = 3f
+                )
+            }
+        }
+
+        return result
+    }
+
+    private fun spawnEventParticles(count: Int) {
+        val origin = pickAccentPosition()
+        val config = EmitterConfig(
+            type = ParticleType.SPARK,
+            speed = 1.5f,
+            speedVariance = 0.5f,
+            life = 1.2f,
+            lifeVariance = 0.3f,
+            spread = 360f
+        )
+        particles.spawn(burstEmitter, count, origin.toVector2(), config)
+    }
+
+    private fun pickAccentPosition(): Point {
+        val col = accentColumns.randomOrNull() ?: 0
+        val row = (1 until height.coerceAtLeast(2)).random()
+        return Point(col, row)
+    }
+}

--- a/ampere-cli/src/main/kotlin/link/socket/ampere/cli/layout/AnsiCellParser.kt
+++ b/ampere-cli/src/main/kotlin/link/socket/ampere/cli/layout/AnsiCellParser.kt
@@ -1,0 +1,85 @@
+package link.socket.ampere.cli.layout
+
+/**
+ * A single parsed cell from an ANSI-styled string.
+ * Holds the visible character and its associated ANSI color state.
+ */
+data class ParsedCell(
+    val char: Char,
+    val ansiPrefix: String?
+)
+
+/**
+ * Parses ANSI-coded strings into sequences of ParsedCells.
+ *
+ * This enables compositing PaneRenderer output into a cell buffer
+ * by extracting the (character, color) pairs from styled terminal strings.
+ */
+object AnsiCellParser {
+
+    private val ANSI_REGEX = Regex("\u001B\\[[0-9;]*[a-zA-Z]")
+
+    /**
+     * Parse a single ANSI-styled line into a list of ParsedCells.
+     * Each cell represents one visible character with its accumulated style.
+     *
+     * @param line The ANSI-styled string to parse
+     * @return List of ParsedCells, one per visible character
+     */
+    fun parseLine(line: String): List<ParsedCell> {
+        val cells = mutableListOf<ParsedCell>()
+        var currentColor: String? = null
+        var i = 0
+
+        while (i < line.length) {
+            if (line[i] == '\u001B' && i + 1 < line.length && line[i + 1] == '[') {
+                // Parse ANSI escape sequence
+                val seqStart = i
+                i += 2 // Skip ESC[
+                while (i < line.length && !line[i].isLetter()) {
+                    i++
+                }
+                if (i < line.length) {
+                    i++ // Skip the final letter
+                }
+                val sequence = line.substring(seqStart, i)
+
+                // Check if this is a reset sequence
+                if (sequence == "\u001B[0m" || sequence == "\u001B[m") {
+                    currentColor = null
+                } else {
+                    // Accumulate color - for simplicity, replace with latest
+                    currentColor = sequence
+                }
+            } else {
+                cells.add(ParsedCell(line[i], currentColor))
+                i++
+            }
+        }
+
+        return cells
+    }
+
+    /**
+     * Parse a line and return exactly [width] cells, padding or truncating.
+     *
+     * @param line The ANSI-styled string to parse
+     * @param width The exact number of visible cells to return
+     * @return List of exactly [width] ParsedCells
+     */
+    fun parseLineToWidth(line: String, width: Int): List<ParsedCell> {
+        val parsed = parseLine(line)
+        return when {
+            parsed.size > width -> parsed.take(width)
+            parsed.size < width -> parsed + List(width - parsed.size) { ParsedCell(' ', null) }
+            else -> parsed
+        }
+    }
+
+    /**
+     * Strip all ANSI escape codes from a string, returning only visible text.
+     */
+    fun stripAnsi(text: String): String {
+        return text.replace(ANSI_REGEX, "")
+    }
+}

--- a/ampere-cli/src/test/kotlin/link/socket/ampere/cli/hybrid/HybridCellBufferTest.kt
+++ b/ampere-cli/src/test/kotlin/link/socket/ampere/cli/hybrid/HybridCellBufferTest.kt
@@ -1,0 +1,236 @@
+package link.socket.ampere.cli.hybrid
+
+import link.socket.ampere.cli.layout.ParsedCell
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class HybridCellTest {
+
+    @Test
+    fun `default cell is space with no color at layer 0`() {
+        val cell = HybridCell()
+        assertEquals(' ', cell.char)
+        assertNull(cell.ansiColor)
+        assertEquals(0, cell.layer)
+    }
+}
+
+class HybridCellBufferTest {
+
+    @Test
+    fun `clear produces all-space buffer`() {
+        val buffer = HybridCellBuffer(5, 3)
+        buffer.clear()
+        for (y in 0 until 3) {
+            for (x in 0 until 5) {
+                val cell = buffer.getCell(x, y)
+                assertEquals(' ', cell.char)
+                assertNull(cell.ansiColor)
+            }
+        }
+    }
+
+    @Test
+    fun `writeChar places character at position`() {
+        val buffer = HybridCellBuffer(10, 5)
+        buffer.clear()
+        buffer.writeChar(3, 2, 'X', "\u001B[31m", layer = 1)
+
+        val cell = buffer.getCell(3, 2)
+        assertEquals('X', cell.char)
+        assertEquals("\u001B[31m", cell.ansiColor)
+        assertEquals(1, cell.layer)
+    }
+
+    @Test
+    fun `writeChar ignores out-of-bounds`() {
+        val buffer = HybridCellBuffer(5, 3)
+        buffer.clear()
+        // Should not throw
+        buffer.writeChar(-1, 0, 'X')
+        buffer.writeChar(5, 0, 'X')
+        buffer.writeChar(0, -1, 'X')
+        buffer.writeChar(0, 3, 'X')
+    }
+
+    @Test
+    fun `higher layer overwrites lower layer`() {
+        val buffer = HybridCellBuffer(10, 5)
+        buffer.clear()
+        buffer.writeChar(0, 0, 'A', null, layer = 0)
+        buffer.writeChar(0, 0, 'B', null, layer = 1)
+
+        assertEquals('B', buffer.getCell(0, 0).char)
+    }
+
+    @Test
+    fun `lower layer does not overwrite higher layer`() {
+        val buffer = HybridCellBuffer(10, 5)
+        buffer.clear()
+        buffer.writeChar(0, 0, 'A', null, layer = 2)
+        buffer.writeChar(0, 0, 'B', null, layer = 1)
+
+        assertEquals('A', buffer.getCell(0, 0).char)
+    }
+
+    @Test
+    fun `same layer overwrites`() {
+        val buffer = HybridCellBuffer(10, 5)
+        buffer.clear()
+        buffer.writeChar(0, 0, 'A', null, layer = 1)
+        buffer.writeChar(0, 0, 'B', null, layer = 1)
+
+        assertEquals('B', buffer.getCell(0, 0).char)
+    }
+
+    @Test
+    fun `writeString places multiple characters`() {
+        val buffer = HybridCellBuffer(10, 3)
+        buffer.clear()
+        buffer.writeString(2, 1, "abc", "\u001B[32m", layer = 1)
+
+        assertEquals('a', buffer.getCell(2, 1).char)
+        assertEquals('b', buffer.getCell(3, 1).char)
+        assertEquals('c', buffer.getCell(4, 1).char)
+        assertEquals("\u001B[32m", buffer.getCell(2, 1).ansiColor)
+    }
+
+    @Test
+    fun `writePaneRegion writes parsed cells at offset`() {
+        val buffer = HybridCellBuffer(10, 5)
+        buffer.clear()
+
+        val rows = listOf(
+            listOf(ParsedCell('H', "\u001B[31m"), ParsedCell('i', "\u001B[31m")),
+            listOf(ParsedCell('!', null), ParsedCell(' ', null))
+        )
+
+        buffer.writePaneRegion(3, 1, rows, layer = 1)
+
+        assertEquals('H', buffer.getCell(3, 1).char)
+        assertEquals("\u001B[31m", buffer.getCell(3, 1).ansiColor)
+        assertEquals('i', buffer.getCell(4, 1).char)
+        assertEquals('!', buffer.getCell(3, 2).char)
+        assertNull(buffer.getCell(3, 2).ansiColor)
+    }
+
+    @Test
+    fun `writePaneRegion clips to buffer bounds`() {
+        val buffer = HybridCellBuffer(5, 3)
+        buffer.clear()
+
+        val rows = listOf(
+            listOf(ParsedCell('A', null), ParsedCell('B', null), ParsedCell('C', null))
+        )
+
+        // Writing at x=4 with 3 chars: only first fits
+        buffer.writePaneRegion(4, 0, rows, layer = 1)
+        assertEquals('A', buffer.getCell(4, 0).char)
+        // Remaining are out of bounds - buffer unchanged
+        assertEquals(' ', buffer.getCell(4, 1).char)
+    }
+
+    @Test
+    fun `renderFull contains cursor positioning`() {
+        val buffer = HybridCellBuffer(3, 2)
+        buffer.clear()
+        buffer.writeChar(0, 0, 'A')
+        buffer.writeChar(1, 0, 'B')
+
+        val output = buffer.renderFull()
+        assertTrue(output.contains("\u001B[1;1H")) // Row 1 positioning
+        assertTrue(output.contains("\u001B[2;1H")) // Row 2 positioning
+        assertTrue(output.contains("AB"))
+    }
+
+    @Test
+    fun `renderFull includes ANSI colors`() {
+        val buffer = HybridCellBuffer(3, 1)
+        buffer.clear()
+        buffer.writeChar(0, 0, 'X', "\u001B[31m")
+
+        val output = buffer.renderFull()
+        assertTrue(output.contains("\u001B[31m"))
+        assertTrue(output.contains("X"))
+        assertTrue(output.contains("\u001B[0m"))
+    }
+
+    @Test
+    fun `renderDiff falls back to renderFull on first frame`() {
+        val buffer = HybridCellBuffer(3, 1)
+        buffer.clear()
+        buffer.writeChar(0, 0, 'A')
+
+        val diff = buffer.renderDiff()
+        val full = buffer.renderFull()
+        // First diff should be equivalent to full render
+        assertEquals(full, diff)
+    }
+
+    @Test
+    fun `renderDiff produces empty string when nothing changed`() {
+        val buffer = HybridCellBuffer(3, 2)
+        buffer.clear()
+        buffer.writeChar(0, 0, 'A')
+        buffer.swapBuffers()
+
+        // Same content
+        buffer.clear()
+        buffer.writeChar(0, 0, 'A')
+
+        val diff = buffer.renderDiff()
+        assertTrue(diff.isEmpty(), "Diff should be empty when nothing changed, got: $diff")
+    }
+
+    @Test
+    fun `renderDiff produces output only for changed cells`() {
+        val buffer = HybridCellBuffer(5, 2)
+        buffer.clear()
+        buffer.writeString(0, 0, "ABCDE")
+        buffer.swapBuffers()
+
+        // Change only one cell
+        buffer.clear()
+        buffer.writeString(0, 0, "ABXDE")
+
+        val diff = buffer.renderDiff()
+        assertTrue(diff.contains("X"))
+        // Should contain cursor positioning for the changed cell
+        assertTrue(diff.contains("\u001B[1;3H")) // Row 1, Col 3 (0-indexed x=2)
+        // Should NOT contain unchanged chars A, B, D, E as individual writes
+        // (they may appear in cursor positioning codes, so just check diff is short)
+        assertTrue(diff.length < buffer.renderFull().length)
+    }
+
+    @Test
+    fun `swapBuffers preserves state for next diff`() {
+        val buffer = HybridCellBuffer(3, 1)
+        buffer.clear()
+        buffer.writeChar(0, 0, 'A')
+        buffer.swapBuffers()
+
+        buffer.clear()
+        buffer.writeChar(0, 0, 'B')
+
+        val diff = buffer.renderDiff()
+        // Should detect the change from A to B
+        assertTrue(diff.contains("B"))
+    }
+
+    @Test
+    fun `renderFull runs color codes efficiently`() {
+        val buffer = HybridCellBuffer(3, 1)
+        buffer.clear()
+        // Three cells with same color - should only emit color once
+        buffer.writeChar(0, 0, 'A', "\u001B[31m", layer = 0)
+        buffer.writeChar(1, 0, 'B', "\u001B[31m", layer = 0)
+        buffer.writeChar(2, 0, 'C', "\u001B[31m", layer = 0)
+
+        val output = buffer.renderFull()
+        // The color code should appear once, not three times
+        val colorCount = output.split("\u001B[31m").size - 1
+        assertEquals(1, colorCount, "Same consecutive color should be emitted once")
+    }
+}

--- a/ampere-cli/src/test/kotlin/link/socket/ampere/cli/hybrid/HybridDashboardRendererTest.kt
+++ b/ampere-cli/src/test/kotlin/link/socket/ampere/cli/hybrid/HybridDashboardRendererTest.kt
@@ -1,0 +1,276 @@
+package link.socket.ampere.cli.hybrid
+
+import link.socket.ampere.cli.layout.AnsiCellParser
+import link.socket.ampere.cli.layout.PaneRenderer
+import link.socket.ampere.cli.watch.presentation.AgentActivityState
+import link.socket.ampere.cli.watch.presentation.AgentState
+import link.socket.ampere.cli.watch.presentation.EventSignificance
+import link.socket.ampere.cli.watch.presentation.SignificantEventSummary
+import link.socket.ampere.cli.watch.presentation.SystemState
+import link.socket.ampere.cli.watch.presentation.SystemVitals
+import link.socket.ampere.cli.watch.presentation.WatchViewState
+import kotlinx.datetime.Clock
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Simple test pane that renders a fixed text pattern.
+ */
+class TestPane(private val fillChar: Char = '.') : PaneRenderer {
+    override fun render(width: Int, height: Int): List<String> {
+        return List(height) { String(CharArray(width) { fillChar }) }
+    }
+}
+
+/**
+ * Test pane that renders visible content in the first few lines.
+ */
+class ContentPane(private val lines: List<String> = emptyList()) : PaneRenderer {
+    override fun render(width: Int, height: Int): List<String> {
+        val result = mutableListOf<String>()
+        for (i in 0 until height) {
+            if (i < lines.size) {
+                val line = lines[i]
+                result.add(line.take(width).padEnd(width))
+            } else {
+                result.add(" ".repeat(width))
+            }
+        }
+        return result
+    }
+}
+
+class HybridDashboardRendererTest {
+
+    private fun createRenderer(
+        width: Int = 80,
+        height: Int = 24,
+        useColor: Boolean = false,
+        useUnicode: Boolean = true
+    ): HybridDashboardRenderer {
+        val config = HybridConfig(
+            enableSubstrate = true,
+            enableParticles = true,
+            useColor = useColor,
+            useUnicode = useUnicode,
+            substrateOpacity = 0.15f,
+            particleMaxCount = 10
+        )
+        return HybridDashboardRenderer(
+            terminal = null,
+            config = config,
+            explicitWidth = width,
+            explicitHeight = height
+        )
+    }
+
+    private fun createViewState(): WatchViewState {
+        val now = Clock.System.now()
+        return WatchViewState(
+            systemVitals = SystemVitals(
+                activeAgentCount = 1,
+                systemState = SystemState.WORKING,
+                lastSignificantEventTime = now
+            ),
+            agentStates = mapOf(
+                "agent-1" to AgentActivityState(
+                    agentId = "agent-1",
+                    displayName = "Agent Alpha",
+                    currentState = AgentState.WORKING,
+                    lastActivityTimestamp = now,
+                    consecutiveCognitiveCycles = 1,
+                    isIdle = false
+                )
+            ),
+            recentSignificantEvents = listOf(
+                SignificantEventSummary(
+                    eventId = "evt-1",
+                    timestamp = now,
+                    eventType = "TaskCreated",
+                    sourceAgentName = "Agent Alpha",
+                    summaryText = "Created task: implement feature",
+                    significance = EventSignificance.SIGNIFICANT
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `renders three panes without crashing`() {
+        val renderer = createRenderer()
+        val output = renderer.render(
+            leftPane = TestPane('L'),
+            middlePane = TestPane('M'),
+            rightPane = TestPane('R'),
+            statusBar = "Status bar text"
+        )
+        assertTrue(output.isNotEmpty())
+    }
+
+    @Test
+    fun `pane content appears in output`() {
+        val renderer = createRenderer()
+        val output = renderer.render(
+            leftPane = ContentPane(listOf("LEFT CONTENT")),
+            middlePane = ContentPane(listOf("MID CONTENT")),
+            rightPane = ContentPane(listOf("RIGHT HERE")),
+            statusBar = "status"
+        )
+
+        val stripped = AnsiCellParser.stripAnsi(output)
+        assertTrue(stripped.contains("LEFT CONTENT"), "Left pane content should appear")
+        assertTrue(stripped.contains("MID CONTENT"), "Middle pane content should appear")
+        assertTrue(stripped.contains("RIGHT HERE"), "Right pane content should appear")
+    }
+
+    @Test
+    fun `status bar appears in output`() {
+        val renderer = createRenderer()
+        val output = renderer.render(
+            leftPane = TestPane(),
+            middlePane = TestPane(),
+            rightPane = TestPane(),
+            statusBar = "MY STATUS"
+        )
+
+        val stripped = AnsiCellParser.stripAnsi(output)
+        assertTrue(stripped.contains("MY STATUS"), "Status bar should appear in output")
+    }
+
+    @Test
+    fun `dividers appear between panes`() {
+        val renderer = createRenderer(useUnicode = true)
+        val output = renderer.render(
+            leftPane = TestPane(),
+            middlePane = TestPane(),
+            rightPane = TestPane(),
+            statusBar = "status"
+        )
+
+        val stripped = AnsiCellParser.stripAnsi(output)
+        assertTrue(stripped.contains("\u2502"), "Unicode divider (│) should appear")
+    }
+
+    @Test
+    fun `null viewState does not crash`() {
+        val renderer = createRenderer()
+        val output = renderer.render(
+            leftPane = TestPane(),
+            middlePane = TestPane(),
+            rightPane = TestPane(),
+            statusBar = "status",
+            viewState = null
+        )
+        assertTrue(output.isNotEmpty())
+    }
+
+    @Test
+    fun `live viewState does not crash`() {
+        val renderer = createRenderer()
+
+        // First frame
+        renderer.render(
+            leftPane = TestPane(),
+            middlePane = TestPane(),
+            rightPane = TestPane(),
+            statusBar = "status",
+            viewState = null
+        )
+
+        // Second frame with live state
+        val output = renderer.render(
+            leftPane = TestPane(),
+            middlePane = TestPane(),
+            rightPane = TestPane(),
+            statusBar = "status",
+            viewState = createViewState()
+        )
+        assertTrue(output.isNotEmpty())
+    }
+
+    @Test
+    fun `second frame uses differential rendering`() {
+        val renderer = createRenderer()
+
+        val first = renderer.render(
+            leftPane = TestPane('A'),
+            middlePane = TestPane('B'),
+            rightPane = TestPane('C'),
+            statusBar = "status"
+        )
+
+        // Second frame with same content (diff should be smaller or equal)
+        val second = renderer.render(
+            leftPane = TestPane('A'),
+            middlePane = TestPane('B'),
+            rightPane = TestPane('C'),
+            statusBar = "status"
+        )
+
+        assertTrue(second.length <= first.length * 2,
+            "Diff render should not be dramatically larger than full render")
+    }
+
+    @Test
+    fun `no-color mode excludes 256-color codes`() {
+        val renderer = createRenderer(useColor = false)
+        val output = renderer.render(
+            leftPane = TestPane('X'),
+            middlePane = TestPane('Y'),
+            rightPane = TestPane('Z'),
+            statusBar = "status"
+        )
+
+        assertFalse(output.contains("\u001B[38;5;"),
+            "No-color mode should not contain 256-color codes")
+    }
+
+    @Test
+    fun `horizontal divider appears above status bar`() {
+        val renderer = createRenderer(useUnicode = true)
+        val output = renderer.render(
+            leftPane = TestPane(),
+            middlePane = TestPane(),
+            rightPane = TestPane(),
+            statusBar = "status"
+        )
+
+        val stripped = AnsiCellParser.stripAnsi(output)
+        assertTrue(stripped.contains("\u2500"), "Horizontal divider (─) should appear")
+    }
+
+    @Test
+    fun `hideCursor and showCursor produce correct escape sequences`() {
+        val renderer = createRenderer()
+        assertEquals("\u001B[?25l", renderer.hideCursor())
+        assertEquals("\u001B[?25h", renderer.showCursor())
+    }
+
+    @Test
+    fun `small terminal dimensions are handled gracefully`() {
+        val renderer = createRenderer(width = 40, height = 10)
+        val output = renderer.render(
+            leftPane = TestPane(),
+            middlePane = TestPane(),
+            rightPane = TestPane(),
+            statusBar = "status"
+        )
+        assertTrue(output.isNotEmpty())
+    }
+
+    @Test
+    fun `ASCII fallback mode uses pipe dividers`() {
+        val renderer = createRenderer(useUnicode = false)
+        val output = renderer.render(
+            leftPane = TestPane(),
+            middlePane = TestPane(),
+            rightPane = TestPane(),
+            statusBar = "status"
+        )
+
+        val stripped = AnsiCellParser.stripAnsi(output)
+        assertTrue(stripped.contains("|"), "ASCII mode should use pipe dividers")
+    }
+}

--- a/ampere-cli/src/test/kotlin/link/socket/ampere/cli/hybrid/WatchStateAnimationBridgeTest.kt
+++ b/ampere-cli/src/test/kotlin/link/socket/ampere/cli/hybrid/WatchStateAnimationBridgeTest.kt
@@ -1,0 +1,221 @@
+package link.socket.ampere.cli.hybrid
+
+import kotlinx.datetime.Clock
+import link.socket.ampere.cli.animation.particle.ParticleSystem
+import link.socket.ampere.cli.animation.substrate.SubstrateAnimator
+import link.socket.ampere.cli.animation.substrate.SubstrateState
+import link.socket.ampere.cli.watch.presentation.AgentActivityState
+import link.socket.ampere.cli.watch.presentation.AgentState
+import link.socket.ampere.cli.watch.presentation.EventSignificance
+import link.socket.ampere.cli.watch.presentation.SignificantEventSummary
+import link.socket.ampere.cli.watch.presentation.SystemVitals
+import link.socket.ampere.cli.watch.presentation.WatchViewState
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class WatchStateAnimationBridgeTest {
+
+    private val now = Clock.System.now()
+
+    private fun createBridge(
+        accentColumns: Set<Int> = setOf(10, 20),
+        height: Int = 24
+    ): Triple<WatchStateAnimationBridge, SubstrateState, ParticleSystem> {
+        val animator = SubstrateAnimator(baseDensity = 0.2f, seed = 42L)
+        val particles = ParticleSystem(maxParticles = 30, lifeDecayRate = 0.5f)
+        val bridge = WatchStateAnimationBridge(
+            substrateAnimator = animator,
+            particles = particles,
+            accentColumns = accentColumns,
+            height = height
+        )
+        val substrate = SubstrateState.create(30, 24, baseDensity = 0.2f)
+        return Triple(bridge, substrate, particles)
+    }
+
+    private fun createViewState(
+        agents: Map<String, AgentActivityState> = emptyMap(),
+        events: List<SignificantEventSummary> = emptyList()
+    ): WatchViewState {
+        return WatchViewState(
+            systemVitals = SystemVitals(
+                activeAgentCount = agents.count { !it.value.isIdle },
+                systemState = link.socket.ampere.cli.watch.presentation.SystemState.WORKING,
+                lastSignificantEventTime = now
+            ),
+            agentStates = agents,
+            recentSignificantEvents = events
+        )
+    }
+
+    private fun createAgent(
+        id: String,
+        state: AgentState = AgentState.IDLE,
+        idle: Boolean = state == AgentState.IDLE
+    ): AgentActivityState {
+        return AgentActivityState(
+            agentId = id,
+            displayName = id,
+            currentState = state,
+            lastActivityTimestamp = now,
+            consecutiveCognitiveCycles = 0,
+            isIdle = idle
+        )
+    }
+
+    private fun createEvent(
+        significance: EventSignificance = EventSignificance.SIGNIFICANT
+    ): SignificantEventSummary {
+        return SignificantEventSummary(
+            eventId = "evt-${System.nanoTime()}",
+            timestamp = now,
+            eventType = "TestEvent",
+            sourceAgentName = "test-agent",
+            summaryText = "Test event",
+            significance = significance
+        )
+    }
+
+    @Test
+    fun `null viewState returns ambient-updated substrate`() {
+        val (bridge, substrate, _) = createBridge()
+        val result = bridge.update(null, substrate, 0.1f)
+
+        // Should still advance time via ambient animation
+        assertTrue(result.time > substrate.time)
+    }
+
+    @Test
+    fun `empty viewState does not crash`() {
+        val (bridge, substrate, particles) = createBridge()
+        val viewState = createViewState()
+
+        val result = bridge.update(viewState, substrate, 0.1f)
+        assertTrue(result.time > substrate.time)
+        assertEquals(0, particles.count)
+    }
+
+    @Test
+    fun `active agents create substrate hotspots`() {
+        val (bridge, substrate, _) = createBridge()
+        val agents = mapOf(
+            "agent-1" to createAgent("agent-1", AgentState.WORKING, idle = false)
+        )
+        val viewState = createViewState(agents = agents)
+
+        val result = bridge.update(viewState, substrate, 0.1f)
+        assertTrue(result.activityHotspots.isNotEmpty())
+    }
+
+    @Test
+    fun `idle agents do not create hotspots`() {
+        val (bridge, substrate, _) = createBridge()
+        val agents = mapOf(
+            "agent-1" to createAgent("agent-1", AgentState.IDLE)
+        )
+        val viewState = createViewState(agents = agents)
+
+        val result = bridge.update(viewState, substrate, 0.1f)
+        assertTrue(result.activityHotspots.isEmpty())
+    }
+
+    @Test
+    fun `significant events spawn particles`() {
+        val (bridge, substrate, particles) = createBridge()
+
+        // First update with no events
+        val viewState1 = createViewState()
+        bridge.update(viewState1, substrate, 0.1f)
+
+        // Second update with new significant event
+        val viewState2 = createViewState(
+            events = listOf(createEvent(EventSignificance.SIGNIFICANT))
+        )
+        bridge.update(viewState2, substrate, 0.1f)
+
+        assertTrue(particles.count > 0, "Should have spawned particles for significant event")
+    }
+
+    @Test
+    fun `routine events do not spawn particles`() {
+        val (bridge, substrate, particles) = createBridge()
+
+        // First update
+        bridge.update(createViewState(), substrate, 0.1f)
+
+        // Second update with routine event only
+        val viewState = createViewState(
+            events = listOf(createEvent(EventSignificance.ROUTINE))
+        )
+        bridge.update(viewState, substrate, 0.1f)
+
+        assertEquals(0, particles.count, "Routine events should not spawn particles")
+    }
+
+    @Test
+    fun `critical events spawn more particles than significant`() {
+        val (bridge1, substrate1, particles1) = createBridge()
+        bridge1.update(createViewState(), substrate1, 0.1f)
+        bridge1.update(
+            createViewState(events = listOf(createEvent(EventSignificance.CRITICAL))),
+            substrate1, 0.1f
+        )
+        val criticalCount = particles1.count
+
+        val (bridge2, substrate2, particles2) = createBridge()
+        bridge2.update(createViewState(), substrate2, 0.1f)
+        bridge2.update(
+            createViewState(events = listOf(createEvent(EventSignificance.SIGNIFICANT))),
+            substrate2, 0.1f
+        )
+        val significantCount = particles2.count
+
+        assertTrue(criticalCount >= significantCount, "Critical events should spawn >= particles than significant")
+    }
+
+    @Test
+    fun `particle count stays bounded`() {
+        val (bridge, substrate, particles) = createBridge()
+
+        // Trigger many events
+        var viewState = createViewState()
+        bridge.update(viewState, substrate, 0.1f)
+
+        for (i in 1..50) {
+            viewState = createViewState(
+                events = (1..i).map { createEvent(EventSignificance.CRITICAL) }
+            )
+            bridge.update(viewState, substrate, 0.1f)
+        }
+
+        assertTrue(particles.count <= 30, "Particles should be bounded at max 30, got ${particles.count}")
+    }
+
+    @Test
+    fun `agent state transition triggers pulse`() {
+        val (bridge, substrate, _) = createBridge()
+
+        // First update: agent is idle
+        val viewState1 = createViewState(
+            agents = mapOf("agent-1" to createAgent("agent-1", AgentState.IDLE))
+        )
+        bridge.update(viewState1, substrate, 0.1f)
+
+        // Second update: agent transitions to working
+        val viewState2 = createViewState(
+            agents = mapOf("agent-1" to createAgent("agent-1", AgentState.WORKING, idle = false))
+        )
+        val result = bridge.update(viewState2, substrate, 0.1f)
+
+        // Should have increased density somewhere via pulse
+        var maxDensity = 0f
+        for (y in 0 until result.height) {
+            for (x in 0 until result.width) {
+                maxDensity = maxOf(maxDensity, result.getDensity(x, y))
+            }
+        }
+        assertTrue(maxDensity > substrate.getDensity(0, 0) + 0.05f,
+            "State transition should create a density pulse")
+    }
+}

--- a/ampere-cli/src/test/kotlin/link/socket/ampere/cli/layout/AnsiCellParserTest.kt
+++ b/ampere-cli/src/test/kotlin/link/socket/ampere/cli/layout/AnsiCellParserTest.kt
@@ -1,0 +1,147 @@
+package link.socket.ampere.cli.layout
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class AnsiCellParserTest {
+
+    @Test
+    fun `plain text produces cells with null color`() {
+        val cells = AnsiCellParser.parseLine("hello")
+        assertEquals(5, cells.size)
+        assertEquals('h', cells[0].char)
+        assertEquals('e', cells[1].char)
+        assertEquals('l', cells[2].char)
+        assertEquals('l', cells[3].char)
+        assertEquals('o', cells[4].char)
+        cells.forEach { assertNull(it.ansiPrefix) }
+    }
+
+    @Test
+    fun `empty string returns empty list`() {
+        val cells = AnsiCellParser.parseLine("")
+        assertTrue(cells.isEmpty())
+    }
+
+    @Test
+    fun `single ANSI color wrapping text`() {
+        // "\u001B[31mHi\u001B[0m"
+        val input = "\u001B[31mHi\u001B[0m"
+        val cells = AnsiCellParser.parseLine(input)
+        assertEquals(2, cells.size)
+        assertEquals('H', cells[0].char)
+        assertEquals("\u001B[31m", cells[0].ansiPrefix)
+        assertEquals('i', cells[1].char)
+        assertEquals("\u001B[31m", cells[1].ansiPrefix)
+    }
+
+    @Test
+    fun `reset clears color state`() {
+        val input = "\u001B[31mA\u001B[0mB"
+        val cells = AnsiCellParser.parseLine(input)
+        assertEquals(2, cells.size)
+        assertEquals('A', cells[0].char)
+        assertEquals("\u001B[31m", cells[0].ansiPrefix)
+        assertEquals('B', cells[1].char)
+        assertNull(cells[1].ansiPrefix)
+    }
+
+    @Test
+    fun `256 color codes are captured`() {
+        val input = "\u001B[38;5;45mX\u001B[0m"
+        val cells = AnsiCellParser.parseLine(input)
+        assertEquals(1, cells.size)
+        assertEquals('X', cells[0].char)
+        assertEquals("\u001B[38;5;45m", cells[0].ansiPrefix)
+    }
+
+    @Test
+    fun `color changes mid-string`() {
+        val input = "\u001B[31mR\u001B[32mG\u001B[34mB\u001B[0m"
+        val cells = AnsiCellParser.parseLine(input)
+        assertEquals(3, cells.size)
+        assertEquals("\u001B[31m", cells[0].ansiPrefix)
+        assertEquals("\u001B[32m", cells[1].ansiPrefix)
+        assertEquals("\u001B[34m", cells[2].ansiPrefix)
+    }
+
+    @Test
+    fun `parseLineToWidth truncates long lines`() {
+        val cells = AnsiCellParser.parseLineToWidth("abcdef", 3)
+        assertEquals(3, cells.size)
+        assertEquals('a', cells[0].char)
+        assertEquals('b', cells[1].char)
+        assertEquals('c', cells[2].char)
+    }
+
+    @Test
+    fun `parseLineToWidth pads short lines`() {
+        val cells = AnsiCellParser.parseLineToWidth("ab", 5)
+        assertEquals(5, cells.size)
+        assertEquals('a', cells[0].char)
+        assertEquals('b', cells[1].char)
+        assertEquals(' ', cells[2].char)
+        assertEquals(' ', cells[3].char)
+        assertEquals(' ', cells[4].char)
+        // Padding cells have no color
+        assertNull(cells[2].ansiPrefix)
+    }
+
+    @Test
+    fun `parseLineToWidth returns exact width`() {
+        val cells = AnsiCellParser.parseLineToWidth("abc", 3)
+        assertEquals(3, cells.size)
+    }
+
+    @Test
+    fun `parseLineToWidth truncates with ANSI codes correctly`() {
+        val input = "\u001B[31mHello World\u001B[0m"
+        val cells = AnsiCellParser.parseLineToWidth(input, 5)
+        assertEquals(5, cells.size)
+        assertEquals('H', cells[0].char)
+        assertEquals('o', cells[4].char)
+        cells.forEach { assertEquals("\u001B[31m", it.ansiPrefix) }
+    }
+
+    @Test
+    fun `stripAnsi removes all escape codes`() {
+        val input = "\u001B[31mHello\u001B[0m \u001B[38;5;45mWorld\u001B[0m"
+        assertEquals("Hello World", AnsiCellParser.stripAnsi(input))
+    }
+
+    @Test
+    fun `stripAnsi returns plain text unchanged`() {
+        assertEquals("hello", AnsiCellParser.stripAnsi("hello"))
+    }
+
+    @Test
+    fun `short reset sequence is handled`() {
+        val input = "\u001B[31mA\u001B[mB"
+        val cells = AnsiCellParser.parseLine(input)
+        assertEquals(2, cells.size)
+        assertEquals("\u001B[31m", cells[0].ansiPrefix)
+        assertNull(cells[1].ansiPrefix)
+    }
+
+    @Test
+    fun `bold and dim codes are captured`() {
+        val input = "\u001B[1mBold\u001B[2mDim\u001B[0m"
+        val cells = AnsiCellParser.parseLine(input)
+        assertEquals(7, cells.size)
+        assertEquals("\u001B[1m", cells[0].ansiPrefix)
+        assertEquals("\u001B[2m", cells[4].ansiPrefix)
+    }
+
+    @Test
+    fun `consecutive escape sequences with no chars between`() {
+        // Two color codes then text
+        val input = "\u001B[1m\u001B[31mX\u001B[0m"
+        val cells = AnsiCellParser.parseLine(input)
+        assertEquals(1, cells.size)
+        assertEquals('X', cells[0].char)
+        // The last color code before the character wins
+        assertEquals("\u001B[31m", cells[0].ansiPrefix)
+    }
+}


### PR DESCRIPTION
## Summary

Implements a hybrid rendering system that bridges the ThreeColumnLayout pane system with the TUI animation system. Animation accents (substrate background, particles) are rendered in "accent areas" (divider columns and margins) and never obscure pane content. The feature drives animation from live WatchViewState data and is opt-in via the `--hybrid` flag.

## Changes

- **AnsiCellParser**: Parses ANSI-styled strings into `(char, color)` cell pairs for compositing
- **HybridCellBuffer**: Double-buffered cell grid with layer compositing and differential rendering
- **WatchStateAnimationBridge**: Converts live WatchViewState into substrate hotspots and particle effects
- **HybridDashboardRenderer**: Main coordinator that composites animation + pane content + particles
- **DemoCommand Integration**: Added `--hybrid` flag (backward-compatible, opt-in)

## Test Plan

- All 49 jvmTest suite tests pass
- 49 new unit tests covering ANSI parsing, cell buffer operations, animation bridge, and hybrid renderer
- Verified backward compatibility: `ampere demo` (without --hybrid) uses unchanged ThreeColumnLayout
- Tested with both color and ASCII modes, various terminal sizes
- Tested with null viewState for graceful degradation