### PR TITLE
Streamline CLI build and testing workflow

### DIFF
--- a/ampere-cli/README.md
+++ b/ampere-cli/README.md
@@ -17,11 +17,16 @@
 ### Build and Install
 
 ```bash
-# Build the CLI
+# Build the CLI distribution
 ./gradlew :ampere-cli:installDist
 
-# Add to your PATH (choose one):
+# Run directly from the project
+./ampere-cli/ampere --help
+```
 
+To make `ampere` available globally, choose one:
+
+```bash
 # Option A: Symlink to /usr/local/bin (recommended)
 sudo ln -sf "$(pwd)/ampere-cli/ampere" /usr/local/bin/ampere
 
@@ -34,19 +39,17 @@ ln -sf "$(pwd)/ampere-cli/ampere" ~/.local/bin/ampere
 echo 'export PATH="$PATH:/path/to/Ampere/ampere-cli"' >> ~/.zshrc
 ```
 
-After installation, verify it works:
+### Development Workflow
+
+When iterating on CLI changes, use the `--rebuild` flag to build and run in one step:
 
 ```bash
-ampere --help
-```
+# Rebuild and run (single command)
+./ampere-cli/ampere --rebuild --help
+./ampere-cli/ampere --rebuild --goal "Test my changes"
 
-### Alternative: Run Without Global Installation
-
-If you prefer not to install globally, run the wrapper script directly from the project:
-
-```bash
-./ampere-cli/ampere              # Start interactive TUI
-./ampere-cli/ampere --goal "..." # Run with a goal
+# Or if ampere is on your PATH via symlink:
+ampere --rebuild --goal "Test my changes"
 ```
 
 The wrapper script automatically finds and uses Java 21+.

--- a/ampere-cli/ampere
+++ b/ampere-cli/ampere
@@ -1,9 +1,17 @@
 #!/bin/bash
 # Wrapper script for ampere CLI that ensures Java 21+ is used
+#
+# Usage:
+#   ./ampere-cli/ampere [args]        Run the CLI (must build first)
+#   ./ampere-cli/ampere --rebuild [args]  Rebuild before running
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # Find Java 21 or higher
-JAVA_21=$(/usr/libexec/java_home -v 21 2>/dev/null)
 JAVA_24=$(/usr/libexec/java_home -v 24 2>/dev/null)
+JAVA_21=$(/usr/libexec/java_home -v 21 2>/dev/null)
 
 if [ -n "$JAVA_24" ]; then
     export JAVA_HOME="$JAVA_24"
@@ -17,8 +25,22 @@ else
     exit 1
 fi
 
-# Get the directory where this script is located
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BINARY="$SCRIPT_DIR/build/install/ampere-jvm/bin/ampere"
+
+# Handle --rebuild flag
+if [ "$1" = "--rebuild" ]; then
+    shift
+    echo "Rebuilding ampere CLI..."
+    "$PROJECT_DIR/gradlew" -p "$PROJECT_DIR" :ampere-cli:installJvmDist --quiet || exit 1
+fi
+
+# Check the binary exists
+if [ ! -f "$BINARY" ]; then
+    echo "Error: ampere CLI not built yet. Run one of:"
+    echo "  ./gradlew :ampere-cli:installDist"
+    echo "  ./ampere-cli/ampere --rebuild"
+    exit 1
+fi
 
 # Execute the ampere CLI
-exec "$SCRIPT_DIR/build/install/ampere-cli/bin/ampere-cli" "$@"
+exec "$BINARY" "$@"

--- a/ampere-cli/build.gradle.kts
+++ b/ampere-cli/build.gradle.kts
@@ -139,3 +139,8 @@ kotlin {
 tasks.named<Test>("jvmTest") {
     useJUnitPlatform()
 }
+
+// Wire installDist to installJvmDist so the familiar command works
+tasks.named("installDist") {
+    dependsOn("installJvmDist")
+}


### PR DESCRIPTION
## Summary

Fixed critical issues with the CLI build process that prevented testing:
- **Wrapper script** was pointing to wrong binary path (ampere-cli → ampere-jvm)
- **installDist task** was a no-op (NO-SOURCE) without wiring to installJvmDist
- Added **--rebuild flag** for one-command build-and-run during development

## Development Experience

Before: Manual `./gradlew :ampere-cli:installDist` then `./ampere-cli/ampere`
After: `./ampere-cli/ampere --rebuild --goal "test changes"` (single command)

Documentation updated to reflect the streamlined workflow.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>