### PR TITLE
Fix infinite test hang in JLine terminal tests

### DIFF
--- a/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/repl/MultiStageProgressTest.kt
+++ b/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/repl/MultiStageProgressTest.kt
@@ -4,7 +4,8 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.jline.terminal.Terminal
-import org.jline.terminal.TerminalBuilder
+import org.jline.terminal.impl.DumbTerminal
+import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import kotlin.test.assertTrue
 
@@ -16,10 +17,7 @@ class MultiStageProgressTest {
     @BeforeEach
     fun setup() {
         outputStream = ByteArrayOutputStream()
-        terminal = TerminalBuilder.builder()
-            .system(false)
-            .streams(System.`in`, outputStream)
-            .build()
+        terminal = DumbTerminal(ByteArrayInputStream(ByteArray(0)), outputStream)
     }
 
     @AfterEach

--- a/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/repl/ProgressIndicatorTest.kt
+++ b/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/repl/ProgressIndicatorTest.kt
@@ -5,8 +5,9 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.jline.terminal.Terminal
-import org.jline.terminal.TerminalBuilder
 import org.jline.terminal.Size
+import org.jline.terminal.impl.DumbTerminal
+import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.PrintWriter
 import kotlin.test.assertEquals
@@ -34,10 +35,7 @@ class ProgressIndicatorTest {
     @BeforeEach
     fun setup() {
         outputStream = ByteArrayOutputStream()
-        terminal = TerminalBuilder.builder()
-            .system(false)
-            .streams(System.`in`, outputStream)
-            .build()
+        terminal = DumbTerminal(ByteArrayInputStream(ByteArray(0)), outputStream)
         writer = terminal.writer()
 
         // Reset TerminalFactory for consistent tests


### PR DESCRIPTION
## Summary
- Replaced `TerminalBuilder` with `DumbTerminal` in test setup to avoid JLine's native PTY provider system
- This resolves the infinite loop issue where `./gradlew :ampere-cli:jvmTest` would hang indefinitely
- Tests now complete in under 10 seconds consistently

## Root Cause
JLine's `TerminalBuilder` was wrapping `System.in` in a `PosixPtyTerminal` despite `system(false)` being set. When the Gradle test executor (which has no real terminal) tried to close this native PTY, `FileDescriptor.close0()` would block forever.

## Changes
- **MultiStageProgressTest**: Use `DumbTerminal(ByteArrayInputStream(ByteArray(0)), outputStream)` instead of TerminalBuilder
- **ProgressIndicatorTest**: Use `DumbTerminal(ByteArrayInputStream(ByteArray(0)), outputStream)` instead of TerminalBuilder

## Test Results
✅ All 446 tests pass in ~10 seconds (previously would hang indefinitely)

🤖 Generated with [Claude Code](https://claude.com/claude-code)