### PR TITLE
Add waveform demo timeline and CLI demo command

### DIFF
--- a/ampere-animation/src/commonMain/kotlin/link/socket/ampere/animation/timeline/WaveformDemoTimeline.kt
+++ b/ampere-animation/src/commonMain/kotlin/link/socket/ampere/animation/timeline/WaveformDemoTimeline.kt
@@ -1,0 +1,281 @@
+package link.socket.ampere.animation.timeline
+
+import link.socket.ampere.animation.agent.AgentActivityState
+import link.socket.ampere.animation.agent.AgentLayer
+import link.socket.ampere.animation.agent.AgentVisualState
+import link.socket.ampere.animation.agent.CognitivePhase
+import link.socket.ampere.animation.emitter.EmitterEffect
+import link.socket.ampere.animation.emitter.EmitterManager
+import link.socket.ampere.animation.flow.FlowLayer
+import link.socket.ampere.animation.math.Vector3
+import link.socket.ampere.animation.render.CognitiveColorRamp
+import link.socket.ampere.animation.substrate.Vector2
+
+/**
+ * Builds a scripted timeline demonstrating the 3D waveform's full visual range.
+ *
+ * The sequence exercises every rendering capability across eight phases:
+ *
+ * 1. **Silence** (2s): Empty surface with gentle Perlin undulation, camera orbiting.
+ * 2. **Spark Arrives** (2s): First agent spawns with SparkBurst + HeightPulse.
+ *    Surface bulges upward. PERCEIVE palette (cool blues).
+ * 3. **Memory Activation** (2s): Agent enters RECALL. ColorWash with warm amber
+ *    spreading from center. Surface settles into new shape.
+ * 4. **Planning** (3s): Agent enters PLAN. Surface shows competing ridges.
+ *    Second agent spawns at different depth. PLAN palette (teal, structured).
+ * 5. **Delegation** (2s): Flow connection forms between agents. Ridge rises.
+ *    SparkBurst at receiving agent.
+ * 6. **Execution** (3s): Both agents in EXECUTE. Surface peaks sharply.
+ *    EXECUTE palette (red to yellow to white). Dense characters, high energy.
+ * 7. **Completion** (2s): Task completes. Confetti at both agents.
+ *    Surface gradually settles.
+ * 8. **Reflection** (2s): EVALUATE phase. EVALUATE palette (purple, diffuse).
+ *    Surface returns to gentle undulation. Camera continues orbiting.
+ *
+ * Suitable for recording the demo GIF showing the 3D cognitive waveform in action.
+ */
+object WaveformDemoTimeline {
+
+    /** World-space position for Spark (center of the waveform surface). */
+    private val SPARK_WORLD_POS = Vector2(10f, 7.5f)
+
+    /** World-space position for Jazz (right-forward, different depth). */
+    private val JAZZ_WORLD_POS = Vector2(14f, 5f)
+
+    /** 3D position for Spark (centered, slight elevation). */
+    private val SPARK_3D = Vector3(SPARK_WORLD_POS.x, 0f, SPARK_WORLD_POS.y)
+
+    /** 3D position for Jazz (offset, different depth plane). */
+    private val JAZZ_3D = Vector3(JAZZ_WORLD_POS.x, 0f, JAZZ_WORLD_POS.y)
+
+    /**
+     * Build the waveform demo timeline.
+     *
+     * @param agents The agent layer to populate during the timeline
+     * @param flow The flow layer for inter-agent connections
+     * @param emitters The emitter manager for firing visual effects
+     * @return A timeline with 8 phases totaling 18 seconds
+     */
+    fun build(
+        agents: AgentLayer,
+        flow: FlowLayer,
+        emitters: EmitterManager
+    ): Timeline = timeline {
+
+        // Phase 1: Silence — empty surface, gentle Perlin undulation, camera orbiting
+        phase("silence", 2.0) {
+            // No agents, no effects. The waveform shows only substrate noise
+            // and the camera orbit provides the dimensionality cue.
+        }
+
+        // Phase 2: Spark Arrives — first agent spawns with visual burst
+        phase("spark-arrives", 2.0) {
+            onStart {
+                agents.addAgent(
+                    AgentVisualState(
+                        id = "spark",
+                        name = "Spark",
+                        role = "reasoning",
+                        position = SPARK_WORLD_POS,
+                        position3D = SPARK_3D,
+                        state = AgentActivityState.SPAWNING,
+                    )
+                )
+                // SparkBurst: concentric rings expanding outward
+                emitters.emit(EmitterEffect.SparkBurst(), SPARK_3D)
+                // HeightPulse: surface bulges upward at agent center
+                emitters.emit(EmitterEffect.HeightPulse(), SPARK_3D)
+            }
+            atProgress(0.5f) {
+                agents.updateAgentState("spark", AgentActivityState.PROCESSING)
+                agents.updateAgentCognitivePhase("spark", CognitivePhase.PERCEIVE)
+            }
+            atProgress(0.8f) {
+                // ColorWash with PERCEIVE palette (cool blues)
+                emitters.emit(
+                    EmitterEffect.ColorWash(colorRamp = CognitiveColorRamp.PERCEIVE),
+                    SPARK_3D
+                )
+            }
+        }
+
+        // Phase 3: Memory Activation — RECALL phase with warm amber wash
+        phase("memory-activation", 2.0) {
+            onStart {
+                agents.updateAgentCognitivePhase("spark", CognitivePhase.RECALL)
+                // ColorWash with RECALL palette (warm amber spreading from center)
+                emitters.emit(
+                    EmitterEffect.ColorWash(
+                        duration = 1.8f,
+                        radius = 10f,
+                        colorRamp = CognitiveColorRamp.RECALL,
+                        waveFrontSpeed = 5f
+                    ),
+                    SPARK_3D
+                )
+            }
+            atProgress(0.6f) {
+                // Subtle HeightPulse as memory settles into shape
+                emitters.emit(
+                    EmitterEffect.HeightPulse(
+                        duration = 1.0f,
+                        radius = 5f,
+                        maxHeightBoost = 2f
+                    ),
+                    SPARK_3D
+                )
+            }
+        }
+
+        // Phase 4: Planning — competing ridges, second agent spawns
+        phase("planning", 3.0) {
+            onStart {
+                agents.updateAgentCognitivePhase("spark", CognitivePhase.PLAN)
+                // ColorWash with PLAN palette (teal, structured)
+                emitters.emit(
+                    EmitterEffect.ColorWash(colorRamp = CognitiveColorRamp.PLAN),
+                    SPARK_3D
+                )
+            }
+            at(1.0) {
+                // Second agent spawns at different depth
+                agents.addAgent(
+                    AgentVisualState(
+                        id = "jazz",
+                        name = "Jazz",
+                        role = "codegen",
+                        position = JAZZ_WORLD_POS,
+                        position3D = JAZZ_3D,
+                        state = AgentActivityState.SPAWNING,
+                    )
+                )
+                emitters.emit(EmitterEffect.SparkBurst(), JAZZ_3D)
+                emitters.emit(EmitterEffect.HeightPulse(), JAZZ_3D)
+            }
+            at(2.0) {
+                agents.updateAgentState("jazz", AgentActivityState.PROCESSING)
+                agents.updateAgentCognitivePhase("jazz", CognitivePhase.PLAN)
+            }
+        }
+
+        // Phase 5: Delegation — flow connection, ridge between agents
+        phase("delegation", 2.0) {
+            onStart {
+                // Create connection and start handoff
+                flow.createConnectionsFromAgents(agents, listOf("spark" to "jazz"))
+                flow.startHandoff("spark", "jazz")
+            }
+            atProgress(0.5f) {
+                // SparkBurst at receiving agent when delegation arrives
+                emitters.emit(
+                    EmitterEffect.SparkBurst(
+                        duration = 1.0f,
+                        radius = 4f,
+                        expansionSpeed = 6f
+                    ),
+                    JAZZ_3D
+                )
+            }
+        }
+
+        // Phase 6: Execution — both agents active, high energy, dense characters
+        phase("execution", 3.0) {
+            onStart {
+                agents.updateAgentCognitivePhase("spark", CognitivePhase.EXECUTE)
+                agents.updateAgentCognitivePhase("jazz", CognitivePhase.EXECUTE)
+                // ColorWash with EXECUTE palette (red->yellow->white)
+                emitters.emit(
+                    EmitterEffect.ColorWash(
+                        duration = 2.0f,
+                        radius = 12f,
+                        colorRamp = CognitiveColorRamp.EXECUTE,
+                        waveFrontSpeed = 8f
+                    ),
+                    SPARK_3D
+                )
+            }
+            at(0.5) {
+                // HeightPulse at both agents — surface peaks sharply
+                emitters.emit(
+                    EmitterEffect.HeightPulse(
+                        duration = 2.0f,
+                        radius = 5f,
+                        maxHeightBoost = 4f,
+                        riseSpeed = 6f
+                    ),
+                    SPARK_3D
+                )
+                emitters.emit(
+                    EmitterEffect.HeightPulse(
+                        duration = 2.0f,
+                        radius = 5f,
+                        maxHeightBoost = 4f,
+                        riseSpeed = 6f
+                    ),
+                    JAZZ_3D
+                )
+            }
+            at(2.0) {
+                // Turbulence during peak execution for visual intensity
+                emitters.emit(
+                    EmitterEffect.Turbulence(
+                        duration = 1.5f,
+                        radius = 8f,
+                        noiseAmplitude = 1.0f
+                    ),
+                    Vector3(
+                        (SPARK_3D.x + JAZZ_3D.x) / 2f,
+                        0f,
+                        (SPARK_3D.z + JAZZ_3D.z) / 2f
+                    )
+                )
+            }
+        }
+
+        // Phase 7: Completion — confetti, surface settles
+        phase("completion", 2.0) {
+            onStart {
+                agents.updateAgentCognitivePhase("spark", CognitivePhase.LOOP)
+                agents.updateAgentCognitivePhase("jazz", CognitivePhase.LOOP)
+                agents.updateAgentState("spark", AgentActivityState.COMPLETE)
+                agents.updateAgentState("jazz", AgentActivityState.COMPLETE)
+                // Confetti at both agents
+                emitters.emit(EmitterEffect.Confetti(duration = 1.5f, radius = 4f), SPARK_3D)
+                emitters.emit(EmitterEffect.Confetti(duration = 1.5f, radius = 4f), JAZZ_3D)
+            }
+        }
+
+        // Phase 8: Reflection — EVALUATE palette, surface returns to gentle undulation
+        phase("reflection", 2.0) {
+            onStart {
+                agents.updateAgentCognitivePhase("spark", CognitivePhase.EVALUATE)
+                agents.updateAgentCognitivePhase("jazz", CognitivePhase.EVALUATE)
+                agents.updateAgentState("spark", AgentActivityState.IDLE)
+                agents.updateAgentState("jazz", AgentActivityState.IDLE)
+                // ColorWash with EVALUATE palette (purple, diffuse)
+                emitters.emit(
+                    EmitterEffect.ColorWash(
+                        duration = 2.0f,
+                        radius = 12f,
+                        colorRamp = CognitiveColorRamp.EVALUATE,
+                        waveFrontSpeed = 4f
+                    ),
+                    Vector3(
+                        (SPARK_3D.x + JAZZ_3D.x) / 2f,
+                        0f,
+                        (SPARK_3D.z + JAZZ_3D.z) / 2f
+                    )
+                )
+            }
+        }
+    }
+
+    /** Expected phase names in order. */
+    val PHASE_NAMES = listOf(
+        "silence", "spark-arrives", "memory-activation", "planning",
+        "delegation", "execution", "completion", "reflection"
+    )
+
+    /** Total expected duration in seconds. */
+    const val TOTAL_DURATION_SECONDS = 18.0
+}

--- a/ampere-animation/src/commonTest/kotlin/link/socket/ampere/animation/timeline/WaveformDemoTimelineTest.kt
+++ b/ampere-animation/src/commonTest/kotlin/link/socket/ampere/animation/timeline/WaveformDemoTimelineTest.kt
@@ -1,0 +1,229 @@
+package link.socket.ampere.animation.timeline
+
+import link.socket.ampere.animation.agent.AgentActivityState
+import link.socket.ampere.animation.agent.AgentLayer
+import link.socket.ampere.animation.agent.AgentLayoutOrientation
+import link.socket.ampere.animation.agent.CognitivePhase
+import link.socket.ampere.animation.emitter.EmitterManager
+import link.socket.ampere.animation.flow.FlowLayer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class WaveformDemoTimelineTest {
+
+    private fun createComponents(): Triple<AgentLayer, FlowLayer, EmitterManager> {
+        val agents = AgentLayer(80, 40, AgentLayoutOrientation.CIRCULAR)
+        val flow = FlowLayer(80, 40)
+        val emitters = EmitterManager()
+        return Triple(agents, flow, emitters)
+    }
+
+    private fun createTimeline(): Timeline {
+        val (agents, flow, emitters) = createComponents()
+        return WaveformDemoTimeline.build(agents, flow, emitters)
+    }
+
+    @Test
+    fun `timeline builds successfully`() {
+        val timeline = createTimeline()
+        assertTrue(timeline.phaseCount > 0)
+    }
+
+    @Test
+    fun `timeline has correct number of phases`() {
+        val timeline = createTimeline()
+        assertEquals(8, timeline.phaseCount)
+    }
+
+    @Test
+    fun `timeline has correct total duration`() {
+        val timeline = createTimeline()
+        val expectedDuration = WaveformDemoTimeline.TOTAL_DURATION_SECONDS.seconds
+        assertEquals(expectedDuration, timeline.totalDuration)
+    }
+
+    @Test
+    fun `phase ordering matches expected sequence`() {
+        val timeline = createTimeline()
+        val phaseNames = timeline.phases.map { it.name }
+        assertEquals(WaveformDemoTimeline.PHASE_NAMES, phaseNames)
+    }
+
+    @Test
+    fun `all expected phases are present`() {
+        val timeline = createTimeline()
+        for (name in WaveformDemoTimeline.PHASE_NAMES) {
+            assertNotNull(timeline.getPhase(name), "Missing phase: $name")
+        }
+    }
+
+    @Test
+    fun `silence phase has 2 second duration`() {
+        val timeline = createTimeline()
+        val silence = timeline.getPhase("silence")
+        assertNotNull(silence)
+        assertEquals(2.seconds, silence.duration)
+    }
+
+    @Test
+    fun `execution phase has 3 second duration`() {
+        val timeline = createTimeline()
+        val execute = timeline.getPhase("execution")
+        assertNotNull(execute)
+        assertEquals(3.seconds, execute.duration)
+    }
+
+    @Test
+    fun `planning phase has 3 second duration`() {
+        val timeline = createTimeline()
+        val plan = timeline.getPhase("planning")
+        assertNotNull(plan)
+        assertEquals(3.seconds, plan.duration)
+    }
+
+    @Test
+    fun `spark-arrives phase spawns agent and fires effects`() {
+        val (agents, flow, emitters) = createComponents()
+        val timeline = WaveformDemoTimeline.build(agents, flow, emitters)
+
+        assertEquals(0, agents.agentCount, "No agents before timeline starts")
+        assertEquals(0, emitters.activeCount, "No effects before timeline starts")
+
+        // Fire the spark-arrives onStart
+        timeline.phases[1].onStart?.invoke()
+
+        assertEquals(1, agents.agentCount, "Spark should be added")
+        assertNotNull(agents.getAgent("spark"))
+        assertTrue(emitters.activeCount >= 2, "SparkBurst + HeightPulse effects should be active")
+    }
+
+    @Test
+    fun `planning phase spawns second agent`() {
+        val (agents, flow, emitters) = createComponents()
+        val timeline = WaveformDemoTimeline.build(agents, flow, emitters)
+
+        // Fire spark-arrives to add first agent
+        timeline.phases[1].onStart?.invoke()
+        assertEquals(1, agents.agentCount)
+
+        // Fire planning onStart (sets phase) then keyframe at 1s (adds Jazz)
+        timeline.phases[3].onStart?.invoke()
+
+        // Fire keyframe at 1.0s — Jazz spawns
+        val planPhase = timeline.phases[3]
+        val spawnKeyframe = planPhase.keyframes.find {
+            it.time == 1000.milliseconds
+        }
+        assertNotNull(spawnKeyframe, "Should have keyframe at 1s for Jazz spawn")
+        spawnKeyframe.action()
+
+        assertEquals(2, agents.agentCount, "Jazz should be added")
+        assertNotNull(agents.getAgent("jazz"))
+    }
+
+    @Test
+    fun `delegation phase creates flow connection`() {
+        val (agents, flow, emitters) = createComponents()
+        val timeline = WaveformDemoTimeline.build(agents, flow, emitters)
+
+        // Set up agents first
+        timeline.phases[1].onStart?.invoke()  // spark-arrives
+        timeline.phases[3].onStart?.invoke()  // planning onStart
+        timeline.phases[3].keyframes[0].action()  // Jazz spawns at 1s
+
+        assertEquals(0, flow.connectionCount, "No connections before delegation")
+
+        // Fire delegation onStart
+        timeline.phases[4].onStart?.invoke()
+
+        assertEquals(1, flow.connectionCount, "Connection should be created")
+    }
+
+    @Test
+    fun `completion phase fires confetti and completes agents`() {
+        val (agents, flow, emitters) = createComponents()
+        val timeline = WaveformDemoTimeline.build(agents, flow, emitters)
+
+        // Set up agents
+        timeline.phases[1].onStart?.invoke()
+        timeline.phases[3].keyframes[0].action()
+
+        val emitterCountBefore = emitters.activeCount
+
+        // Fire completion onStart
+        timeline.phases[6].onStart?.invoke()
+
+        assertTrue(emitters.activeCount > emitterCountBefore, "Confetti effects should be active")
+        assertEquals(AgentActivityState.COMPLETE, agents.getAgent("spark")?.state)
+        assertEquals(AgentActivityState.COMPLETE, agents.getAgent("jazz")?.state)
+    }
+
+    @Test
+    fun `reflection phase sets EVALUATE cognitive phase`() {
+        val (agents, flow, emitters) = createComponents()
+        val timeline = WaveformDemoTimeline.build(agents, flow, emitters)
+
+        // Set up agents
+        timeline.phases[1].onStart?.invoke()
+        timeline.phases[3].keyframes[0].action()
+
+        // Fire reflection onStart
+        timeline.phases[7].onStart?.invoke()
+
+        assertEquals(CognitivePhase.EVALUATE, agents.getAgent("spark")?.cognitivePhase)
+        assertEquals(CognitivePhase.EVALUATE, agents.getAgent("jazz")?.cognitivePhase)
+    }
+
+    @Test
+    fun `full timeline plays through via controller without errors`() {
+        val (agents, flow, emitters) = createComponents()
+        val timeline = WaveformDemoTimeline.build(agents, flow, emitters)
+        val controller = TimelineController(timeline)
+
+        controller.play()
+
+        // Simulate stepping through the full timeline at ~30fps
+        val stepMs = 33f
+        val totalSteps = (WaveformDemoTimeline.TOTAL_DURATION_SECONDS * 1000 / stepMs).toInt() + 10
+
+        for (i in 0..totalSteps) {
+            if (controller.isCompleted) break
+            controller.update(stepMs / 1000f)
+        }
+
+        assertTrue(controller.isCompleted, "Timeline should complete after full duration")
+        assertEquals(2, agents.agentCount, "Both agents should be present")
+    }
+
+    @Test
+    fun `execution phase keyframes fire effects at both agents`() {
+        val (agents, flow, emitters) = createComponents()
+        val timeline = WaveformDemoTimeline.build(agents, flow, emitters)
+
+        // Set up agents
+        timeline.phases[1].onStart?.invoke()
+        timeline.phases[3].keyframes[0].action()
+
+        // Fire execution onStart
+        timeline.phases[5].onStart?.invoke()
+
+        val countAfterOnStart = emitters.activeCount
+
+        // Fire the 0.5s keyframe (HeightPulse at both agents)
+        val execPhase = timeline.phases[5]
+        val pulseKeyframe = execPhase.keyframes.find {
+            it.time == 500.milliseconds
+        }
+        assertNotNull(pulseKeyframe, "Should have keyframe at 0.5s")
+        pulseKeyframe.action()
+
+        assertTrue(
+            emitters.activeCount > countAfterOnStart,
+            "HeightPulse effects should fire at both agents"
+        )
+    }
+}

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/AmpereCommand.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/AmpereCommand.kt
@@ -102,6 +102,7 @@ class AmpereCommand(
           work         Autonomous headless work on issues
           respond      Respond to agent input requests
           test         Headless automated tests
+          demo         Run visual demos (e.g., ampere demo waveform)
     """.trimIndent()
 ) {
 

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/DemoCommand.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/DemoCommand.kt
@@ -1,0 +1,180 @@
+package link.socket.ampere
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.subcommands
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.float
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.runBlocking
+import link.socket.ampere.animation.agent.AgentLayer
+import link.socket.ampere.animation.agent.AgentLayoutOrientation
+import link.socket.ampere.animation.emitter.CognitiveEmitterBridge
+import link.socket.ampere.animation.emitter.EmitterManager
+import link.socket.ampere.animation.flow.FlowLayer
+import link.socket.ampere.animation.substrate.SubstrateState
+import link.socket.ampere.animation.timeline.PlaybackState
+import link.socket.ampere.animation.timeline.TimelineController
+import link.socket.ampere.animation.timeline.TimelineEvent
+import link.socket.ampere.animation.timeline.WaveformDemoTimeline
+import link.socket.ampere.cli.render.WaveformPaneRenderer
+import link.socket.ampere.repl.TerminalFactory
+
+/**
+ * Container command for demo subcommands.
+ *
+ * Usage:
+ *   ampere demo waveform         Run 3D waveform cognitive cycle demo
+ *   ampere demo waveform --loop  Loop the demo continuously
+ *   ampere demo waveform --speed 0.5  Run at half speed
+ */
+class DemoCommand : CliktCommand(
+    name = "demo",
+    help = "Run visual demos without a live LLM connection"
+) {
+    init {
+        subcommands(WaveformDemoSubcommand())
+    }
+
+    override fun run() = Unit
+}
+
+/**
+ * Runs the 3D cognitive waveform demo sequence in the terminal.
+ *
+ * The demo exercises the full visual range of the waveform renderer:
+ * agent spawning, phase transitions, emitter effects, flow delegation,
+ * and completion — all with an orbiting 3D camera.
+ */
+class WaveformDemoSubcommand : CliktCommand(
+    name = "waveform",
+    help = "Run 3D cognitive waveform demo (18s sequence)"
+) {
+    private val speed by option("--speed", "-s", help = "Playback speed multiplier (default 1.0)")
+        .float().default(1.0f)
+
+    private val loop by option("--loop", "-l", help = "Loop the demo continuously")
+        .flag(default = false)
+
+    override fun run() = runBlocking {
+        val caps = TerminalFactory.getCapabilities()
+        val width = caps.width.coerceAtLeast(40)
+        val height = caps.height.coerceAtLeast(10)
+        val contentHeight = height - 2 // Reserve 2 lines for status bar
+
+        // Create shared animation components
+        val agents = AgentLayer(width, contentHeight, AgentLayoutOrientation.CIRCULAR)
+        val flow = FlowLayer(width, contentHeight)
+        val emitters = EmitterManager()
+        val emitterBridge = CognitiveEmitterBridge(emitters)
+        val substrate = SubstrateState.create(width, contentHeight, baseDensity = 0.2f)
+
+        // Create waveform renderer
+        val waveformPane = WaveformPaneRenderer(
+            agentLayer = agents,
+            emitterManager = emitters,
+            cognitiveEmitterBridge = emitterBridge
+        )
+
+        // Build timeline and controller
+        var timeline = WaveformDemoTimeline.build(agents, flow, emitters)
+        var controller = TimelineController(timeline)
+
+        // Track current phase name for status bar
+        var currentPhaseName = ""
+        controller.addEventListener { event ->
+            when (event) {
+                is TimelineEvent.PhaseStarted -> currentPhaseName = event.phase.name
+                else -> {}
+            }
+        }
+        controller.changeSpeed(speed)
+
+        // Terminal setup
+        val out = System.out
+        out.print("\u001B[?1049h") // Enter alternate screen buffer
+        out.print("\u001B[?25l")   // Hide cursor
+        out.print("\u001B[2J")     // Clear screen
+        out.flush()
+
+        val frameIntervalMs = 50L // 20 FPS
+        val dt = (frameIntervalMs / 1000f) * speed
+
+        try {
+            controller.play()
+
+            while (isActive) {
+                // Update timeline
+                controller.update(frameIntervalMs / 1000f)
+
+                // Update waveform renderer state
+                waveformPane.update(substrate, flow, dt)
+
+                // Render the waveform
+                val lines = waveformPane.render(width, contentHeight)
+
+                // Build status bar
+                val progress = (controller.progress * 100).toInt()
+                val phaseDisplay = currentPhaseName.replace('-', ' ')
+                val speedDisplay = if (speed != 1.0f) " ${speed}x" else ""
+                val loopDisplay = if (loop) " [loop]" else ""
+                val statusLine = "\u001B[38;5;45m[$progress%]\u001B[0m " +
+                    "\u001B[38;5;226m$phaseDisplay\u001B[0m" +
+                    "\u001B[38;5;240m ·$speedDisplay$loopDisplay · q to exit\u001B[0m"
+                val separator = "\u001B[38;5;236m${"─".repeat(width)}\u001B[0m"
+
+                // Output frame
+                val frame = buildString {
+                    append("\u001B[H") // Move cursor to home
+                    for (line in lines) {
+                        append(line)
+                        append("\n")
+                    }
+                    append(separator)
+                    append("\n")
+                    append(statusLine)
+                }
+                out.print(frame)
+                out.flush()
+
+                // Check for completion
+                if (controller.isCompleted) {
+                    if (loop) {
+                        // Reset everything for next loop
+                        agents.clear()
+                        flow.clear()
+                        emitters.clear()
+                        timeline = WaveformDemoTimeline.build(agents, flow, emitters)
+                        controller = TimelineController(timeline)
+                        controller.changeSpeed(speed)
+                        controller.addEventListener { event ->
+                            when (event) {
+                                is TimelineEvent.PhaseStarted -> currentPhaseName = event.phase.name
+                                else -> {}
+                            }
+                        }
+                        currentPhaseName = ""
+                        controller.play()
+                    } else {
+                        // Show completion for a beat then exit
+                        delay(1500)
+                        break
+                    }
+                }
+
+                delay(frameIntervalMs)
+            }
+        } catch (_: Exception) {
+            // Handle Ctrl+C or other interrupts gracefully
+        } finally {
+            // Restore terminal
+            out.print("\u001B[2J")       // Clear screen
+            out.print("\u001B[H")        // Move cursor to home
+            out.print("\u001B[?25h")     // Show cursor
+            out.print("\u001B[?1049l")   // Exit alternate screen buffer
+            out.flush()
+        }
+    }
+}

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/Main.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/Main.kt
@@ -130,6 +130,7 @@ fun main(args: Array<String>) {
                 RespondCommand(),
                 WorkCommand { context },
                 TestCommand(),
+                DemoCommand(),
             )
             .main(filteredArgs)
     } finally {

--- a/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/DemoCommandTest.kt
+++ b/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/DemoCommandTest.kt
@@ -1,0 +1,201 @@
+package link.socket.ampere
+
+import link.socket.ampere.animation.agent.AgentLayer
+import link.socket.ampere.animation.agent.AgentLayoutOrientation
+import link.socket.ampere.animation.emitter.CognitiveEmitterBridge
+import link.socket.ampere.animation.emitter.EmitterManager
+import link.socket.ampere.animation.flow.FlowLayer
+import link.socket.ampere.animation.substrate.SubstrateState
+import link.socket.ampere.animation.timeline.TimelineController
+import link.socket.ampere.animation.timeline.TimelineEvent
+import link.socket.ampere.animation.timeline.WaveformDemoTimeline
+import link.socket.ampere.cli.render.WaveformPaneRenderer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for the waveform demo pipeline — verifying that the timeline,
+ * renderer, and emitter components integrate correctly for the demo command.
+ */
+class DemoCommandTest {
+
+    private fun createDemoPipeline(): DemoPipeline {
+        val width = 60
+        val height = 30
+        val agents = AgentLayer(width, height, AgentLayoutOrientation.CIRCULAR)
+        val flow = FlowLayer(width, height)
+        val emitters = EmitterManager()
+        val emitterBridge = CognitiveEmitterBridge(emitters)
+        val substrate = SubstrateState.create(width, height, baseDensity = 0.2f)
+
+        val waveformPane = WaveformPaneRenderer(
+            agentLayer = agents,
+            emitterManager = emitters,
+            cognitiveEmitterBridge = emitterBridge
+        )
+
+        val timeline = WaveformDemoTimeline.build(agents, flow, emitters)
+        val controller = TimelineController(timeline)
+
+        return DemoPipeline(
+            agents = agents,
+            flow = flow,
+            emitters = emitters,
+            substrate = substrate,
+            waveformPane = waveformPane,
+            controller = controller,
+            width = width,
+            height = height
+        )
+    }
+
+    data class DemoPipeline(
+        val agents: AgentLayer,
+        val flow: FlowLayer,
+        val emitters: EmitterManager,
+        val substrate: SubstrateState,
+        val waveformPane: WaveformPaneRenderer,
+        val controller: TimelineController,
+        val width: Int,
+        val height: Int
+    )
+
+    @Test
+    fun `demo pipeline renders initial frame without errors`() {
+        val pipeline = createDemoPipeline()
+
+        pipeline.waveformPane.update(pipeline.substrate, pipeline.flow, 0.033f)
+        val lines = pipeline.waveformPane.render(pipeline.width, pipeline.height)
+
+        assertEquals(pipeline.height, lines.size, "Should produce exactly height lines")
+    }
+
+    @Test
+    fun `demo runs through full timeline rendering each frame`() {
+        val pipeline = createDemoPipeline()
+        val dt = 0.05f // 20 FPS
+        var frameCount = 0
+
+        pipeline.controller.play()
+
+        val totalSteps = (WaveformDemoTimeline.TOTAL_DURATION_SECONDS / dt).toInt() + 10
+
+        for (i in 0..totalSteps) {
+            if (pipeline.controller.isCompleted) break
+
+            pipeline.controller.update(dt)
+            pipeline.waveformPane.update(pipeline.substrate, pipeline.flow, dt)
+
+            val lines = pipeline.waveformPane.render(pipeline.width, pipeline.height)
+            assertEquals(pipeline.height, lines.size, "Frame $frameCount: Should have correct height")
+            frameCount++
+        }
+
+        assertTrue(pipeline.controller.isCompleted, "Timeline should complete")
+        assertTrue(frameCount > 50, "Should render many frames (got $frameCount)")
+    }
+
+    @Test
+    fun `demo populates agents during playback`() {
+        val pipeline = createDemoPipeline()
+
+        assertEquals(0, pipeline.agents.agentCount, "No agents before start")
+
+        pipeline.controller.play()
+
+        // Advance past spark-arrives phase (starts at 2s)
+        advanceTimeline(pipeline, 3.0f)
+
+        assertTrue(pipeline.agents.agentCount >= 1, "At least Spark should be present")
+        assertNotNull(pipeline.agents.getAgent("spark"))
+    }
+
+    @Test
+    fun `demo creates flow connections during delegation phase`() {
+        val pipeline = createDemoPipeline()
+
+        pipeline.controller.play()
+
+        // Advance past delegation phase start (silence=2 + spark=2 + memory=2 + planning=3 = 9s)
+        advanceTimeline(pipeline, 10.0f)
+
+        assertTrue(pipeline.flow.connectionCount >= 1, "Should have flow connection")
+    }
+
+    @Test
+    fun `demo fires emitter effects during playback`() {
+        val pipeline = createDemoPipeline()
+        var effectsFired = false
+
+        pipeline.controller.play()
+
+        // Advance to spark-arrives where effects fire
+        val dt = 0.05f
+        val stepsToSparkArrives = (2.5f / dt).toInt()
+
+        for (i in 0..stepsToSparkArrives) {
+            pipeline.controller.update(dt)
+            pipeline.emitters.update(dt)
+            if (pipeline.emitters.activeCount > 0) {
+                effectsFired = true
+            }
+        }
+
+        assertTrue(effectsFired, "Emitter effects should fire during spark-arrives phase")
+    }
+
+    @Test
+    fun `demo timeline tracks phase transitions`() {
+        val pipeline = createDemoPipeline()
+        val phaseNames = mutableListOf<String>()
+
+        pipeline.controller.addEventListener { event ->
+            when (event) {
+                is TimelineEvent.PhaseStarted -> phaseNames.add(event.phase.name)
+                else -> {}
+            }
+        }
+
+        pipeline.controller.play()
+        advanceTimeline(pipeline, WaveformDemoTimeline.TOTAL_DURATION_SECONDS.toFloat() + 1f)
+
+        assertEquals(
+            WaveformDemoTimeline.PHASE_NAMES,
+            phaseNames,
+            "All phases should fire in order"
+        )
+    }
+
+    @Test
+    fun `rendered lines have correct width`() {
+        val pipeline = createDemoPipeline()
+
+        pipeline.controller.play()
+        advanceTimeline(pipeline, 5.0f) // Middle of the demo
+
+        pipeline.waveformPane.update(pipeline.substrate, pipeline.flow, 0.033f)
+        val lines = pipeline.waveformPane.render(pipeline.width, pipeline.height)
+
+        for ((i, line) in lines.withIndex()) {
+            // Strip ANSI codes to check visible width
+            val visible = line.replace(Regex("\u001B\\[[0-9;]*[a-zA-Z]"), "")
+            assertEquals(
+                pipeline.width,
+                visible.length,
+                "Line $i visible width should match requested width"
+            )
+        }
+    }
+
+    private fun advanceTimeline(pipeline: DemoPipeline, seconds: Float) {
+        val dt = 0.05f
+        val steps = (seconds / dt).toInt()
+        for (i in 0..steps) {
+            if (pipeline.controller.isCompleted) break
+            pipeline.controller.update(dt)
+            pipeline.emitters.update(dt)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- **WaveformDemoTimeline**: Scripted 18-second, 8-phase timeline exercising the full 3D waveform visual range — silence, spark arrival, memory activation, planning, delegation, execution, completion, and reflection — with emitter effects (SparkBurst, HeightPulse, ColorWash, Turbulence, Confetti) at each stage
- **DemoCommand**: New `ampere demo waveform` CLI subcommand that runs the timeline in a full-screen TUI render loop with `--speed` and `--loop` options, requiring no live LLM connection
- Wired into Main.kt subcommands and updated AmpereCommand help text

## Test plan
- [x] WaveformDemoTimelineTest: phase count, durations, ordering, agent population, flow connections, emitter firing, full controller playback
- [x] DemoCommandTest: end-to-end pipeline integration — rendering frames, agent lifecycle, flow creation, effect firing, phase tracking, output dimensions

🤖 Generated with [Claude Code](https://claude.com/claude-code)