### PR TITLE
Fix JLine terminal provider for system terminal support

### DIFF
--- a/ampere-cli/build.gradle.kts
+++ b/ampere-cli/build.gradle.kts
@@ -95,6 +95,8 @@ kotlin {
 
                 // REPL terminal handling
                 implementation("org.jline:jline:3.25.0")
+                implementation("org.jline:jline-terminal-jna:3.25.0")
+                implementation("net.java.dev.jna:jna:5.14.0")
 
                 // Coroutines
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")


### PR DESCRIPTION
## Summary
After the Mosaic migration, JLine was unable to create system terminals and fell back to "dumb terminal" mode. The issue was that the JLine uber-JAR was missing its terminal provider implementation (specifically the JNA-based provider).

## Solution
Added `jline-terminal-jna` module alongside the existing JLine dependency, which provides the TerminalProvider implementation via ServiceLoader. Also explicitly declared the JNA dependency that was previously only available transitively from Mordant.

## Testing
Verified that tests pass with `./gradlew jvmTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)