### PR TITLE
Task 6-8: Desktop canvas, phase-aware bridge, demo timeline

### DIFF
--- a/ampere-animation/src/commonMain/kotlin/link/socket/ampere/animation/agent/AgentLayer.kt
+++ b/ampere-animation/src/commonMain/kotlin/link/socket/ampere/animation/agent/AgentLayer.kt
@@ -78,6 +78,15 @@ class AgentLayer(
     }
 
     /**
+     * Update an agent's cognitive phase and optional progress.
+     */
+    fun updateAgentCognitivePhase(agentId: String, phase: CognitivePhase, progress: Float = 0f) {
+        agents[agentId]?.let { agent ->
+            agents[agentId] = agent.withCognitivePhase(phase, progress)
+        }
+    }
+
+    /**
      * Update an agent's status text.
      */
     fun updateAgentStatus(agentId: String, status: String) {

--- a/ampere-animation/src/commonMain/kotlin/link/socket/ampere/animation/timeline/CognitiveDemoTimeline.kt
+++ b/ampere-animation/src/commonMain/kotlin/link/socket/ampere/animation/timeline/CognitiveDemoTimeline.kt
@@ -1,0 +1,119 @@
+package link.socket.ampere.animation.timeline
+
+import link.socket.ampere.animation.agent.AgentActivityState
+import link.socket.ampere.animation.agent.AgentLayer
+import link.socket.ampere.animation.agent.AgentVisualState
+import link.socket.ampere.animation.agent.CognitivePhase
+import link.socket.ampere.animation.flow.FlowLayer
+import link.socket.ampere.animation.substrate.Vector2
+
+/**
+ * Builds a scripted timeline demonstrating a complete PROPEL cognitive cycle.
+ *
+ * The timeline walks through observable cognition with two agents:
+ * 1. Spark spawns and enters PERCEIVE (sensory gathering)
+ * 2. Spark transitions to RECALL (memory activation)
+ * 3. Spark enters PLAN, Jazz spawns (strategy + delegation)
+ * 4. Jazz enters EXECUTE (committed action)
+ * 5. Both enter EVALUATE (reflection)
+ * 6. Cycle completes
+ *
+ * Suitable for recording the demo GIF showing "you can watch AI think."
+ */
+object CognitiveDemoTimeline {
+
+    /**
+     * Build a timeline demonstrating a complete cognitive cycle.
+     *
+     * @param agents The agent layer to populate during the timeline
+     * @param flow The flow layer for inter-agent connections
+     * @return A timeline with phases matching the PROPEL cycle
+     */
+    fun build(
+        agents: AgentLayer,
+        flow: FlowLayer
+    ): Timeline = timeline {
+        phase("spawn", 2.0) {
+            onStart {
+                agents.addAgent(
+                    AgentVisualState(
+                        id = "spark",
+                        name = "Spark",
+                        role = "reasoning",
+                        position = Vector2(20f, 15f),
+                        state = AgentActivityState.SPAWNING,
+                    )
+                )
+            }
+            atProgress(0.8f) {
+                agents.updateAgentState("spark", AgentActivityState.PROCESSING)
+            }
+        }
+
+        phase("perceive", 3.0) {
+            onStart {
+                agents.updateAgentCognitivePhase("spark", CognitivePhase.PERCEIVE)
+            }
+        }
+
+        phase("recall", 2.0) {
+            onStart {
+                agents.updateAgentCognitivePhase("spark", CognitivePhase.RECALL)
+            }
+        }
+
+        phase("plan-and-delegate", 3.0) {
+            onStart {
+                agents.updateAgentCognitivePhase("spark", CognitivePhase.PLAN)
+                agents.addAgent(
+                    AgentVisualState(
+                        id = "jazz",
+                        name = "Jazz",
+                        role = "codegen",
+                        position = Vector2(60f, 15f),
+                        state = AgentActivityState.SPAWNING,
+                    )
+                )
+            }
+            at(1.0) {
+                agents.updateAgentState("jazz", AgentActivityState.PROCESSING)
+                flow.createConnectionsFromAgents(agents, listOf("spark" to "jazz"))
+            }
+            at(1.5) {
+                flow.startHandoff("spark", "jazz")
+            }
+        }
+
+        phase("execute", 3.0) {
+            onStart {
+                agents.updateAgentCognitivePhase("spark", CognitivePhase.EXECUTE)
+                agents.updateAgentCognitivePhase("jazz", CognitivePhase.EXECUTE)
+            }
+        }
+
+        phase("evaluate", 2.0) {
+            onStart {
+                agents.updateAgentCognitivePhase("spark", CognitivePhase.EVALUATE)
+                agents.updateAgentCognitivePhase("jazz", CognitivePhase.EVALUATE)
+            }
+        }
+
+        phase("complete", 1.0) {
+            onStart {
+                agents.updateAgentCognitivePhase("spark", CognitivePhase.LOOP)
+                agents.updateAgentCognitivePhase("jazz", CognitivePhase.LOOP)
+                agents.updateAgentState("spark", AgentActivityState.COMPLETE)
+                agents.updateAgentState("jazz", AgentActivityState.COMPLETE)
+            }
+        }
+    }
+
+    /** Expected phase names in order. */
+    val PHASE_NAMES = listOf(
+        "spawn", "perceive", "recall", "plan-and-delegate",
+        "execute", "evaluate", "complete"
+    )
+
+    /** Total expected duration in seconds. */
+    const val TOTAL_DURATION_SECONDS = 16.0
+}

--- a/ampere-animation/src/commonTest/kotlin/link/socket/ampere/animation/timeline/CognitiveDemoTimelineTest.kt
+++ b/ampere-animation/src/commonTest/kotlin/link/socket/ampere/animation/timeline/CognitiveDemoTimelineTest.kt
@@ -1,0 +1,91 @@
+package link.socket.ampere.animation.timeline
+
+import link.socket.ampere.animation.agent.AgentLayer
+import link.socket.ampere.animation.agent.AgentLayoutOrientation
+import link.socket.ampere.animation.flow.FlowLayer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+class CognitiveDemoTimelineTest {
+
+    private fun createTimeline(): Timeline {
+        val agents = AgentLayer(80, 40, AgentLayoutOrientation.CIRCULAR)
+        val flow = FlowLayer(80, 40)
+        return CognitiveDemoTimeline.build(agents, flow)
+    }
+
+    @Test
+    fun `timeline builds successfully`() {
+        val timeline = createTimeline()
+        assertTrue(timeline.phaseCount > 0)
+    }
+
+    @Test
+    fun `timeline has correct number of phases`() {
+        val timeline = createTimeline()
+        assertEquals(7, timeline.phaseCount)
+    }
+
+    @Test
+    fun `timeline has correct total duration`() {
+        val timeline = createTimeline()
+        val expectedDuration = CognitiveDemoTimeline.TOTAL_DURATION_SECONDS.seconds
+        assertEquals(expectedDuration, timeline.totalDuration)
+    }
+
+    @Test
+    fun `phase ordering matches PROPEL cycle`() {
+        val timeline = createTimeline()
+        val phaseNames = timeline.phases.map { it.name }
+        assertEquals(CognitiveDemoTimeline.PHASE_NAMES, phaseNames)
+    }
+
+    @Test
+    fun `all expected phases are present`() {
+        val timeline = createTimeline()
+        for (name in CognitiveDemoTimeline.PHASE_NAMES) {
+            assertNotNull(timeline.getPhase(name), "Missing phase: $name")
+        }
+    }
+
+    @Test
+    fun `spawn phase has correct duration`() {
+        val timeline = createTimeline()
+        val spawn = timeline.getPhase("spawn")
+        assertNotNull(spawn)
+        assertEquals(2.seconds, spawn.duration)
+    }
+
+    @Test
+    fun `execute phase has correct duration`() {
+        val timeline = createTimeline()
+        val execute = timeline.getPhase("execute")
+        assertNotNull(execute)
+        assertEquals(3.seconds, execute.duration)
+    }
+
+    @Test
+    fun `plan-and-delegate phase has keyframes`() {
+        val timeline = createTimeline()
+        val plan = timeline.getPhase("plan-and-delegate")
+        assertNotNull(plan)
+        assertTrue(plan.keyframes.isNotEmpty(), "plan-and-delegate should have keyframes")
+    }
+
+    @Test
+    fun `timeline callbacks populate agents when invoked`() {
+        val agents = AgentLayer(80, 40, AgentLayoutOrientation.CIRCULAR)
+        val flow = FlowLayer(80, 40)
+        val timeline = CognitiveDemoTimeline.build(agents, flow)
+
+        assertEquals(0, agents.agentCount, "No agents before timeline starts")
+
+        // Fire the spawn phase onStart
+        timeline.phases[0].onStart?.invoke()
+        assertEquals(1, agents.agentCount, "Spark should be added after spawn onStart")
+        assertNotNull(agents.getAgent("spark"))
+    }
+}

--- a/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/cli/hybrid/WatchStateAnimationBridgeTest.kt
+++ b/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/cli/hybrid/WatchStateAnimationBridgeTest.kt
@@ -193,6 +193,30 @@ class WatchStateAnimationBridgeTest {
     }
 
     @Test
+    fun `choreographer triggers on cognitive phase transition`() {
+        val (bridge, substrate, particles) = createBridge()
+
+        // First update: agent is THINKING (maps to PLAN phase)
+        val viewState1 = createViewState(
+            agents = mapOf("agent-1" to createAgent("agent-1", AgentState.THINKING, idle = false))
+        )
+        bridge.update(viewState1, substrate, 0.1f)
+        val particlesAfterThinking = particles.count
+
+        // Second update: agent transitions to WORKING (maps to EXECUTE phase)
+        // EXECUTE transition should trigger a spark burst via choreographer
+        val viewState2 = createViewState(
+            agents = mapOf("agent-1" to createAgent("agent-1", AgentState.WORKING, idle = false))
+        )
+        bridge.update(viewState2, substrate, 0.1f)
+
+        assertTrue(
+            particles.count > particlesAfterThinking,
+            "Phase transition to EXECUTE should trigger particle burst via choreographer"
+        )
+    }
+
+    @Test
     fun `agent state transition triggers pulse`() {
         val (bridge, substrate, _) = createBridge()
 

--- a/ampere-desktop/build.gradle.kts
+++ b/ampere-desktop/build.gradle.kts
@@ -19,6 +19,8 @@ kotlin {
         val jvmMain by getting {
             dependencies {
                 implementation(project(":ampere-core"))
+                implementation(project(":ampere-compose"))
+                implementation(project(":ampere-animation"))
                 implementation(compose.desktop.currentOs)
             }
         }

--- a/ampere-desktop/src/jvmMain/kotlin/link/socket/ampere/Main.kt
+++ b/ampere-desktop/src/jvmMain/kotlin/link/socket/ampere/Main.kt
@@ -1,23 +1,100 @@
 package link.socket.ampere
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.WindowState
 import androidx.compose.ui.window.application
+import kotlinx.coroutines.delay
+import link.socket.ampere.animation.agent.AgentActivityState
+import link.socket.ampere.animation.agent.AgentLayer
+import link.socket.ampere.animation.agent.AgentLayoutOrientation
+import link.socket.ampere.animation.agent.AgentVisualState
+import link.socket.ampere.animation.agent.CognitiveChoreographer
+import link.socket.ampere.animation.agent.CognitivePhase
+import link.socket.ampere.animation.flow.FlowLayer
+import link.socket.ampere.animation.particle.ParticleSystem
+import link.socket.ampere.animation.substrate.SubstrateAnimator
+import link.socket.ampere.animation.substrate.SubstrateState
+import link.socket.ampere.animation.substrate.Vector2
+import link.socket.ampere.compose.CognitiveCanvas
 import java.awt.Dimension
 
 fun main() =
     application {
         Window(
             onCloseRequest = ::exitApplication,
-            title = "Ampere",
+            title = "Ampere \u2014 Cognitive Engine",
             state =
                 WindowState(
-                    width = 800.dp,
-                    height = 1200.dp,
+                    width = 1200.dp,
+                    height = 800.dp,
                 ),
         ) {
-            window.minimumSize = Dimension(600, 800)
-            MainView()
+            window.minimumSize = Dimension(800, 600)
+            CognitiveDemoScreen()
         }
     }
+
+@Composable
+fun CognitiveDemoScreen() {
+    val substrate = remember { mutableStateOf(SubstrateState.create(80, 40, 0.2f)) }
+    val particles = remember { ParticleSystem(maxParticles = 200) }
+    val agents = remember { AgentLayer(80, 40, AgentLayoutOrientation.CIRCULAR) }
+    val flow = remember { FlowLayer(80, 40) }
+    val animator = remember { SubstrateAnimator(baseDensity = 0.2f) }
+    val choreographer = remember { CognitiveChoreographer(particles, animator) }
+
+    LaunchedEffect(Unit) {
+        agents.addAgent(
+            AgentVisualState(
+                id = "spark",
+                name = "Spark",
+                role = "reasoning",
+                position = Vector2(20f, 20f),
+                state = AgentActivityState.PROCESSING,
+                cognitivePhase = CognitivePhase.PERCEIVE,
+            ),
+        )
+        agents.addAgent(
+            AgentVisualState(
+                id = "jazz",
+                name = "Jazz",
+                role = "codegen",
+                position = Vector2(60f, 20f),
+                state = AgentActivityState.IDLE,
+            ),
+        )
+        agents.relayout()
+        flow.createConnectionsFromAgents(agents, listOf("spark" to "jazz"))
+    }
+
+    LaunchedEffect(Unit) {
+        val dt = 0.033f
+        while (true) {
+            delay(33)
+            substrate.value = animator.updateAmbient(substrate.value, dt)
+            substrate.value = choreographer.update(agents, substrate.value, dt)
+            particles.update(dt)
+            agents.update(dt)
+            flow.update(dt)
+        }
+    }
+
+    Box(modifier = Modifier.fillMaxSize().background(Color(0xFF1A1A2E))) {
+        CognitiveCanvas(
+            substrate = substrate.value,
+            particles = particles,
+            agents = agents,
+            flow = flow,
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Completes the Compose cognitive renderer implementation with:

- **Task 6**: CognitiveCanvas wired into ampere-desktop with animation loop showing real particle choreography
- **Task 7**: WatchStateAnimationBridge enriched with CognitiveChoreographer, mapping CLI AgentState to animation CognitivePhase for TUI
- **Task 8**: CognitiveDemoTimeline scripting a full PROPEL cycle for demo GIF and educational scenarios

The animation pipeline now supports phase-specific particle effects across all renderers (terminal, desktop, mobile).

Closes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)