### PR TITLE
AMPR-137 GH#419: Add unit tests for ampere-compose renderers

### DIFF
--- a/ampere-compose/src/commonMain/kotlin/link/socket/ampere/compose/AgentCanvasRenderer.kt
+++ b/ampere-compose/src/commonMain/kotlin/link/socket/ampere/compose/AgentCanvasRenderer.kt
@@ -26,6 +26,37 @@ import kotlin.math.sin
  */
 object AgentCanvasRenderer {
 
+    /** Map depth (0=near, 1=far) to a factor (1=near, 0=far). */
+    internal fun depthFactor(depth: Float): Float = 1f - depth.coerceIn(0f, 1f)
+
+    /** Scale node radius by depth: near agents are full-size, far agents are half. */
+    internal fun nodeRadius(baseRadius: Float, depthFactor: Float): Float =
+        baseRadius * (0.5f + 0.5f * depthFactor)
+
+    /** Outer ring alpha: active phases are brighter, NONE phase is dim. */
+    internal fun ringAlpha(depthFactor: Float, phase: CognitivePhase): Float =
+        if (phase != CognitivePhase.NONE) {
+            0.3f + 0.5f * depthFactor
+        } else {
+            0.1f + 0.1f * depthFactor
+        }
+
+    /** Inner fill alpha scaled by depth. */
+    internal fun fillAlpha(depthFactor: Float): Float = 0.4f + 0.5f * depthFactor
+
+    /** Processing shimmer alpha oscillating in [0, 0.5]. */
+    internal fun shimmerAlpha(pulsePhase: Float): Float =
+        (sin(pulsePhase * 2 * PI.toFloat()) + 1f) / 4f
+
+    /** Map agent activity state to its display color. */
+    internal fun colorForState(state: AgentActivityState): Color = when (state) {
+        AgentActivityState.IDLE -> CognitivePalette.agentIdle
+        AgentActivityState.ACTIVE -> CognitivePalette.agentActive
+        AgentActivityState.PROCESSING -> CognitivePalette.agentProcessing
+        AgentActivityState.COMPLETE -> CognitivePalette.agentComplete
+        AgentActivityState.SPAWNING -> CognitivePalette.agentIdle
+    }
+
     /**
      * Render all agents with optional 3D depth-based scaling.
      *
@@ -109,18 +140,14 @@ object AgentCanvasRenderer {
 
         with(drawScope) {
             for ((cx, cy, depth, agent) in projected) {
-                // Depth factor: near (depth≈0) → 1.0, far (depth≈1) → 0.0
-                val depthFactor = 1f - depth.coerceIn(0f, 1f)
-
-                val nodeRadius = baseRadius * (0.5f + 0.5f * depthFactor)
-                val ringAlpha = if (agent.cognitivePhase != CognitivePhase.NONE) {
-                    0.3f + 0.5f * depthFactor
-                } else {
-                    0.1f + 0.1f * depthFactor
-                }
-                val fillAlpha = 0.4f + 0.5f * depthFactor
-
-                drawAgentNode(this, cx, cy, nodeRadius, ringAlpha, fillAlpha, agent)
+                val df = depthFactor(depth)
+                drawAgentNode(
+                    this, cx, cy,
+                    nodeRadius(baseRadius, df),
+                    ringAlpha(df, agent.cognitivePhase),
+                    fillAlpha(df),
+                    agent
+                )
             }
         }
     }
@@ -149,16 +176,8 @@ object AgentCanvasRenderer {
             )
 
             // Inner fill: agent state color
-            val stateColor = when (agent.state) {
-                AgentActivityState.IDLE -> CognitivePalette.agentIdle
-                AgentActivityState.ACTIVE -> CognitivePalette.agentActive
-                AgentActivityState.PROCESSING -> CognitivePalette.agentProcessing
-                AgentActivityState.COMPLETE -> CognitivePalette.agentComplete
-                AgentActivityState.SPAWNING -> CognitivePalette.agentIdle
-            }
-
             drawCircle(
-                color = stateColor,
+                color = colorForState(agent.state),
                 radius = nodeRadius,
                 center = Offset(cx, cy),
                 alpha = fillAlpha
@@ -166,12 +185,11 @@ object AgentCanvasRenderer {
 
             // Processing shimmer (pulse phase)
             if (agent.state == AgentActivityState.PROCESSING) {
-                val shimmerAlpha = (sin(agent.pulsePhase * 2 * PI.toFloat()) + 1f) / 4f
                 drawCircle(
                     color = Color.White,
                     radius = nodeRadius * 0.8f,
                     center = Offset(cx, cy),
-                    alpha = shimmerAlpha * fillAlpha
+                    alpha = shimmerAlpha(agent.pulsePhase) * fillAlpha
                 )
             }
         }

--- a/ampere-compose/src/commonMain/kotlin/link/socket/ampere/compose/FlowCanvasRenderer.kt
+++ b/ampere-compose/src/commonMain/kotlin/link/socket/ampere/compose/FlowCanvasRenderer.kt
@@ -1,6 +1,7 @@
 package link.socket.ampere.compose
 
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
@@ -14,6 +15,22 @@ import link.socket.ampere.animation.flow.FlowState
  * showing active handoffs between agents.
  */
 object FlowCanvasRenderer {
+
+    /** Map flow state to its display color. */
+    internal fun colorForFlowState(state: FlowState): Color = when (state) {
+        FlowState.DORMANT -> CognitivePalette.flowDormant
+        FlowState.ACTIVATING -> CognitivePalette.flowActive
+        FlowState.TRANSMITTING -> CognitivePalette.flowActive
+        FlowState.RECEIVED -> CognitivePalette.agentComplete
+    }
+
+    /** Map flow state to path alpha (visibility). */
+    internal fun alphaForFlowState(state: FlowState): Float = when (state) {
+        FlowState.DORMANT -> 0.15f
+        FlowState.ACTIVATING -> 0.4f
+        FlowState.TRANSMITTING -> 0.7f
+        FlowState.RECEIVED -> 0.5f
+    }
 
     /**
      * Render flow connections and active handoffs.
@@ -42,24 +59,10 @@ object FlowCanvasRenderer {
                     }
                 }
 
-                val pathColor = when (connection.state) {
-                    FlowState.DORMANT -> CognitivePalette.flowDormant
-                    FlowState.ACTIVATING -> CognitivePalette.flowActive
-                    FlowState.TRANSMITTING -> CognitivePalette.flowActive
-                    FlowState.RECEIVED -> CognitivePalette.agentComplete
-                }
-
-                val pathAlpha = when (connection.state) {
-                    FlowState.DORMANT -> 0.15f
-                    FlowState.ACTIVATING -> 0.4f
-                    FlowState.TRANSMITTING -> 0.7f
-                    FlowState.RECEIVED -> 0.5f
-                }
-
                 drawPath(
                     path = path,
-                    color = pathColor,
-                    alpha = pathAlpha,
+                    color = colorForFlowState(connection.state),
+                    alpha = alphaForFlowState(connection.state),
                     style = Stroke(width = 2f)
                 )
 

--- a/ampere-compose/src/commonMain/kotlin/link/socket/ampere/compose/ParticleCanvasRenderer.kt
+++ b/ampere-compose/src/commonMain/kotlin/link/socket/ampere/compose/ParticleCanvasRenderer.kt
@@ -16,6 +16,16 @@ import link.socket.ampere.animation.particle.ParticleType
  */
 object ParticleCanvasRenderer {
 
+    /** Compute particle radius from life and cell width. */
+    internal fun particleRadius(life: Float, cellWidth: Float): Float =
+        (life * 4f + 1f) * (cellWidth / 4)
+
+    /** Outer glow alpha scales linearly with life. */
+    internal fun glowAlpha(life: Float): Float = life * 0.2f
+
+    /** Core circle alpha scales linearly with life. */
+    internal fun coreAlpha(life: Float): Float = life * 0.8f
+
     /**
      * Render all alive particles.
      *
@@ -34,7 +44,7 @@ object ParticleCanvasRenderer {
             particles.getParticles().forEach { particle ->
                 val cx = particle.position.x * cellWidth + cellWidth / 2
                 val cy = particle.position.y * cellHeight + cellHeight / 2
-                val radius = (particle.life * 4f + 1f) * (cellWidth / 4)
+                val radius = particleRadius(particle.life, cellWidth)
                 val color = colorForParticle(particle)
 
                 // Glow effect: outer translucent circle
@@ -42,7 +52,7 @@ object ParticleCanvasRenderer {
                     color = color,
                     radius = radius * 2f,
                     center = Offset(cx, cy),
-                    alpha = particle.life * 0.2f
+                    alpha = glowAlpha(particle.life)
                 )
 
                 // Core: solid circle
@@ -50,13 +60,13 @@ object ParticleCanvasRenderer {
                     color = color,
                     radius = radius,
                     center = Offset(cx, cy),
-                    alpha = particle.life * 0.8f
+                    alpha = coreAlpha(particle.life)
                 )
             }
         }
     }
 
-    private fun colorForParticle(particle: Particle): Color {
+    internal fun colorForParticle(particle: Particle): Color {
         return when (particle.type) {
             ParticleType.MOTE -> CognitivePalette.substrateMid
             ParticleType.SPARK -> CognitivePalette.sparkAccent

--- a/ampere-compose/src/commonMain/kotlin/link/socket/ampere/compose/SubstrateCanvasRenderer.kt
+++ b/ampere-compose/src/commonMain/kotlin/link/socket/ampere/compose/SubstrateCanvasRenderer.kt
@@ -13,6 +13,12 @@ import link.socket.ampere.animation.substrate.SubstrateState
  */
 object SubstrateCanvasRenderer {
 
+    /** Threshold below which cells are not rendered. */
+    internal fun shouldRenderCell(density: Float): Boolean = density > 0.05f
+
+    /** Map density to alpha for rendering. */
+    internal fun cellAlpha(density: Float): Float = density * 0.6f
+
     /**
      * Render substrate density field.
      *
@@ -31,13 +37,12 @@ object SubstrateCanvasRenderer {
             for (y in 0 until substrate.height) {
                 for (x in 0 until substrate.width) {
                     val density = substrate.getDensity(x, y)
-                    if (density > 0.05f) {
-                        val color = CognitivePalette.forDensity(density)
+                    if (shouldRenderCell(density)) {
                         drawRect(
-                            color = color,
+                            color = CognitivePalette.forDensity(density),
                             topLeft = Offset(x * cellWidth, y * cellHeight),
                             size = Size(cellWidth, cellHeight),
-                            alpha = density * 0.6f
+                            alpha = cellAlpha(density)
                         )
                     }
                 }

--- a/ampere-compose/src/commonTest/kotlin/link/socket/ampere/compose/AgentCanvasRendererTest.kt
+++ b/ampere-compose/src/commonTest/kotlin/link/socket/ampere/compose/AgentCanvasRendererTest.kt
@@ -1,0 +1,172 @@
+package link.socket.ampere.compose
+
+import link.socket.ampere.animation.agent.AgentActivityState
+import link.socket.ampere.animation.agent.CognitivePhase
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AgentCanvasRendererTest {
+
+    // --- depthFactor ---
+
+    @Test
+    fun depthFactor_zero_depth_returns_one() {
+        assertEquals(1f, AgentCanvasRenderer.depthFactor(0f))
+    }
+
+    @Test
+    fun depthFactor_one_depth_returns_zero() {
+        assertEquals(0f, AgentCanvasRenderer.depthFactor(1f))
+    }
+
+    @Test
+    fun depthFactor_half_depth_returns_half() {
+        assertEquals(0.5f, AgentCanvasRenderer.depthFactor(0.5f))
+    }
+
+    @Test
+    fun depthFactor_negative_depth_clamped_to_one() {
+        assertEquals(1f, AgentCanvasRenderer.depthFactor(-0.5f))
+    }
+
+    @Test
+    fun depthFactor_above_one_clamped_to_zero() {
+        assertEquals(0f, AgentCanvasRenderer.depthFactor(1.5f))
+    }
+
+    // --- nodeRadius ---
+
+    @Test
+    fun nodeRadius_full_depth_factor_returns_full_base() {
+        assertEquals(10f, AgentCanvasRenderer.nodeRadius(10f, 1f))
+    }
+
+    @Test
+    fun nodeRadius_zero_depth_factor_returns_half_base() {
+        assertEquals(5f, AgentCanvasRenderer.nodeRadius(10f, 0f))
+    }
+
+    @Test
+    fun nodeRadius_half_depth_factor_returns_three_quarter_base() {
+        assertEquals(7.5f, AgentCanvasRenderer.nodeRadius(10f, 0.5f))
+    }
+
+    // --- ringAlpha ---
+
+    @Test
+    fun ringAlpha_active_phase_full_depth_returns_08() {
+        assertEquals(0.8f, AgentCanvasRenderer.ringAlpha(1f, CognitivePhase.EXECUTE))
+    }
+
+    @Test
+    fun ringAlpha_active_phase_zero_depth_returns_03() {
+        assertEquals(0.3f, AgentCanvasRenderer.ringAlpha(0f, CognitivePhase.PERCEIVE))
+    }
+
+    @Test
+    fun ringAlpha_none_phase_full_depth_returns_02() {
+        assertEquals(0.2f, AgentCanvasRenderer.ringAlpha(1f, CognitivePhase.NONE))
+    }
+
+    @Test
+    fun ringAlpha_none_phase_zero_depth_returns_01() {
+        assertEquals(0.1f, AgentCanvasRenderer.ringAlpha(0f, CognitivePhase.NONE))
+    }
+
+    @Test
+    fun ringAlpha_active_always_brighter_than_none() {
+        for (df in listOf(0f, 0.25f, 0.5f, 0.75f, 1f)) {
+            val active = AgentCanvasRenderer.ringAlpha(df, CognitivePhase.PLAN)
+            val none = AgentCanvasRenderer.ringAlpha(df, CognitivePhase.NONE)
+            assertTrue(active > none, "Active phase ring should be brighter than NONE at depthFactor=$df")
+        }
+    }
+
+    // --- fillAlpha ---
+
+    @Test
+    fun fillAlpha_full_depth_returns_09() {
+        assertEquals(0.9f, AgentCanvasRenderer.fillAlpha(1f))
+    }
+
+    @Test
+    fun fillAlpha_zero_depth_returns_04() {
+        assertEquals(0.4f, AgentCanvasRenderer.fillAlpha(0f))
+    }
+
+    // --- shimmerAlpha ---
+
+    @Test
+    fun shimmerAlpha_zero_phase_returns_025() {
+        assertApprox(0.25f, AgentCanvasRenderer.shimmerAlpha(0f))
+    }
+
+    @Test
+    fun shimmerAlpha_quarter_phase_returns_05() {
+        assertApprox(0.5f, AgentCanvasRenderer.shimmerAlpha(0.25f))
+    }
+
+    @Test
+    fun shimmerAlpha_half_phase_returns_025() {
+        assertApprox(0.25f, AgentCanvasRenderer.shimmerAlpha(0.5f))
+    }
+
+    @Test
+    fun shimmerAlpha_three_quarter_phase_returns_0() {
+        assertApprox(0f, AgentCanvasRenderer.shimmerAlpha(0.75f))
+    }
+
+    @Test
+    fun shimmerAlpha_range_always_between_0_and_05() {
+        for (i in 0..100) {
+            val phase = i / 100f
+            val alpha = AgentCanvasRenderer.shimmerAlpha(phase)
+            assertTrue(alpha >= -0.001f, "shimmerAlpha($phase) = $alpha should be >= 0")
+            assertTrue(alpha <= 0.501f, "shimmerAlpha($phase) = $alpha should be <= 0.5")
+        }
+    }
+
+    // --- colorForState ---
+
+    @Test
+    fun colorForState_idle_returns_agentIdle() {
+        assertEquals(CognitivePalette.agentIdle, AgentCanvasRenderer.colorForState(AgentActivityState.IDLE))
+    }
+
+    @Test
+    fun colorForState_active_returns_agentActive() {
+        assertEquals(CognitivePalette.agentActive, AgentCanvasRenderer.colorForState(AgentActivityState.ACTIVE))
+    }
+
+    @Test
+    fun colorForState_processing_returns_agentProcessing() {
+        assertEquals(
+            CognitivePalette.agentProcessing,
+            AgentCanvasRenderer.colorForState(AgentActivityState.PROCESSING),
+        )
+    }
+
+    @Test
+    fun colorForState_complete_returns_agentComplete() {
+        assertEquals(
+            CognitivePalette.agentComplete,
+            AgentCanvasRenderer.colorForState(AgentActivityState.COMPLETE),
+        )
+    }
+
+    @Test
+    fun colorForState_spawning_returns_agentIdle() {
+        assertEquals(CognitivePalette.agentIdle, AgentCanvasRenderer.colorForState(AgentActivityState.SPAWNING))
+    }
+
+    // --- helpers ---
+
+    private fun assertApprox(expected: Float, actual: Float, tolerance: Float = 0.001f) {
+        assertTrue(
+            abs(expected - actual) <= tolerance,
+            "Expected $expected but was $actual (tolerance $tolerance)",
+        )
+    }
+}

--- a/ampere-compose/src/commonTest/kotlin/link/socket/ampere/compose/FlowCanvasRendererTest.kt
+++ b/ampere-compose/src/commonTest/kotlin/link/socket/ampere/compose/FlowCanvasRendererTest.kt
@@ -1,0 +1,74 @@
+package link.socket.ampere.compose
+
+import link.socket.ampere.animation.flow.FlowState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class FlowCanvasRendererTest {
+
+    // --- colorForFlowState ---
+
+    @Test
+    fun colorForFlowState_dormant_returns_flowDormant() {
+        assertEquals(CognitivePalette.flowDormant, FlowCanvasRenderer.colorForFlowState(FlowState.DORMANT))
+    }
+
+    @Test
+    fun colorForFlowState_activating_returns_flowActive() {
+        assertEquals(CognitivePalette.flowActive, FlowCanvasRenderer.colorForFlowState(FlowState.ACTIVATING))
+    }
+
+    @Test
+    fun colorForFlowState_transmitting_returns_flowActive() {
+        assertEquals(CognitivePalette.flowActive, FlowCanvasRenderer.colorForFlowState(FlowState.TRANSMITTING))
+    }
+
+    @Test
+    fun colorForFlowState_received_returns_agentComplete() {
+        assertEquals(CognitivePalette.agentComplete, FlowCanvasRenderer.colorForFlowState(FlowState.RECEIVED))
+    }
+
+    // --- alphaForFlowState ---
+
+    @Test
+    fun alphaForFlowState_dormant_returns_015() {
+        assertEquals(0.15f, FlowCanvasRenderer.alphaForFlowState(FlowState.DORMANT))
+    }
+
+    @Test
+    fun alphaForFlowState_activating_returns_04() {
+        assertEquals(0.4f, FlowCanvasRenderer.alphaForFlowState(FlowState.ACTIVATING))
+    }
+
+    @Test
+    fun alphaForFlowState_transmitting_returns_07() {
+        assertEquals(0.7f, FlowCanvasRenderer.alphaForFlowState(FlowState.TRANSMITTING))
+    }
+
+    @Test
+    fun alphaForFlowState_received_returns_05() {
+        assertEquals(0.5f, FlowCanvasRenderer.alphaForFlowState(FlowState.RECEIVED))
+    }
+
+    @Test
+    fun alphaForFlowState_transmitting_is_highest() {
+        val transmitting = FlowCanvasRenderer.alphaForFlowState(FlowState.TRANSMITTING)
+        for (state in FlowState.entries) {
+            if (state != FlowState.TRANSMITTING) {
+                assertTrue(
+                    transmitting > FlowCanvasRenderer.alphaForFlowState(state),
+                    "TRANSMITTING alpha should be higher than $state",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun alphaForFlowState_all_values_in_valid_range() {
+        for (state in FlowState.entries) {
+            val alpha = FlowCanvasRenderer.alphaForFlowState(state)
+            assertTrue(alpha in 0f..1f, "$state alpha $alpha should be in [0, 1]")
+        }
+    }
+}

--- a/ampere-compose/src/commonTest/kotlin/link/socket/ampere/compose/ParticleCanvasRendererTest.kt
+++ b/ampere-compose/src/commonTest/kotlin/link/socket/ampere/compose/ParticleCanvasRendererTest.kt
@@ -1,0 +1,116 @@
+package link.socket.ampere.compose
+
+import link.socket.ampere.animation.particle.Particle
+import link.socket.ampere.animation.particle.ParticleType
+import link.socket.ampere.animation.substrate.Vector2
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ParticleCanvasRendererTest {
+
+    // --- colorForParticle ---
+
+    @Test
+    fun colorForParticle_mote_returns_substrateMid() {
+        val particle = makeParticle(ParticleType.MOTE)
+        assertEquals(CognitivePalette.substrateMid, ParticleCanvasRenderer.colorForParticle(particle))
+    }
+
+    @Test
+    fun colorForParticle_spark_returns_sparkAccent() {
+        val particle = makeParticle(ParticleType.SPARK)
+        assertEquals(CognitivePalette.sparkAccent, ParticleCanvasRenderer.colorForParticle(particle))
+    }
+
+    @Test
+    fun colorForParticle_trail_returns_flowToken() {
+        val particle = makeParticle(ParticleType.TRAIL)
+        assertEquals(CognitivePalette.flowToken, ParticleCanvasRenderer.colorForParticle(particle))
+    }
+
+    @Test
+    fun colorForParticle_ripple_returns_substrateBright() {
+        val particle = makeParticle(ParticleType.RIPPLE)
+        assertEquals(CognitivePalette.substrateBright, ParticleCanvasRenderer.colorForParticle(particle))
+    }
+
+    // --- particleRadius ---
+
+    @Test
+    fun particleRadius_zero_life_returns_quarter_cell() {
+        // (0 * 4 + 1) * (20 / 4) = 1 * 5 = 5
+        assertEquals(5f, ParticleCanvasRenderer.particleRadius(0f, 20f))
+    }
+
+    @Test
+    fun particleRadius_full_life_returns_expected() {
+        // (1 * 4 + 1) * (20 / 4) = 5 * 5 = 25
+        assertEquals(25f, ParticleCanvasRenderer.particleRadius(1f, 20f))
+    }
+
+    @Test
+    fun particleRadius_half_life_returns_expected() {
+        // (0.5 * 4 + 1) * (20 / 4) = 3 * 5 = 15
+        assertEquals(15f, ParticleCanvasRenderer.particleRadius(0.5f, 20f))
+    }
+
+    @Test
+    fun particleRadius_proportional_to_cell_width() {
+        val r1 = ParticleCanvasRenderer.particleRadius(0.5f, 10f)
+        val r2 = ParticleCanvasRenderer.particleRadius(0.5f, 20f)
+        assertEquals(r1 * 2, r2, "Radius should double when cellWidth doubles")
+    }
+
+    // --- glowAlpha ---
+
+    @Test
+    fun glowAlpha_full_life_returns_02() {
+        assertEquals(0.2f, ParticleCanvasRenderer.glowAlpha(1f))
+    }
+
+    @Test
+    fun glowAlpha_zero_life_returns_0() {
+        assertEquals(0f, ParticleCanvasRenderer.glowAlpha(0f))
+    }
+
+    @Test
+    fun glowAlpha_half_life_returns_01() {
+        assertEquals(0.1f, ParticleCanvasRenderer.glowAlpha(0.5f))
+    }
+
+    // --- coreAlpha ---
+
+    @Test
+    fun coreAlpha_full_life_returns_08() {
+        assertEquals(0.8f, ParticleCanvasRenderer.coreAlpha(1f))
+    }
+
+    @Test
+    fun coreAlpha_zero_life_returns_0() {
+        assertEquals(0f, ParticleCanvasRenderer.coreAlpha(0f))
+    }
+
+    @Test
+    fun coreAlpha_always_four_times_glow() {
+        for (life in listOf(0f, 0.1f, 0.25f, 0.5f, 0.75f, 1f)) {
+            val glow = ParticleCanvasRenderer.glowAlpha(life)
+            val core = ParticleCanvasRenderer.coreAlpha(life)
+            assertTrue(
+                kotlin.math.abs(core - glow * 4f) < 0.001f,
+                "coreAlpha should be 4x glowAlpha at life=$life",
+            )
+        }
+    }
+
+    // --- helpers ---
+
+    private fun makeParticle(type: ParticleType): Particle =
+        Particle(
+            position = Vector2(0f, 0f),
+            velocity = Vector2(0f, 0f),
+            life = 1f,
+            type = type,
+            glyph = '.',
+        )
+}

--- a/ampere-compose/src/commonTest/kotlin/link/socket/ampere/compose/SubstrateCanvasRendererTest.kt
+++ b/ampere-compose/src/commonTest/kotlin/link/socket/ampere/compose/SubstrateCanvasRendererTest.kt
@@ -1,0 +1,53 @@
+package link.socket.ampere.compose
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SubstrateCanvasRendererTest {
+
+    // --- shouldRenderCell ---
+
+    @Test
+    fun shouldRenderCell_zero_density_returns_false() {
+        assertFalse(SubstrateCanvasRenderer.shouldRenderCell(0f))
+    }
+
+    @Test
+    fun shouldRenderCell_below_threshold_returns_false() {
+        assertFalse(SubstrateCanvasRenderer.shouldRenderCell(0.03f))
+    }
+
+    @Test
+    fun shouldRenderCell_at_threshold_returns_false() {
+        assertFalse(SubstrateCanvasRenderer.shouldRenderCell(0.05f))
+    }
+
+    @Test
+    fun shouldRenderCell_above_threshold_returns_true() {
+        assertTrue(SubstrateCanvasRenderer.shouldRenderCell(0.06f))
+    }
+
+    @Test
+    fun shouldRenderCell_full_density_returns_true() {
+        assertTrue(SubstrateCanvasRenderer.shouldRenderCell(1f))
+    }
+
+    // --- cellAlpha ---
+
+    @Test
+    fun cellAlpha_zero_density_returns_zero() {
+        assertEquals(0f, SubstrateCanvasRenderer.cellAlpha(0f))
+    }
+
+    @Test
+    fun cellAlpha_full_density_returns_06() {
+        assertEquals(0.6f, SubstrateCanvasRenderer.cellAlpha(1f))
+    }
+
+    @Test
+    fun cellAlpha_half_density_returns_03() {
+        assertEquals(0.3f, SubstrateCanvasRenderer.cellAlpha(0.5f))
+    }
+}


### PR DESCRIPTION
## Summary

Extract pure calculation logic from Canvas renderers into testable internal functions, then add ~50 comprehensive unit tests covering all four renderers.

- **AgentCanvasRenderer**: depth scaling, alpha blending, shimmer effects, state→color mapping
- **FlowCanvasRenderer**: state→color and state→alpha mappings for all flow states
- **ParticleCanvasRenderer**: type→color, radius calculations, and alpha relationships
- **SubstrateCanvasRenderer**: density threshold and alpha calculations

Brings ampere-compose test total from 19 to ~71 tests. All tests pass. Closes #419.

🤖 Generated by Claude Opus 4.6