### PR TITLE
Fix TUI resizing when terminal window changes

### DIFF
--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/AmpereCommand.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/AmpereCommand.kt
@@ -370,7 +370,7 @@ class AmpereCommand(
                         }
                         val shortcuts = StatusBar.defaultShortcuts(activeMode)
                         val statusBarStr = statusBar.render(
-                            width = terminal.info.width,
+                            width = TerminalFactory.getCapabilities().width.coerceAtLeast(40),
                             shortcuts = shortcuts,
                             status = systemStatus,
                             focusedAgent = viewConfig.focusedAgentIndex,


### PR DESCRIPTION
## Summary

Fixed TUI terminal resizing by switching from stale Mordant Terminal.info dimensions to live TerminalFactory.getCapabilities() which updates via SIGWINCH signal handler. The HybridDashboardRenderer now properly detects window resizes, reinitializes the layout, and redraws the screen without artifacts. Also updated status bar width calculation to use live dimensions.

## Changes

- **HybridDashboardRenderer.kt**: Initialize and resize detection now use TerminalFactory instead of stale terminal.info; screen clear on resize prevents layout artifacts
- **AmpereCommand.kt**: Status bar width uses live terminal dimensions
- **HybridDashboardRendererTest.kt**: Added tests for resize detection behavior

## Testing

Added two tests verifying resize detection triggers full screen redraw and that false resizes aren't detected when dimensions unchanged.