### PR TITLE
Agent 3D positioning & coordinate migration

### DIFF
--- a/ampere-animation/src/commonMain/kotlin/link/socket/ampere/animation/agent/AgentVisualState.kt
+++ b/ampere-animation/src/commonMain/kotlin/link/socket/ampere/animation/agent/AgentVisualState.kt
@@ -1,5 +1,6 @@
 package link.socket.ampere.animation.agent
 
+import link.socket.ampere.animation.math.Vector3
 import link.socket.ampere.animation.substrate.Vector2
 
 /**
@@ -48,7 +49,8 @@ enum class AgentActivityState {
  * @property id Unique agent identifier
  * @property name Display name for the agent
  * @property role Agent's role (e.g., "reasoning", "codegen")
- * @property position Position in 2D space
+ * @property position Position in 2D space (preserved for 2D renderers)
+ * @property position3D Full 3D position (x=horizontal, y=height/waveform, z=depth)
  * @property state Current activity state
  * @property statusText Status message displayed below agent
  * @property pulsePhase Phase for shimmer animation (0.0-1.0)
@@ -58,6 +60,7 @@ data class AgentVisualState(
     val name: String,
     val role: String,
     val position: Vector2,
+    val position3D: Vector3 = Vector3(position.x, 0f, position.y),
     val state: AgentActivityState = AgentActivityState.IDLE,
     val statusText: String = "",
     val pulsePhase: Float = 0f,
@@ -65,9 +68,22 @@ data class AgentVisualState(
     val phaseProgress: Float = 0f
 ) {
     /**
-     * Create a copy with updated position.
+     * Create a copy with updated 2D position. The 3D position is updated
+     * to keep X and Z in sync, preserving the current Y (height).
      */
-    fun withPosition(newPosition: Vector2): AgentVisualState = copy(position = newPosition)
+    fun withPosition(newPosition: Vector2): AgentVisualState = copy(
+        position = newPosition,
+        position3D = Vector3(newPosition.x, position3D.y, newPosition.y)
+    )
+
+    /**
+     * Create a copy with updated 3D position. The 2D position is
+     * derived as the XZ projection.
+     */
+    fun withPosition3D(newPosition3D: Vector3): AgentVisualState = copy(
+        position = Vector2(newPosition3D.x, newPosition3D.z),
+        position3D = newPosition3D
+    )
 
     /**
      * Create a copy with updated state.


### PR DESCRIPTION
## Summary
- Extends `AgentVisualState` with a `position3D: Vector3` field alongside the existing `position: Vector2`, with automatic sync between the two via `withPosition`/`withPosition3D` helpers
- Adds `SPHERE` (Fibonacci distribution) and `CLUSTERED` (role-grouped depth) layout orientations to `AgentLayer`, and updates `CIRCULAR` to distribute agents in the XZ plane at Y=0
- Makes `WatchStateAnimationBridge` 3D-aware, assigning Z-depth to agents based on creation order so they appear at different distances in 3D scenes

## Test plan
- [ ] Verify all existing tests pass with `./gradlew jvmTest` (backward-compatible — all 2D-only callers unchanged)
- [ ] Verify new tests: `AgentVisualState3DTest`, sphere/clustered layout tests, `setAgentPosition3D`
- [ ] Verify CIRCULAR layout test updated for XZ-plane 3D distribution
- [ ] Verify downstream modules compile: ampere-cli, ampere-desktop, ampere-compose

🤖 Generated with [Claude Code](https://claude.com/claude-code)