### PR TITLE
Add 3D depth rendering to Compose canvas and fix TUI gaps

### DIFF
--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/AmpereCommand.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/AmpereCommand.kt
@@ -401,10 +401,13 @@ class AmpereCommand(
                             else -> memoryPane
                         }
 
+                        // Use waveform pane as center if available, otherwise fall back to progress pane
+                        val middlePane: PaneRenderer = hybridRenderer.waveformPane ?: jazzPane
+
                         // Render the hybrid animated layout
                         hybridRenderer.render(
                             leftPane = eventPane,
-                            middlePane = jazzPane,
+                            middlePane = middlePane,
                             rightPane = rightPane,
                             statusBar = statusBarStr,
                             viewState = watchState,

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/hybrid/HybridDashboardRenderer.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/hybrid/HybridDashboardRenderer.kt
@@ -208,7 +208,7 @@ class HybridDashboardRenderer(
         substrate = bridge.update(viewState, substrate, deltaSeconds)
 
         // 2. Update waveform pane with current substrate/flow state
-        waveformPane?.update(substrate, flow = null, dt = deltaSeconds)
+        waveformPane?.update(substrate, flow = bridge.flowLayer, dt = deltaSeconds)
 
         // 3. (ambient + particle updates handled inside bridge.update)
 
@@ -373,7 +373,7 @@ class HybridDashboardRenderer(
         substrate = bridge.update(viewState, substrate, deltaSeconds)
 
         // 2. Update waveform pane with current substrate/flow state
-        waveformPane?.update(substrate, flow = null, dt = deltaSeconds)
+        waveformPane?.update(substrate, flow = bridge.flowLayer, dt = deltaSeconds)
 
         // 4. Clear buffer
         buffer.clear()

--- a/ampere-compose/src/commonMain/kotlin/link/socket/ampere/compose/AgentCanvasRenderer.kt
+++ b/ampere-compose/src/commonMain/kotlin/link/socket/ampere/compose/AgentCanvasRenderer.kt
@@ -6,7 +6,10 @@ import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
 import link.socket.ampere.animation.agent.AgentActivityState
 import link.socket.ampere.animation.agent.AgentLayer
+import link.socket.ampere.animation.agent.AgentVisualState
 import link.socket.ampere.animation.agent.CognitivePhase
+import link.socket.ampere.animation.projection.Camera
+import link.socket.ampere.animation.projection.ScreenProjector
 import kotlin.math.PI
 import kotlin.math.sin
 
@@ -16,68 +19,160 @@ import kotlin.math.sin
  * Each agent is drawn as a circle with state-dependent color and size,
  * cognitive phase glow ring, and processing shimmer effect.
  *
- * Note: Agent name/status text labels require Compose Text overlays
- * (Canvas doesn't have cross-platform drawText). The visual demo works
- * without labels since nodes are self-documenting through color and motion.
+ * When a [Camera] is provided, agents are projected from 3D space with
+ * depth-based scaling: nearby agents appear larger and more opaque,
+ * while distant agents are smaller and more diffuse — creating a
+ * parallax depth effect.
  */
 object AgentCanvasRenderer {
 
     /**
-     * Render all agents.
+     * Render all agents with optional 3D depth-based scaling.
      *
      * @param drawScope The Compose DrawScope to render into
      * @param agents Current agent layer
      * @param cellWidth Width of each cell in pixels
      * @param cellHeight Height of each cell in pixels
+     * @param camera Optional camera for 3D depth projection. When null,
+     *   falls back to flat 2D rendering using agent.position.
      */
     fun render(
         drawScope: DrawScope,
         agents: AgentLayer,
         cellWidth: Float,
+        cellHeight: Float,
+        camera: Camera? = null
+    ) {
+        if (camera == null) {
+            render2D(drawScope, agents, cellWidth, cellHeight)
+        } else {
+            render3D(drawScope, agents, cellWidth, cellHeight, camera)
+        }
+    }
+
+    /**
+     * Flat 2D rendering — original behavior, no depth projection.
+     */
+    private fun render2D(
+        drawScope: DrawScope,
+        agents: AgentLayer,
+        cellWidth: Float,
         cellHeight: Float
     ) {
+        val baseRadius = cellWidth * 1.5f
         with(drawScope) {
             agents.allAgents.forEach { agent ->
                 val cx = agent.position.x * cellWidth
                 val cy = agent.position.y * cellHeight
-                val nodeRadius = cellWidth * 1.5f
+                drawAgentNode(this, cx, cy, baseRadius, 0.8f, 0.9f, agent)
+            }
+        }
+    }
 
-                // Outer ring: cognitive phase color
-                val phaseColor = CognitivePalette.forPhase(agent.cognitivePhase)
-                drawCircle(
-                    color = phaseColor,
-                    radius = nodeRadius + 3f,
-                    center = Offset(cx, cy),
-                    style = Stroke(width = 2f),
-                    alpha = if (agent.cognitivePhase != CognitivePhase.NONE) 0.8f else 0.2f
-                )
+    /**
+     * 3D depth-projected rendering. Agents are sorted back-to-front and
+     * scaled by their distance from the camera.
+     */
+    private fun render3D(
+        drawScope: DrawScope,
+        agents: AgentLayer,
+        cellWidth: Float,
+        cellHeight: Float,
+        camera: Camera
+    ) {
+        val canvasWidth = drawScope.size.width
+        val canvasHeight = drawScope.size.height
+        val baseRadius = cellWidth * 1.5f
 
-                // Inner fill: agent state color
-                val stateColor = when (agent.state) {
-                    AgentActivityState.IDLE -> CognitivePalette.agentIdle
-                    AgentActivityState.ACTIVE -> CognitivePalette.agentActive
-                    AgentActivityState.PROCESSING -> CognitivePalette.agentProcessing
-                    AgentActivityState.COMPLETE -> CognitivePalette.agentComplete
-                    AgentActivityState.SPAWNING -> CognitivePalette.agentIdle
+        // Pixel-based canvas uses charAspect 1.0 (unlike terminal's 0.5)
+        val projector = ScreenProjector(
+            screenWidth = canvasWidth.toInt().coerceAtLeast(1),
+            screenHeight = canvasHeight.toInt().coerceAtLeast(1),
+            charAspect = 1.0f
+        )
+
+        data class ProjectedAgent(
+            val cx: Float,
+            val cy: Float,
+            val depth: Float,
+            val agent: AgentVisualState
+        )
+
+        val projected = agents.allAgents.mapNotNull { agent ->
+            val (screenX, screenY, depth) = projector.projectContinuous(agent.position3D, camera)
+            if (depth in 0f..1f && screenX in -canvasWidth..canvasWidth * 2 && screenY in -canvasHeight..canvasHeight * 2) {
+                ProjectedAgent(screenX, screenY, depth, agent)
+            } else {
+                null
+            }
+        }.sortedByDescending { it.depth } // Back-to-front for correct occlusion
+
+        with(drawScope) {
+            for ((cx, cy, depth, agent) in projected) {
+                // Depth factor: near (depth≈0) → 1.0, far (depth≈1) → 0.0
+                val depthFactor = 1f - depth.coerceIn(0f, 1f)
+
+                val nodeRadius = baseRadius * (0.5f + 0.5f * depthFactor)
+                val ringAlpha = if (agent.cognitivePhase != CognitivePhase.NONE) {
+                    0.3f + 0.5f * depthFactor
+                } else {
+                    0.1f + 0.1f * depthFactor
                 }
+                val fillAlpha = 0.4f + 0.5f * depthFactor
 
+                drawAgentNode(this, cx, cy, nodeRadius, ringAlpha, fillAlpha, agent)
+            }
+        }
+    }
+
+    /**
+     * Draw a single agent node — shared between 2D and 3D paths.
+     */
+    private fun drawAgentNode(
+        drawScope: DrawScope,
+        cx: Float,
+        cy: Float,
+        nodeRadius: Float,
+        ringAlpha: Float,
+        fillAlpha: Float,
+        agent: AgentVisualState
+    ) {
+        with(drawScope) {
+            // Outer ring: cognitive phase color
+            val phaseColor = CognitivePalette.forPhase(agent.cognitivePhase)
+            drawCircle(
+                color = phaseColor,
+                radius = nodeRadius + 3f,
+                center = Offset(cx, cy),
+                style = Stroke(width = 2f),
+                alpha = ringAlpha
+            )
+
+            // Inner fill: agent state color
+            val stateColor = when (agent.state) {
+                AgentActivityState.IDLE -> CognitivePalette.agentIdle
+                AgentActivityState.ACTIVE -> CognitivePalette.agentActive
+                AgentActivityState.PROCESSING -> CognitivePalette.agentProcessing
+                AgentActivityState.COMPLETE -> CognitivePalette.agentComplete
+                AgentActivityState.SPAWNING -> CognitivePalette.agentIdle
+            }
+
+            drawCircle(
+                color = stateColor,
+                radius = nodeRadius,
+                center = Offset(cx, cy),
+                alpha = fillAlpha
+            )
+
+            // Processing shimmer (pulse phase)
+            if (agent.state == AgentActivityState.PROCESSING) {
+                val shimmerAlpha = (sin(agent.pulsePhase * 2 * PI.toFloat()) + 1f) / 4f
                 drawCircle(
-                    color = stateColor,
-                    radius = nodeRadius,
+                    color = Color.White,
+                    radius = nodeRadius * 0.8f,
                     center = Offset(cx, cy),
-                    alpha = 0.9f
+                    alpha = shimmerAlpha * fillAlpha
                 )
-
-                // Processing shimmer (pulse phase)
-                if (agent.state == AgentActivityState.PROCESSING) {
-                    val shimmerAlpha = (sin(agent.pulsePhase * 2 * PI.toFloat()) + 1f) / 4f
-                    drawCircle(
-                        color = Color.White,
-                        radius = nodeRadius * 0.8f,
-                        center = Offset(cx, cy),
-                        alpha = shimmerAlpha
-                    )
-                }
             }
         }
     }

--- a/ampere-compose/src/commonMain/kotlin/link/socket/ampere/compose/CognitiveCanvas.kt
+++ b/ampere-compose/src/commonMain/kotlin/link/socket/ampere/compose/CognitiveCanvas.kt
@@ -7,16 +7,19 @@ import androidx.compose.ui.Modifier
 import link.socket.ampere.animation.agent.AgentLayer
 import link.socket.ampere.animation.flow.FlowLayer
 import link.socket.ampere.animation.particle.ParticleSystem
+import link.socket.ampere.animation.projection.Camera
 import link.socket.ampere.animation.substrate.SubstrateState
+import link.socket.ampere.animation.waveform.CognitiveWaveform
 
 /**
  * Primary composable for rendering AMPERE's cognitive visualization.
  *
  * Composites all animation layers onto a Compose Canvas:
  * - Layer 0: Substrate density field (background)
+ * - Layer 0.5: Waveform gradient mesh (optional, when waveform + camera provided)
  * - Layer 1: Flow connections between agents
  * - Layer 2: Particles (events, trails, ambient)
- * - Layer 3: Agent nodes
+ * - Layer 3: Agent nodes (depth-sorted when camera provided)
  *
  * The same animation state that drives the terminal TUI is rendered here
  * through Compose Canvas/DrawScope — same brain, different eyes.
@@ -25,6 +28,11 @@ import link.socket.ampere.animation.substrate.SubstrateState
  * @param particles Current particle system
  * @param agents Current agent layer
  * @param flow Current flow layer (optional)
+ * @param camera Camera for 3D depth projection (optional). When provided,
+ *   agents are depth-sorted and scaled by distance, and the waveform
+ *   gradient mesh is rendered as a background surface.
+ * @param waveform Cognitive waveform for gradient mesh rendering (optional).
+ *   Only rendered when both camera and waveform are provided.
  * @param modifier Compose modifier
  */
 @Composable
@@ -33,6 +41,8 @@ fun CognitiveCanvas(
     particles: ParticleSystem,
     agents: AgentLayer,
     flow: FlowLayer? = null,
+    camera: Camera? = null,
+    waveform: CognitiveWaveform? = null,
     modifier: Modifier = Modifier
 ) {
     Canvas(modifier = modifier.fillMaxSize()) {
@@ -42,6 +52,11 @@ fun CognitiveCanvas(
         // Layer 0: Substrate density field
         SubstrateCanvasRenderer.render(this, substrate, cellWidth, cellHeight)
 
+        // Layer 0.5: Waveform gradient mesh (3D surface as colored background)
+        if (waveform != null && camera != null) {
+            WaveformCanvasRenderer.render(this, waveform, agents, camera)
+        }
+
         // Layer 1: Flow connections between agents
         flow?.let {
             FlowCanvasRenderer.render(this, it, cellWidth, cellHeight)
@@ -50,7 +65,7 @@ fun CognitiveCanvas(
         // Layer 2: Particles
         ParticleCanvasRenderer.render(this, particles, cellWidth, cellHeight)
 
-        // Layer 3: Agent nodes
-        AgentCanvasRenderer.render(this, agents, cellWidth, cellHeight)
+        // Layer 3: Agent nodes (depth-projected when camera available)
+        AgentCanvasRenderer.render(this, agents, cellWidth, cellHeight, camera)
     }
 }

--- a/ampere-compose/src/commonMain/kotlin/link/socket/ampere/compose/WaveformCanvasRenderer.kt
+++ b/ampere-compose/src/commonMain/kotlin/link/socket/ampere/compose/WaveformCanvasRenderer.kt
@@ -1,0 +1,148 @@
+package link.socket.ampere.compose
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import link.socket.ampere.animation.agent.AgentLayer
+import link.socket.ampere.animation.agent.CognitivePhase
+import link.socket.ampere.animation.projection.Camera
+import link.socket.ampere.animation.projection.ScreenProjector
+import link.socket.ampere.animation.waveform.CognitiveWaveform
+import kotlin.math.sqrt
+
+/**
+ * Renders the [CognitiveWaveform] as a colored gradient mesh on a Compose Canvas.
+ *
+ * Height maps to brightness (higher peaks are brighter), and the nearest
+ * agent's cognitive phase maps to hue — creating a subtle, ambient landscape
+ * behind the agent nodes. Think of it as a heat-map of cognitive activity
+ * rendered as a smooth surface.
+ */
+object WaveformCanvasRenderer {
+
+    /** Maximum alpha for the gradient mesh to keep it as a subtle background. */
+    private const val MAX_ALPHA = 0.35f
+
+    /** Minimum alpha — even flat regions get a hint of color. */
+    private const val MIN_ALPHA = 0.03f
+
+    /**
+     * Render the waveform surface as a gradient mesh.
+     *
+     * @param drawScope The Compose DrawScope to render into
+     * @param waveform The cognitive waveform heightmap
+     * @param agents Agent layer for phase-based coloring
+     * @param camera Camera for 3D-to-2D projection
+     */
+    fun render(
+        drawScope: DrawScope,
+        waveform: CognitiveWaveform,
+        agents: AgentLayer,
+        camera: Camera
+    ) {
+        val canvasWidth = drawScope.size.width
+        val canvasHeight = drawScope.size.height
+
+        val projector = ScreenProjector(
+            screenWidth = canvasWidth.toInt().coerceAtLeast(1),
+            screenHeight = canvasHeight.toInt().coerceAtLeast(1),
+            charAspect = 1.0f
+        )
+
+        // Compute height range for normalization
+        var minHeight = Float.MAX_VALUE
+        var maxHeight = Float.MIN_VALUE
+        for (gz in 0 until waveform.gridDepth) {
+            for (gx in 0 until waveform.gridWidth) {
+                val h = waveform.heightAt(gx, gz)
+                if (h < minHeight) minHeight = h
+                if (h > maxHeight) maxHeight = h
+            }
+        }
+        val heightRange = (maxHeight - minHeight).coerceAtLeast(0.01f)
+
+        // Pre-compute agent positions for phase lookup
+        val agentPositions = agents.allAgents.map { agent ->
+            Triple(agent.position.x, agent.position.y, agent.cognitivePhase)
+        }
+
+        // Render each grid cell as a colored rectangle
+        with(drawScope) {
+            for (gz in 0 until waveform.gridDepth) {
+                for (gx in 0 until waveform.gridWidth) {
+                    val worldPos = waveform.worldPosition(gx, gz)
+                    val (screenX, screenY, depth) = projector.projectContinuous(worldPos, camera)
+
+                    // Skip points outside the visible area
+                    if (depth !in 0f..1f) continue
+                    if (screenX < -canvasWidth * 0.1f || screenX > canvasWidth * 1.1f) continue
+                    if (screenY < -canvasHeight * 0.1f || screenY > canvasHeight * 1.1f) continue
+
+                    // Normalized height (0 = lowest, 1 = highest)
+                    val normalizedHeight = ((waveform.heightAt(gx, gz) - minHeight) / heightRange)
+                        .coerceIn(0f, 1f)
+
+                    // Find dominant phase at this position (nearest agent)
+                    val phase = dominantPhaseAt(
+                        worldPos.x, worldPos.z, agentPositions
+                    )
+                    val baseColor = CognitivePalette.forPhase(phase)
+
+                    // Height → brightness: higher peaks are brighter
+                    val alpha = (MIN_ALPHA + (MAX_ALPHA - MIN_ALPHA) * normalizedHeight)
+
+                    // Depth-based fade: farther cells are dimmer
+                    val depthFade = 1f - depth.coerceIn(0f, 1f) * 0.5f
+
+                    // Cell size in screen space — approximate from grid resolution
+                    val cellScreenWidth = canvasWidth / waveform.gridWidth * 1.2f
+                    val cellScreenHeight = canvasHeight / waveform.gridDepth * 1.2f
+
+                    drawRect(
+                        color = baseColor,
+                        topLeft = Offset(screenX - cellScreenWidth / 2, screenY - cellScreenHeight / 2),
+                        size = Size(cellScreenWidth, cellScreenHeight),
+                        alpha = (alpha * depthFade).coerceIn(0f, 1f)
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     * Find the dominant cognitive phase at a world position based on
+     * inverse-distance weighting from nearby agents.
+     */
+    private fun dominantPhaseAt(
+        worldX: Float,
+        worldZ: Float,
+        agentPositions: List<Triple<Float, Float, CognitivePhase>>
+    ): CognitivePhase {
+        if (agentPositions.isEmpty()) return CognitivePhase.NONE
+
+        var bestPhase = CognitivePhase.NONE
+        var bestWeight = 0f
+
+        val phaseWeights = mutableMapOf<CognitivePhase, Float>()
+
+        for ((ax, az, phase) in agentPositions) {
+            val dx = worldX - ax
+            val dz = worldZ - az
+            val dist = sqrt(dx * dx + dz * dz)
+
+            // Smooth falloff: weight = 1 / (1 + dist^2)
+            val weight = 1f / (1f + dist * dist * 0.1f)
+            phaseWeights[phase] = (phaseWeights[phase] ?: 0f) + weight
+        }
+
+        for ((phase, weight) in phaseWeights) {
+            if (weight > bestWeight) {
+                bestWeight = weight
+                bestPhase = phase
+            }
+        }
+
+        return bestPhase
+    }
+}


### PR DESCRIPTION
## Summary
- **Wire FlowLayer into waveform pipeline**: `WatchStateAnimationBridge` now owns a `FlowLayer` with auto-managed connections between active agents, passed through `HybridDashboardRenderer` to `WaveformPaneRenderer` (was always `null`)
- **Activate 3D layout**: Switch agent layout from `HORIZONTAL` to `CIRCULAR` so agents distribute in the XZ plane with meaningful 3D positions for the waveform surface
- **Connect waveformPane as center pane**: `AmpereCommand` now uses `hybridRenderer.waveformPane` as the middle pane when available, replacing the flat progress pane with the 3D waveform
- **Depth-based Compose agent rendering** (Ticket 9.1): `AgentCanvasRenderer` accepts an optional `Camera` — agents are projected from 3D, sorted back-to-front, with radius and opacity scaled by depth for parallax effect
- **Waveform gradient mesh** (Ticket 9.2): New `WaveformCanvasRenderer` renders `CognitiveWaveform` as a colored gradient surface on the Compose Canvas — height maps to brightness, nearest agent phase maps to hue

## Test plan
- [ ] Run `./gradlew jvmTest` to verify existing tests pass
- [ ] Launch CLI TUI and verify waveform renders in center pane with agent peaks
- [ ] Verify flow ridges appear between active agents on the waveform
- [ ] Launch Compose Desktop and verify depth-scaled agent nodes (near=large, far=small)
- [ ] Verify waveform gradient mesh renders as subtle background in Compose view

🤖 Generated with [Claude Code](https://claude.com/claude-code)