### PR TITLE
Suppress SQLite JDBC native access warnings in CLI launcher

### DIFF
--- a/ampere-cli/build.gradle.kts
+++ b/ampere-cli/build.gradle.kts
@@ -140,6 +140,11 @@ tasks.named<Test>("jvmTest") {
     useJUnitPlatform()
 }
 
+// Allow SQLite JDBC (and other libs) to call restricted native methods without warnings
+tasks.named<CreateStartScripts>("startScriptsForJvm") {
+    defaultJvmOpts = listOf("--enable-native-access=ALL-UNNAMED")
+}
+
 // Wire installDist to installJvmDist so the familiar command works
 tasks.named("installDist") {
     dependsOn("installJvmDist")


### PR DESCRIPTION
Configure the startScriptsForJvm Gradle task to include the --enable-native-access=ALL-UNNAMED JVM option. This suppresses warnings from the SQLite JDBC driver about restricted native method access, which will be blocked in future Java versions unless native access is explicitly enabled.