### PR TITLE
Wire emitter effects into waveform rasterizer

### DIFF
--- a/ampere-animation/src/commonTest/kotlin/link/socket/ampere/animation/waveform/WaveformRasterizerEmitterTest.kt
+++ b/ampere-animation/src/commonTest/kotlin/link/socket/ampere/animation/waveform/WaveformRasterizerEmitterTest.kt
@@ -1,0 +1,324 @@
+package link.socket.ampere.animation.waveform
+
+import link.socket.ampere.animation.agent.AgentLayer
+import link.socket.ampere.animation.agent.AgentLayoutOrientation
+import link.socket.ampere.animation.emitter.EmitterEffect
+import link.socket.ampere.animation.emitter.EmitterManager
+import link.socket.ampere.animation.math.Vector3
+import link.socket.ampere.animation.projection.Camera
+import link.socket.ampere.animation.projection.ScreenProjector
+import link.socket.ampere.animation.render.AsciiCell
+import link.socket.ampere.animation.render.AsciiLuminancePalette
+import link.socket.ampere.animation.render.CognitiveColorRamp
+import link.socket.ampere.animation.substrate.SubstrateState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class WaveformRasterizerEmitterTest {
+
+    private val screenWidth = 40
+    private val screenHeight = 20
+    private val projector = ScreenProjector(screenWidth, screenHeight)
+    private val lighting = SurfaceLighting()
+    private val rasterizer = WaveformRasterizer(screenWidth, screenHeight, projector, lighting)
+
+    private val camera = Camera(
+        position = Vector3(0f, 10f, 15f),
+        target = Vector3.ZERO
+    )
+
+    private fun createPopulatedWaveform(): CognitiveWaveform {
+        val waveform = CognitiveWaveform(gridWidth = 20, gridDepth = 15)
+        val substrate = SubstrateState.create(20, 15, 0.5f)
+        val agents = AgentLayer(20, 15, AgentLayoutOrientation.CUSTOM)
+        waveform.update(substrate, agents, null, dt = 1f)
+        return waveform
+    }
+
+    @Test
+    fun `rasterize without emitter manager produces same result as before`() {
+        val waveform = createPopulatedWaveform()
+
+        val gridWithout = rasterizer.rasterize(
+            waveform, camera,
+            AsciiLuminancePalette.STANDARD,
+            CognitiveColorRamp.NEUTRAL
+        )
+
+        val gridWithNull = rasterizer.rasterize(
+            waveform, camera,
+            AsciiLuminancePalette.STANDARD,
+            CognitiveColorRamp.NEUTRAL,
+            emitterManager = null
+        )
+
+        assertEquals(gridWithout.size, gridWithNull.size)
+        for (y in gridWithout.indices) {
+            for (x in gridWithout[y].indices) {
+                assertEquals(gridWithout[y][x], gridWithNull[y][x],
+                    "Cell at ($x, $y) should be identical with no emitter manager")
+            }
+        }
+    }
+
+    @Test
+    fun `rasterize with empty emitter manager produces same result as without`() {
+        val waveform = createPopulatedWaveform()
+        val emitterManager = EmitterManager()
+
+        val gridWithout = rasterizer.rasterize(
+            waveform, camera,
+            AsciiLuminancePalette.STANDARD,
+            CognitiveColorRamp.NEUTRAL
+        )
+
+        val gridWith = rasterizer.rasterize(
+            waveform, camera,
+            AsciiLuminancePalette.STANDARD,
+            CognitiveColorRamp.NEUTRAL,
+            emitterManager = emitterManager
+        )
+
+        for (y in gridWithout.indices) {
+            for (x in gridWithout[y].indices) {
+                assertEquals(gridWithout[y][x], gridWith[y][x],
+                    "Cell at ($x, $y) should be identical with empty emitter manager")
+            }
+        }
+    }
+
+    @Test
+    fun `height pulse at center modifies rasterized output`() {
+        val waveform = createPopulatedWaveform()
+        val emitterManager = EmitterManager()
+        emitterManager.emit(
+            EmitterEffect.HeightPulse(duration = 2f, radius = 5f, maxHeightBoost = 5f),
+            Vector3.ZERO
+        )
+        emitterManager.update(0.3f) // Advance to mid-rise
+
+        val gridWithout = rasterizer.rasterize(
+            waveform, camera,
+            AsciiLuminancePalette.STANDARD,
+            CognitiveColorRamp.NEUTRAL
+        )
+
+        val gridWith = rasterizer.rasterize(
+            waveform, camera,
+            AsciiLuminancePalette.STANDARD,
+            CognitiveColorRamp.NEUTRAL,
+            emitterManager = emitterManager
+        )
+
+        // At least some cells should differ due to height/luminance modification
+        var differences = 0
+        for (y in gridWithout.indices) {
+            for (x in gridWithout[y].indices) {
+                if (gridWithout[y][x] != gridWith[y][x]) differences++
+            }
+        }
+
+        assertTrue(
+            differences > 0,
+            "HeightPulse should modify at least some cells, got $differences differences"
+        )
+    }
+
+    @Test
+    fun `color wash overrides cell colors`() {
+        val waveform = createPopulatedWaveform()
+        val emitterManager = EmitterManager()
+        emitterManager.emit(
+            EmitterEffect.ColorWash(
+                duration = 2f,
+                radius = 15f, // Large radius to cover the surface
+                colorRamp = CognitiveColorRamp.EXECUTE,
+                waveFrontSpeed = 100f // Fast wave to ensure it covers the area
+            ),
+            Vector3.ZERO
+        )
+        emitterManager.update(0.2f)
+
+        val gridBase = rasterizer.rasterize(
+            waveform, camera,
+            AsciiLuminancePalette.STANDARD,
+            CognitiveColorRamp.NEUTRAL // Neutral uses grays
+        )
+
+        val gridWash = rasterizer.rasterize(
+            waveform, camera,
+            AsciiLuminancePalette.STANDARD,
+            CognitiveColorRamp.NEUTRAL,
+            emitterManager = emitterManager
+        )
+
+        // Collect non-empty cell colors from each
+        val baseColors = gridBase.flatMap { it.toList() }
+            .filter { it != AsciiCell.EMPTY }
+            .map { it.fgColor }
+            .toSet()
+
+        val washColors = gridWash.flatMap { it.toList() }
+            .filter { it != AsciiCell.EMPTY }
+            .map { it.fgColor }
+            .toSet()
+
+        // ColorWash should introduce colors from EXECUTE ramp not in NEUTRAL
+        val newColors = washColors - baseColors
+        assertTrue(
+            newColors.isNotEmpty() || washColors != baseColors,
+            "ColorWash should change some cell colors"
+        )
+    }
+
+    @Test
+    fun `confetti overrides characters`() {
+        val waveform = createPopulatedWaveform()
+        val emitterManager = EmitterManager()
+        emitterManager.emit(
+            EmitterEffect.Confetti(duration = 2f, radius = 15f),
+            Vector3.ZERO
+        )
+        emitterManager.update(0.2f)
+
+        val gridConfetti = rasterizer.rasterize(
+            waveform, camera,
+            AsciiLuminancePalette.STANDARD,
+            CognitiveColorRamp.NEUTRAL,
+            emitterManager = emitterManager
+        )
+
+        // Confetti characters are: ✦✧⚡★·*
+        val confettiChars = "\u2726\u2727\u26A1\u2605\u00B7*".toSet()
+        val renderedChars = gridConfetti.flatMap { it.toList() }
+            .filter { it != AsciiCell.EMPTY }
+            .map { it.char }
+            .toSet()
+
+        val hasConfetti = renderedChars.any { it in confettiChars }
+        assertTrue(hasConfetti, "Confetti effect should inject special characters into the output")
+    }
+
+    @Test
+    fun `spark burst modifies luminance and can override palette`() {
+        val waveform = createPopulatedWaveform()
+        val emitterManager = EmitterManager()
+        emitterManager.emit(
+            EmitterEffect.SparkBurst(
+                duration = 2f,
+                radius = 15f,
+                expansionSpeed = 50f, // Fast expansion to cover area
+                palette = AsciiLuminancePalette.EXECUTE
+            ),
+            Vector3.ZERO
+        )
+        emitterManager.update(0.1f)
+
+        val gridBase = rasterizer.rasterize(
+            waveform, camera,
+            AsciiLuminancePalette.PERCEIVE, // Use a distinctly different palette
+            CognitiveColorRamp.PERCEIVE
+        )
+
+        val gridBurst = rasterizer.rasterize(
+            waveform, camera,
+            AsciiLuminancePalette.PERCEIVE,
+            CognitiveColorRamp.PERCEIVE,
+            emitterManager = emitterManager
+        )
+
+        var differences = 0
+        for (y in gridBase.indices) {
+            for (x in gridBase[y].indices) {
+                if (gridBase[y][x] != gridBurst[y][x]) differences++
+            }
+        }
+
+        assertTrue(
+            differences > 0,
+            "SparkBurst should modify at least some cells"
+        )
+    }
+
+    @Test
+    fun `high intensity effect produces bold cells`() {
+        val waveform = createPopulatedWaveform()
+        val emitterManager = EmitterManager()
+        // Confetti at peak intensity (just started, at center) should produce bold cells
+        emitterManager.emit(
+            EmitterEffect.Confetti(duration = 2f, radius = 15f),
+            Vector3.ZERO
+        )
+        emitterManager.update(0.05f) // Very early = high intensity near center
+
+        val grid = rasterizer.rasterize(
+            waveform, camera,
+            AsciiLuminancePalette.STANDARD,
+            CognitiveColorRamp.NEUTRAL,
+            emitterManager = emitterManager
+        )
+
+        val boldCells = grid.flatMap { it.toList() }
+            .filter { it != AsciiCell.EMPTY && it.bold }
+
+        assertTrue(
+            boldCells.isNotEmpty(),
+            "High intensity confetti should produce some bold cells"
+        )
+    }
+
+    @Test
+    fun `expired effects do not modify output`() {
+        val waveform = createPopulatedWaveform()
+        val emitterManager = EmitterManager()
+        emitterManager.emit(
+            EmitterEffect.HeightPulse(duration = 0.5f, radius = 5f, maxHeightBoost = 5f),
+            Vector3.ZERO
+        )
+        // Advance past expiration
+        emitterManager.update(0.6f)
+
+        assertEquals(0, emitterManager.activeCount, "Effect should be expired")
+
+        val gridBase = rasterizer.rasterize(
+            waveform, camera,
+            AsciiLuminancePalette.STANDARD,
+            CognitiveColorRamp.NEUTRAL
+        )
+
+        val gridExpired = rasterizer.rasterize(
+            waveform, camera,
+            AsciiLuminancePalette.STANDARD,
+            CognitiveColorRamp.NEUTRAL,
+            emitterManager = emitterManager
+        )
+
+        for (y in gridBase.indices) {
+            for (x in gridBase[y].indices) {
+                assertEquals(gridBase[y][x], gridExpired[y][x],
+                    "Expired effects should not change output at ($x, $y)")
+            }
+        }
+    }
+
+    @Test
+    fun `rasterize grid dimensions unchanged with emitter manager`() {
+        val waveform = createPopulatedWaveform()
+        val emitterManager = EmitterManager()
+        emitterManager.emit(EmitterEffect.HeightPulse(), Vector3.ZERO)
+        emitterManager.update(0.1f)
+
+        val grid = rasterizer.rasterize(
+            waveform, camera,
+            AsciiLuminancePalette.STANDARD,
+            CognitiveColorRamp.NEUTRAL,
+            emitterManager = emitterManager
+        )
+
+        assertEquals(screenHeight, grid.size, "grid should have $screenHeight rows")
+        for (row in grid) {
+            assertEquals(screenWidth, row.size, "each row should have $screenWidth cols")
+        }
+    }
+}

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/animation/demo/AnimationDemoRunner.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/animation/demo/AnimationDemoRunner.kt
@@ -4,6 +4,7 @@ import link.socket.ampere.animation.agent.AgentActivityState
 import link.socket.ampere.animation.agent.AgentLayer
 import link.socket.ampere.animation.agent.AgentLayoutOrientation
 import link.socket.ampere.animation.agent.AgentVisualState
+import link.socket.ampere.animation.emitter.EmitterManager
 import link.socket.ampere.animation.flow.FlowLayer
 import link.socket.ampere.animation.logo.LogoCrystallizer
 import link.socket.ampere.animation.particle.ParticleSystem
@@ -60,6 +61,7 @@ class AnimationDemoRunner(
     private lateinit var agents: AgentLayer
     private lateinit var flow: FlowLayer
     private var logoCrystallizer: LogoCrystallizer? = null
+    private val emitterManager: EmitterManager = EmitterManager()
 
     // Timing
     private var elapsedTime: Duration = Duration.ZERO
@@ -125,6 +127,7 @@ class AnimationDemoRunner(
         outputBuffer.clear()
         statusMessage = ""
         logoCrystallizer = null
+        emitterManager.clear()
     }
 
     /**
@@ -320,6 +323,9 @@ class AnimationDemoRunner(
         if (config.showParticles) {
             particles.update(deltaSeconds)
         }
+
+        // Update emitter effects (decay/expire active effects)
+        emitterManager.update(deltaSeconds)
 
         // Update substrate
         if (config.showSubstrate) {


### PR DESCRIPTION
## Summary
- Integrate `EmitterManager` into `WaveformRasterizer.rasterize()` and `rasterizeBlended()` so active emitter effects modify surface height, luminance, palette, color, and character selection during rasterization
- Wire `emitterManager.update(dt)` into the `AnimationDemoRunner` animation loop alongside substrate, particles, agents, and flow updates
- Add integration tests verifying HeightPulse, ColorWash, Confetti, SparkBurst effects modify rasterized output correctly

## Test plan
- [ ] Verify existing `WaveformRasterizerTest` still passes
- [ ] Verify new `WaveformRasterizerEmitterTest` passes (height pulse modifies output, color wash overrides colors, confetti overrides characters, expired effects don't modify output, empty emitter manager = no change)
- [ ] Run `./gradlew jvmTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)