### PR TITLE
Integrate 3D waveform renderer into TUI center pane

### DIFF
--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/render/WaveformCellAdapter.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/render/WaveformCellAdapter.kt
@@ -1,0 +1,70 @@
+package link.socket.ampere.cli.render
+
+import link.socket.ampere.animation.render.AsciiCell
+import link.socket.ampere.cli.hybrid.HybridCellBuffer
+
+/**
+ * Converts the renderer-agnostic AsciiCell grid into the CLI's
+ * HybridCellBuffer format, applying ANSI color codes.
+ *
+ * This is the final optic nerve fiber — translating the brain's
+ * internal visual representation into the specific signal format
+ * that the terminal "retina" (Mosaic) can display.
+ */
+class WaveformCellAdapter {
+
+    /**
+     * Write AsciiCell grid into an existing HybridCellBuffer region.
+     *
+     * @param cells The rasterized waveform output [row][col]
+     * @param buffer The target cell buffer
+     * @param offsetX Column offset within the buffer (for pane positioning)
+     * @param offsetY Row offset within the buffer
+     * @param layer The layer to write at (default 1 = PANE_CONTENT)
+     */
+    fun writeToBuffer(
+        cells: Array<Array<AsciiCell>>,
+        buffer: HybridCellBuffer,
+        offsetX: Int,
+        offsetY: Int,
+        layer: Int = 1
+    ) {
+        for (row in cells.indices) {
+            val y = offsetY + row
+            if (y >= buffer.height) break
+            val rowCells = cells[row]
+            for (col in rowCells.indices) {
+                val x = offsetX + col
+                if (x >= buffer.width) break
+                val cell = rowCells[col]
+                if (cell.char == ' ' && cell.fgColor == 7) continue // Skip empty cells
+                val ansiColor = toAnsiColor(cell)
+                buffer.writeChar(x, y, cell.char, ansiColor, layer)
+            }
+        }
+    }
+
+    companion object {
+        /**
+         * Convert an AsciiCell's color attributes to an ANSI escape sequence.
+         *
+         * Produces ANSI 256-color foreground codes, with optional bold
+         * and background color support.
+         */
+        fun toAnsiColor(cell: AsciiCell): String? {
+            if (cell.fgColor == 7 && !cell.bold && cell.bgColor == null) return null
+
+            return buildString {
+                append("\u001B[")
+                val parts = mutableListOf<String>()
+                if (cell.bold) parts.add("1")
+                parts.add("38;5;${cell.fgColor}")
+                if (cell.bgColor != null) {
+                    parts.add("48;5;${cell.bgColor}")
+                }
+                append(parts.joinToString(";"))
+                append("m")
+            }
+        }
+    }
+}

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/render/WaveformPaneRenderer.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/render/WaveformPaneRenderer.kt
@@ -1,0 +1,199 @@
+package link.socket.ampere.cli.render
+
+import link.socket.ampere.animation.agent.AgentLayer
+import link.socket.ampere.animation.agent.AgentLayoutOrientation
+import link.socket.ampere.animation.emitter.CognitiveEmitterBridge
+import link.socket.ampere.animation.emitter.CognitiveEvent
+import link.socket.ampere.animation.emitter.EmitterManager
+import link.socket.ampere.animation.flow.FlowLayer
+import link.socket.ampere.animation.math.Vector3
+import link.socket.ampere.animation.projection.CameraOrbit
+import link.socket.ampere.animation.projection.ScreenProjector
+import link.socket.ampere.animation.render.AsciiCell
+import link.socket.ampere.animation.render.AsciiLuminancePalette
+import link.socket.ampere.animation.render.CognitiveColorRamp
+import link.socket.ampere.animation.substrate.SubstrateState
+import link.socket.ampere.animation.waveform.CognitiveWaveform
+import link.socket.ampere.animation.waveform.PhaseBlender
+import link.socket.ampere.animation.waveform.SurfaceLighting
+import link.socket.ampere.animation.waveform.WaveformRasterizer
+import link.socket.ampere.cli.layout.PaneRenderer
+
+/**
+ * Renders the 3D cognitive waveform as a pane within the hybrid dashboard.
+ *
+ * Replaces the flat spatial map with a living 3D heightmap surface rendered
+ * in ASCII, where agent activity creates peaks and ridges, cognitive phases
+ * shift the character palette and color, and emitter effects fire transient
+ * visual perturbations.
+ *
+ * The pane orchestrates the full pipeline each frame:
+ *   camera orbit → waveform update → emitter update → rasterize → ANSI output
+ */
+class WaveformPaneRenderer(
+    private val agentLayer: AgentLayer,
+    private val emitterManager: EmitterManager,
+    private val cognitiveEmitterBridge: CognitiveEmitterBridge
+) : PaneRenderer {
+
+    private var cameraOrbit = CameraOrbit(
+        radius = 15f,
+        height = 8f,
+        orbitSpeed = 0.08f,
+        wobbleAmplitude = 0.3f,
+        wobbleFrequency = 0.2f
+    )
+
+    private val lighting = SurfaceLighting()
+    private val phaseBlender = PhaseBlender(influenceRadius = 8f)
+
+    // Lazily constructed per-size to avoid rebuilding when pane dimensions are stable.
+    private var cachedWidth = 0
+    private var cachedHeight = 0
+    private var waveform: CognitiveWaveform? = null
+    private var rasterizer: WaveformRasterizer? = null
+
+    // Animation time tracking
+    private var elapsedTime = 0f
+    private var deltaSeconds = 0.033f // ~30fps default, updated externally
+
+    // Substrate and flow state provided externally via update()
+    private var currentSubstrate: SubstrateState? = null
+    private var currentFlow: FlowLayer? = null
+
+    /**
+     * Update the renderer's animation state before the next render call.
+     *
+     * @param substrate Current substrate density field
+     * @param flow Current flow connections (nullable)
+     * @param dt Delta time since last frame in seconds
+     */
+    fun update(substrate: SubstrateState, flow: FlowLayer?, dt: Float) {
+        currentSubstrate = substrate
+        currentFlow = flow
+        deltaSeconds = dt
+        elapsedTime += dt
+    }
+
+    /**
+     * Fire a cognitive event through the emitter bridge.
+     */
+    fun onCognitiveEvent(event: CognitiveEvent, agentPosition: Vector3) {
+        cognitiveEmitterBridge.onCognitiveEvent(event, agentPosition)
+    }
+
+    override fun render(width: Int, height: Int): List<String> {
+        ensureComponents(width, height)
+
+        val wf = waveform ?: return emptyGrid(width, height)
+        val rast = rasterizer ?: return emptyGrid(width, height)
+
+        // 1. Advance camera orbit
+        val camera = cameraOrbit.update(deltaSeconds)
+
+        // 2. Update waveform heightmap from current state
+        val substrate = currentSubstrate ?: SubstrateState.create(width, height, baseDensity = 0.1f)
+        wf.update(substrate, agentLayer, currentFlow, deltaSeconds)
+
+        // 3. Update emitter effects
+        emitterManager.update(deltaSeconds)
+
+        // 4. Rasterize with phase blending for per-point palette selection
+        val cells: Array<Array<AsciiCell>> = if (agentLayer.agentCount > 0) {
+            rast.rasterizeBlended(
+                waveform = wf,
+                camera = camera,
+                blender = phaseBlender,
+                agents = agentLayer,
+                fallbackPalette = AsciiLuminancePalette.STANDARD,
+                fallbackRamp = CognitiveColorRamp.NEUTRAL,
+                emitterManager = emitterManager
+            )
+        } else {
+            rast.rasterize(
+                waveform = wf,
+                camera = camera,
+                palette = AsciiLuminancePalette.STANDARD,
+                colorRamp = CognitiveColorRamp.NEUTRAL,
+                emitterManager = emitterManager
+            )
+        }
+
+        // 5. Convert AsciiCell grid to ANSI-styled strings
+        return cellsToLines(cells, width, height)
+    }
+
+    /**
+     * Ensure waveform and rasterizer are sized correctly for the current pane dimensions.
+     */
+    private fun ensureComponents(width: Int, height: Int) {
+        if (width != cachedWidth || height != cachedHeight) {
+            cachedWidth = width
+            cachedHeight = height
+
+            // Heightmap resolution: use pane dimensions directly for 1:1 mapping
+            // but cap grid resolution to keep frame time under budget.
+            val gridWidth = width.coerceAtMost(60)
+            val gridDepth = height.coerceAtMost(40)
+
+            waveform = CognitiveWaveform(
+                gridWidth = gridWidth,
+                gridDepth = gridDepth,
+                worldWidth = 20f,
+                worldDepth = 15f
+            )
+
+            val projector = ScreenProjector(
+                screenWidth = width,
+                screenHeight = height
+            )
+
+            rasterizer = WaveformRasterizer(
+                screenWidth = width,
+                screenHeight = height,
+                projector = projector,
+                lighting = lighting
+            )
+        }
+    }
+
+    private fun emptyGrid(width: Int, height: Int): List<String> {
+        val emptyLine = " ".repeat(width)
+        return List(height) { emptyLine }
+    }
+
+    companion object {
+        /**
+         * Convert a 2D AsciiCell grid to a list of ANSI-styled strings,
+         * one per row. Each line is exactly [width] visible characters.
+         */
+        fun cellsToLines(
+            cells: Array<Array<AsciiCell>>,
+            width: Int,
+            height: Int
+        ): List<String> {
+            return List(height) { row ->
+                if (row >= cells.size) {
+                    " ".repeat(width)
+                } else {
+                    buildString {
+                        val rowCells = cells[row]
+                        var lastColor: String? = null
+                        for (col in 0 until width) {
+                            val cell = if (col < rowCells.size) rowCells[col] else AsciiCell.EMPTY
+                            val ansiColor = WaveformCellAdapter.toAnsiColor(cell)
+
+                            if (ansiColor != lastColor) {
+                                if (lastColor != null) append("\u001B[0m")
+                                if (ansiColor != null) append(ansiColor)
+                                lastColor = ansiColor
+                            }
+                            append(cell.char)
+                        }
+                        if (lastColor != null) append("\u001B[0m")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/cli/render/WaveformCellAdapterTest.kt
+++ b/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/cli/render/WaveformCellAdapterTest.kt
@@ -1,0 +1,136 @@
+package link.socket.ampere.cli.render
+
+import link.socket.ampere.animation.render.AsciiCell
+import link.socket.ampere.cli.hybrid.HybridCellBuffer
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class WaveformCellAdapterTest {
+
+    private val adapter = WaveformCellAdapter()
+
+    @Test
+    fun `toAnsiColor returns null for default cell`() {
+        val cell = AsciiCell()
+        assertNull(WaveformCellAdapter.toAnsiColor(cell))
+    }
+
+    @Test
+    fun `toAnsiColor produces 256-color foreground code`() {
+        val cell = AsciiCell(char = '#', fgColor = 196)
+        val color = WaveformCellAdapter.toAnsiColor(cell)
+        assertNotNull(color)
+        assertEquals("\u001B[38;5;196m", color)
+    }
+
+    @Test
+    fun `toAnsiColor includes bold when set`() {
+        val cell = AsciiCell(char = '@', fgColor = 220, bold = true)
+        val color = WaveformCellAdapter.toAnsiColor(cell)
+        assertNotNull(color)
+        assertTrue(color.contains("1;"), "Expected bold prefix in: $color")
+        assertTrue(color.contains("38;5;220"), "Expected fg color in: $color")
+    }
+
+    @Test
+    fun `toAnsiColor includes background when set`() {
+        val cell = AsciiCell(char = '*', fgColor = 117, bgColor = 232)
+        val color = WaveformCellAdapter.toAnsiColor(cell)
+        assertNotNull(color)
+        assertTrue(color.contains("38;5;117"), "Expected fg color in: $color")
+        assertTrue(color.contains("48;5;232"), "Expected bg color in: $color")
+    }
+
+    @Test
+    fun `writeToBuffer places cells at correct offset`() {
+        val buffer = HybridCellBuffer(20, 10)
+        buffer.clear()
+
+        val cells = Array(2) { row ->
+            Array(3) { col ->
+                AsciiCell(char = ('A' + row * 3 + col), fgColor = 196)
+            }
+        }
+
+        adapter.writeToBuffer(cells, buffer, offsetX = 5, offsetY = 3)
+
+        // Verify cells are placed at the offset
+        assertEquals('A', buffer.getCell(5, 3).char)
+        assertEquals('B', buffer.getCell(6, 3).char)
+        assertEquals('C', buffer.getCell(7, 3).char)
+        assertEquals('D', buffer.getCell(5, 4).char)
+        assertEquals('E', buffer.getCell(6, 4).char)
+        assertEquals('F', buffer.getCell(7, 4).char)
+    }
+
+    @Test
+    fun `writeToBuffer applies ANSI color from fgColor`() {
+        val buffer = HybridCellBuffer(10, 5)
+        buffer.clear()
+
+        val cells = Array(1) { Array(1) { AsciiCell(char = '#', fgColor = 196) } }
+        adapter.writeToBuffer(cells, buffer, offsetX = 0, offsetY = 0)
+
+        val cell = buffer.getCell(0, 0)
+        assertEquals('#', cell.char)
+        assertNotNull(cell.ansiColor)
+        assertTrue(cell.ansiColor!!.contains("38;5;196"))
+    }
+
+    @Test
+    fun `writeToBuffer skips empty cells`() {
+        val buffer = HybridCellBuffer(10, 5)
+        buffer.clear()
+        buffer.writeChar(2, 0, 'Z', "\u001B[31m", layer = 0)
+
+        // AsciiCell with default char=' ' and fgColor=7 should be skipped
+        val cells = Array(1) { Array(5) { AsciiCell.EMPTY } }
+        adapter.writeToBuffer(cells, buffer, offsetX = 0, offsetY = 0, layer = 1)
+
+        // 'Z' at layer 0 should still be there since empty cells were skipped
+        assertEquals('Z', buffer.getCell(2, 0).char)
+    }
+
+    @Test
+    fun `writeToBuffer clips to buffer bounds`() {
+        val buffer = HybridCellBuffer(5, 3)
+        buffer.clear()
+
+        // 4x4 grid at offset 3,1 — only first 2 cols and 2 rows fit
+        val cells = Array(4) { row ->
+            Array(4) { col ->
+                AsciiCell(char = 'X', fgColor = 196)
+            }
+        }
+
+        adapter.writeToBuffer(cells, buffer, offsetX = 3, offsetY = 1)
+
+        assertEquals('X', buffer.getCell(3, 1).char)
+        assertEquals('X', buffer.getCell(4, 1).char)
+        assertEquals('X', buffer.getCell(3, 2).char)
+        assertEquals('X', buffer.getCell(4, 2).char)
+        // Out of bounds cells are unaffected
+        assertEquals(' ', buffer.getCell(0, 0).char)
+    }
+
+    @Test
+    fun `writeToBuffer respects layer parameter`() {
+        val buffer = HybridCellBuffer(10, 5)
+        buffer.clear()
+        // Pre-fill at layer 2
+        buffer.writeChar(0, 0, 'Z', null, layer = 2)
+
+        val cells = Array(1) { Array(1) { AsciiCell(char = 'A', fgColor = 196) } }
+
+        // Write at layer 1 — should NOT overwrite layer 2
+        adapter.writeToBuffer(cells, buffer, offsetX = 0, offsetY = 0, layer = 1)
+        assertEquals('Z', buffer.getCell(0, 0).char)
+
+        // Write at layer 2 — should overwrite
+        adapter.writeToBuffer(cells, buffer, offsetX = 0, offsetY = 0, layer = 2)
+        assertEquals('A', buffer.getCell(0, 0).char)
+    }
+}

--- a/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/cli/render/WaveformPaneRendererTest.kt
+++ b/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/cli/render/WaveformPaneRendererTest.kt
@@ -1,0 +1,182 @@
+package link.socket.ampere.cli.render
+
+import link.socket.ampere.animation.agent.AgentActivityState
+import link.socket.ampere.animation.agent.AgentLayer
+import link.socket.ampere.animation.agent.AgentLayoutOrientation
+import link.socket.ampere.animation.agent.AgentVisualState
+import link.socket.ampere.animation.agent.CognitivePhase
+import link.socket.ampere.animation.emitter.CognitiveEmitterBridge
+import link.socket.ampere.animation.emitter.EmitterManager
+import link.socket.ampere.animation.math.Vector3
+import link.socket.ampere.animation.render.AsciiCell
+import link.socket.ampere.animation.substrate.SubstrateState
+import link.socket.ampere.animation.substrate.Vector2
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class WaveformPaneRendererTest {
+
+    private val agentLayer = AgentLayer(80, 24, AgentLayoutOrientation.CUSTOM)
+    private val emitterManager = EmitterManager()
+    private val cognitiveEmitterBridge = CognitiveEmitterBridge(emitterManager)
+
+    private val renderer = WaveformPaneRenderer(
+        agentLayer = agentLayer,
+        emitterManager = emitterManager,
+        cognitiveEmitterBridge = cognitiveEmitterBridge
+    )
+
+    @Test
+    fun `render returns correct number of lines`() {
+        val width = 40
+        val height = 20
+        val substrate = SubstrateState.create(width, height, baseDensity = 0.3f)
+        renderer.update(substrate, flow = null, dt = 0.033f)
+
+        val lines = renderer.render(width, height)
+
+        assertEquals(height, lines.size, "Expected $height lines")
+    }
+
+    @Test
+    fun `render returns lines with correct visible width`() {
+        val width = 30
+        val height = 15
+        val substrate = SubstrateState.create(width, height, baseDensity = 0.3f)
+        renderer.update(substrate, flow = null, dt = 0.033f)
+
+        val lines = renderer.render(width, height)
+
+        for ((idx, line) in lines.withIndex()) {
+            // Strip ANSI escape sequences to get visible width
+            val visible = line.replace(Regex("\u001B\\[[0-9;]*[a-zA-Z]"), "")
+            assertEquals(width, visible.length, "Line $idx visible width should be $width, was ${visible.length}")
+        }
+    }
+
+    @Test
+    fun `render with agents produces non-empty content`() {
+        val width = 40
+        val height = 20
+        val substrate = SubstrateState.create(width, height, baseDensity = 0.5f)
+
+        agentLayer.addAgent(
+            AgentVisualState(
+                id = "agent-1",
+                name = "Test Agent",
+                role = "worker",
+                position = Vector2(10f, 7f),
+                position3D = Vector3(0f, 0f, 0f),
+                state = AgentActivityState.ACTIVE,
+                cognitivePhase = CognitivePhase.EXECUTE
+            )
+        )
+
+        renderer.update(substrate, flow = null, dt = 0.1f)
+        val lines = renderer.render(width, height)
+
+        // With an active agent creating peaks, at least some lines should have non-space characters
+        val hasContent = lines.any { line ->
+            val visible = line.replace(Regex("\u001B\\[[0-9;]*[a-zA-Z]"), "")
+            visible.any { it != ' ' }
+        }
+        assertTrue(hasContent, "Expected non-empty waveform content with an active agent")
+    }
+
+    @Test
+    fun `render without substrate produces valid output`() {
+        val width = 30
+        val height = 15
+
+        // Don't call update() — renderer should handle missing substrate gracefully
+        val lines = renderer.render(width, height)
+
+        assertEquals(height, lines.size, "Should produce $height lines even without substrate update")
+    }
+
+    @Test
+    fun `cellsToLines produces correct dimensions`() {
+        val width = 10
+        val height = 5
+        val cells = Array(height) { Array(width) { AsciiCell(char = '.', fgColor = 240) } }
+
+        val lines = WaveformPaneRenderer.cellsToLines(cells, width, height)
+
+        assertEquals(height, lines.size)
+        for (line in lines) {
+            val visible = line.replace(Regex("\u001B\\[[0-9;]*[a-zA-Z]"), "")
+            assertEquals(width, visible.length)
+        }
+    }
+
+    @Test
+    fun `cellsToLines preserves characters from cells`() {
+        val cells = Array(1) {
+            arrayOf(
+                AsciiCell(char = '#', fgColor = 196),
+                AsciiCell(char = '.', fgColor = 240),
+                AsciiCell(char = '@', fgColor = 231)
+            )
+        }
+
+        val lines = WaveformPaneRenderer.cellsToLines(cells, 3, 1)
+        val visible = lines[0].replace(Regex("\u001B\\[[0-9;]*[a-zA-Z]"), "")
+        assertEquals("#.@", visible)
+    }
+
+    @Test
+    fun `cellsToLines includes ANSI color codes`() {
+        val cells = Array(1) {
+            arrayOf(AsciiCell(char = '*', fgColor = 196, bold = true))
+        }
+
+        val lines = WaveformPaneRenderer.cellsToLines(cells, 1, 1)
+        assertTrue(lines[0].contains("\u001B["), "Expected ANSI escape codes")
+        assertTrue(lines[0].contains("196"), "Expected color code 196")
+    }
+
+    @Test
+    fun `cellsToLines pads short rows`() {
+        // Grid has 3 rows but we ask for 5 — should pad with spaces
+        val cells = Array(3) { Array(5) { AsciiCell(char = '.', fgColor = 240) } }
+        val lines = WaveformPaneRenderer.cellsToLines(cells, 5, 5)
+
+        assertEquals(5, lines.size)
+        // Last 2 lines should be empty spaces
+        val last = lines[4].replace(Regex("\u001B\\[[0-9;]*[a-zA-Z]"), "")
+        assertEquals("     ", last)
+    }
+
+    @Test
+    fun `emitter effects are active after update`() {
+        val width = 20
+        val height = 10
+        val substrate = SubstrateState.create(width, height, baseDensity = 0.3f)
+
+        agentLayer.addAgent(
+            AgentVisualState(
+                id = "test-agent",
+                name = "Test",
+                role = "worker",
+                position = Vector2(5f, 5f),
+                position3D = Vector3(0f, 0f, 0f),
+                state = AgentActivityState.PROCESSING,
+                cognitivePhase = CognitivePhase.PLAN
+            )
+        )
+
+        // Fire an emitter effect
+        renderer.onCognitiveEvent(
+            link.socket.ampere.animation.emitter.CognitiveEvent.SparkReceived("test-agent"),
+            Vector3(0f, 0f, 0f)
+        )
+
+        // Effects should be active
+        assertTrue(emitterManager.activeCount > 0, "Emitter should have active effects after spark event")
+
+        renderer.update(substrate, flow = null, dt = 0.033f)
+        val lines = renderer.render(width, height)
+        assertEquals(height, lines.size)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `WaveformCellAdapter` to convert renderer-agnostic `AsciiCell` grids into `HybridCellBuffer` format with ANSI 256-color mapping
- Adds `WaveformPaneRenderer` implementing `PaneRenderer` — orchestrates the full waveform pipeline each frame (camera orbit → waveform update → emitter update → rasterize → ANSI output)
- Wires `HybridDashboardRenderer` to expose `waveformPane` as a drop-in replacement for the center pane, with `EmitterManager` and `CognitiveEmitterBridge` lifecycle management
- Extends `WatchStateAnimationBridge` with cognitive event emission (phase transitions → `ColorWash`, sparks → `SparkBurst`+`HeightPulse`, task completion → `Confetti`)

## Test plan
- [x] `WaveformCellAdapterTest` — ANSI color mapping, buffer writes, bounds clipping, layer priority, empty cell skipping
- [x] `WaveformPaneRendererTest` — output dimensions, visible width, content with active agents, graceful degradation without substrate, emitter integration
- [x] Build compiles cleanly (`./gradlew :ampere-cli:compileKotlinJvm`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)