### PR TITLE
Add Bayer ordered dithering to ASCII waveform renderer

### DIFF
--- a/ampere-animation/src/commonMain/kotlin/link/socket/ampere/animation/render/AsciiCell.kt
+++ b/ampere-animation/src/commonMain/kotlin/link/socket/ampere/animation/render/AsciiCell.kt
@@ -46,5 +46,40 @@ data class AsciiCell(
                 bold = isBold
             )
         }
+
+        /**
+         * Build a cell from surface lighting parameters with ordered dithering.
+         *
+         * Screen coordinates drive the Bayer matrix pattern, breaking up
+         * banding in both character selection and color.
+         *
+         * @param luminance 0.0 (dark) to 1.0 (bright)
+         * @param normalX Horizontal surface normal component (-1.0 to 1.0)
+         * @param normalY Vertical surface normal component (-1.0 to 1.0)
+         * @param screenX Horizontal screen coordinate
+         * @param screenY Vertical screen coordinate
+         * @param palette Character palette for this phase
+         * @param colorRamp Color ramp for this phase
+         * @return A fully resolved AsciiCell with dithered character and color
+         */
+        fun fromSurfaceDithered(
+            luminance: Float,
+            normalX: Float,
+            normalY: Float,
+            screenX: Int,
+            screenY: Int,
+            palette: AsciiLuminancePalette,
+            colorRamp: CognitiveColorRamp
+        ): AsciiCell {
+            val ch = palette.charForSurfaceDithered(luminance, normalX, normalY, screenX, screenY)
+            val fg = colorRamp.colorForLuminanceDithered(luminance, screenX, screenY)
+            val isBold = luminance > 0.8f
+            return AsciiCell(
+                char = ch,
+                fgColor = fg,
+                bgColor = null,
+                bold = isBold
+            )
+        }
     }
 }

--- a/ampere-animation/src/commonMain/kotlin/link/socket/ampere/animation/render/BayerDither.kt
+++ b/ampere-animation/src/commonMain/kotlin/link/socket/ampere/animation/render/BayerDither.kt
@@ -1,0 +1,44 @@
+package link.socket.ampere.animation.render
+
+/**
+ * Ordered dithering using a 4x4 Bayer matrix.
+ *
+ * Ordered dithering breaks up banding artifacts in the luminance-to-character
+ * quantization. At each screen cell, the fractional part of the scaled luminance
+ * is compared against a spatially-varying threshold from the Bayer matrix.
+ * This decides whether to round up or down to the adjacent palette entry,
+ * producing a stippled mix that simulates intermediate brightness levels.
+ *
+ * The 4x4 Bayer matrix is tileable and produces a visually pleasing,
+ * non-repetitive pattern well suited to ASCII art scales.
+ */
+object BayerDither {
+
+    /**
+     * 4x4 Bayer threshold matrix, values 0-15.
+     * Each entry represents the order in which that position "turns on"
+     * as brightness increases.
+     */
+    private val BAYER_4X4 = intArrayOf(
+         0,  8,  2, 10,
+        12,  4, 14,  6,
+         3, 11,  1,  9,
+        15,  7, 13,  5
+    )
+
+    /**
+     * Get the Bayer threshold for a screen position, normalized to [0, 1).
+     *
+     * Used for ordered dithering: compare the fractional part of a scaled
+     * value against this threshold to decide whether to round up or down.
+     *
+     * @param screenX Horizontal screen coordinate
+     * @param screenY Vertical screen coordinate
+     * @return Threshold in [0, 15/16], 16 distinct evenly-spaced values
+     */
+    fun threshold(screenX: Int, screenY: Int): Float {
+        val x = screenX and 3 // mod 4
+        val y = screenY and 3
+        return BAYER_4X4[y * 4 + x] / 16f
+    }
+}

--- a/ampere-animation/src/commonMain/kotlin/link/socket/ampere/animation/render/CognitiveColorRamp.kt
+++ b/ampere-animation/src/commonMain/kotlin/link/socket/ampere/animation/render/CognitiveColorRamp.kt
@@ -32,6 +32,27 @@ data class CognitiveColorRamp(
         return colorStops[index]
     }
 
+    /**
+     * Get the ANSI 256-color code with ordered dithering.
+     *
+     * Applies Bayer matrix dithering to break up color banding between
+     * adjacent color stops.
+     *
+     * @param luminance 0.0 (dark) to 1.0 (bright), clamped internally
+     * @param screenX Horizontal screen coordinate (for dither pattern)
+     * @param screenY Vertical screen coordinate (for dither pattern)
+     * @return ANSI 256-color code
+     */
+    fun colorForLuminanceDithered(luminance: Float, screenX: Int, screenY: Int): Int {
+        val clamped = luminance.coerceIn(0f, 1f)
+        val scaled = clamped * lastIndex
+        val base = scaled.toInt().coerceIn(0, lastIndex)
+        if (base >= lastIndex) return colorStops[lastIndex]
+        val frac = scaled - base
+        val index = if (frac > BayerDither.threshold(screenX, screenY)) base + 1 else base
+        return colorStops[index]
+    }
+
     companion object {
         /** Cool blues -> white (sensory, exploratory) */
         val PERCEIVE = CognitiveColorRamp(

--- a/ampere-animation/src/commonTest/kotlin/link/socket/ampere/animation/render/AsciiCellTest.kt
+++ b/ampere-animation/src/commonTest/kotlin/link/socket/ampere/animation/render/AsciiCellTest.kt
@@ -113,6 +113,71 @@ class AsciiCellTest {
         assertNull(cell.bgColor)
     }
 
+    // --- Dithered fromSurface ---
+
+    @Test
+    fun `fromSurfaceDithered produces valid cell`() {
+        val cell = AsciiCell.fromSurfaceDithered(
+            luminance = 0.5f,
+            normalX = 0f,
+            normalY = 0f,
+            screenX = 2,
+            screenY = 3,
+            palette = AsciiLuminancePalette.STANDARD,
+            colorRamp = CognitiveColorRamp.PERCEIVE
+        )
+        assertNotEquals(' ', cell.char)
+        assertNull(cell.bgColor)
+    }
+
+    @Test
+    fun `fromSurfaceDithered respects bold threshold`() {
+        val notBold = AsciiCell.fromSurfaceDithered(
+            luminance = 0.79f,
+            normalX = 0f,
+            normalY = 0f,
+            screenX = 0,
+            screenY = 0,
+            palette = AsciiLuminancePalette.STANDARD,
+            colorRamp = CognitiveColorRamp.PERCEIVE
+        )
+        val isBold = AsciiCell.fromSurfaceDithered(
+            luminance = 0.81f,
+            normalX = 0f,
+            normalY = 0f,
+            screenX = 0,
+            screenY = 0,
+            palette = AsciiLuminancePalette.STANDARD,
+            colorRamp = CognitiveColorRamp.PERCEIVE
+        )
+        assertFalse(notBold.bold)
+        assertTrue(isBold.bold)
+    }
+
+    @Test
+    fun `fromSurfaceDithered produces variation across screen positions`() {
+        // At a luminance near a boundary, different positions should give different results
+        val cells = mutableSetOf<Char>()
+        for (y in 0..3) {
+            for (x in 0..3) {
+                cells.add(
+                    AsciiCell.fromSurfaceDithered(
+                        luminance = 0.45f,
+                        normalX = 0f,
+                        normalY = 0f,
+                        screenX = x,
+                        screenY = y,
+                        palette = AsciiLuminancePalette.STANDARD,
+                        colorRamp = CognitiveColorRamp.NEUTRAL
+                    ).char
+                )
+            }
+        }
+        assert(cells.size >= 2) {
+            "Dithered cells should vary across screen positions, got $cells"
+        }
+    }
+
     @Test
     fun `different phases produce different cells at same luminance`() {
         val perceiveCell = AsciiCell.fromSurface(

--- a/ampere-animation/src/commonTest/kotlin/link/socket/ampere/animation/render/BayerDitherTest.kt
+++ b/ampere-animation/src/commonTest/kotlin/link/socket/ampere/animation/render/BayerDitherTest.kt
@@ -1,0 +1,78 @@
+package link.socket.ampere.animation.render
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class BayerDitherTest {
+
+    @Test
+    fun `threshold values are in valid range`() {
+        for (y in 0..3) {
+            for (x in 0..3) {
+                val t = BayerDither.threshold(x, y)
+                assertTrue(t >= 0f, "threshold($x, $y) = $t < 0")
+                assertTrue(t < 1f, "threshold($x, $y) = $t >= 1")
+            }
+        }
+    }
+
+    @Test
+    fun `matrix tiles at period 4`() {
+        for (y in 0..3) {
+            for (x in 0..3) {
+                assertEquals(
+                    BayerDither.threshold(x, y),
+                    BayerDither.threshold(x + 4, y + 4),
+                    "threshold not periodic at ($x, $y)"
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `all 16 thresholds are distinct`() {
+        val values = mutableSetOf<Float>()
+        for (y in 0..3) {
+            for (x in 0..3) {
+                values.add(BayerDither.threshold(x, y))
+            }
+        }
+        assertEquals(16, values.size, "Bayer 4x4 should produce 16 distinct thresholds")
+    }
+
+    @Test
+    fun `thresholds are evenly spaced`() {
+        val values = mutableListOf<Float>()
+        for (y in 0..3) {
+            for (x in 0..3) {
+                values.add(BayerDither.threshold(x, y))
+            }
+        }
+        values.sort()
+        // Should be 0/16, 1/16, 2/16, ..., 15/16
+        for (i in values.indices) {
+            assertEquals(i / 16f, values[i], "threshold at sorted position $i")
+        }
+    }
+
+    @Test
+    fun `adjacent cells get different thresholds`() {
+        assertNotEquals(BayerDither.threshold(0, 0), BayerDither.threshold(1, 0))
+        assertNotEquals(BayerDither.threshold(0, 0), BayerDither.threshold(0, 1))
+        assertNotEquals(BayerDither.threshold(1, 1), BayerDither.threshold(2, 1))
+    }
+
+    @Test
+    fun `negative coordinates produce valid threshold`() {
+        val t = BayerDither.threshold(-1, -1)
+        assertTrue(t >= 0f && t < 1f, "Negative coords should produce valid threshold, got $t")
+    }
+
+    @Test
+    fun `origin threshold is zero`() {
+        // Bayer matrix entry 0 is at position (0,0)
+        assertEquals(0f, BayerDither.threshold(0, 0))
+    }
+}

--- a/ampere-animation/src/commonTest/kotlin/link/socket/ampere/animation/render/CognitiveColorRampTest.kt
+++ b/ampere-animation/src/commonTest/kotlin/link/socket/ampere/animation/render/CognitiveColorRampTest.kt
@@ -108,6 +108,36 @@ class CognitiveColorRampTest {
         }
     }
 
+    // --- Dithered color selection ---
+
+    @Test
+    fun `dithered color extremes are stable`() {
+        val ramp = CognitiveColorRamp.PERCEIVE
+        for (y in 0..3) {
+            for (x in 0..3) {
+                assertEquals(ramp.colorStops.first(), ramp.colorForLuminanceDithered(0.0f, x, y))
+                assertEquals(ramp.colorStops.last(), ramp.colorForLuminanceDithered(1.0f, x, y))
+            }
+        }
+    }
+
+    @Test
+    fun `dithered color produces variation at boundary`() {
+        val ramp = CognitiveColorRamp.EXECUTE
+        // Near a color stop boundary, dithering should produce at least 2 different colors
+        val step = 1f / ramp.colorStops.lastIndex
+        val boundaryLuminance = step * 3 + step * 0.5f // midway between stops 3 and 4
+        val colors = mutableSetOf<Int>()
+        for (y in 0..3) {
+            for (x in 0..3) {
+                colors.add(ramp.colorForLuminanceDithered(boundaryLuminance, x, y))
+            }
+        }
+        assert(colors.size >= 2) {
+            "Dithering at color boundary should produce at least 2 colors, got $colors"
+        }
+    }
+
     @Test
     fun `different phases produce different colors at same luminance`() {
         val perceiveColor = CognitiveColorRamp.PERCEIVE.colorForLuminance(0.5f)


### PR DESCRIPTION
## Summary
- Adds 4x4 Bayer matrix ordered dithering to break up luminance banding in the 3D ASCII shading
- At palette/color-stop boundaries, adjacent screen cells now stipple between neighboring entries instead of showing hard quantization steps
- Dithering applied to both character selection (`AsciiLuminancePalette`) and color selection (`CognitiveColorRamp`), wired through the full rasterizer pipeline including emitter effects

## Test plan
- [x] `BayerDitherTest` — matrix properties (range, periodicity, distinctness, spacing)
- [x] `AsciiLuminancePaletteTest` — dithered extremes stable, mid-luminance variation, edge chars preserved, single-char palette stable
- [x] `AsciiCellTest` — dithered cell creation, bold threshold, variation across positions
- [x] `CognitiveColorRampTest` — dithered color extremes stable, boundary variation
- [ ] Visual verification in TUI demo

🤖 Generated with [Claude Code](https://claude.com/claude-code)