### PR TITLE
Fix Maven Central publish task and credentials configuration

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,18 +57,18 @@ jobs:
       - name: Publish to Maven Central
         if: ${{ github.event.inputs.dry_run != 'true' }}
         env:
-          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
-          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
-          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
-        run: ./gradlew :ampere-core:publishAllPublicationsToOssrhRepository
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
+        run: ./gradlew :ampere-core:publishAllPublicationsToMavenCentralRepository
 
       - name: Dry run publish
         if: ${{ github.event.inputs.dry_run == 'true' }}
         run: |
           echo "Dry run mode - skipping actual publish"
-          ./gradlew :ampere-core:publishAllPublicationsToOssrhRepository --dry-run
+          ./gradlew :ampere-core:publishAllPublicationsToMavenCentralRepository --dry-run
 
       - name: Create GitHub Release
         if: startsWith(github.ref, 'refs/tags/v') && github.event.inputs.dry_run != 'true'

--- a/ampere-cli/build.gradle.kts
+++ b/ampere-cli/build.gradle.kts
@@ -10,18 +10,12 @@ plugins {
     kotlin("plugin.serialization")
     kotlin("plugin.compose")
     id("com.vanniktech.maven.publish")
-    id("signing")
 }
 
 val ampereVersion: String by project
 
 group = "link.socket"
 version = ampereVersion
-
-// === SIGNING CONFIGURATION ===
-signing {
-    useGpgCmd()
-}
 
 // === PUBLISHING CONFIGURATION ===
 mavenPublishing {

--- a/ampere-core/build.gradle.kts
+++ b/ampere-core/build.gradle.kts
@@ -15,7 +15,6 @@ plugins {
     id("org.jetbrains.compose")
     id("org.jetbrains.kotlin.plugin.compose")
     id("com.vanniktech.maven.publish")
-    id("signing")
     id("org.jetbrains.dokka") version "2.1.0"
     id("app.cash.sqldelight") version "2.2.1"
     id("org.jlleitschuh.gradle.ktlint")
@@ -25,11 +24,6 @@ val ampereVersion: String by project
 
 group = "link.socket"
 version = ampereVersion
-
-// === SIGNING CONFIGURATION ===
-signing {
-    useGpgCmd()
-}
 
 // === PUBLISHING CONFIGURATION ===
 mavenPublishing {

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -4,11 +4,11 @@ This document describes how to publish new versions of AMPERE to Maven Central.
 
 ## Prerequisites
 
-### 1. Sonatype OSSRH Account
+### 1. Maven Central Portal Account
 
-1. Create account at https://issues.sonatype.org
-2. Create JIRA ticket requesting access to `link.socket` group ID
-3. Wait for approval (usually 1-2 business days)
+1. Create account at https://central.sonatype.com
+2. Register the `link.socket` namespace
+3. Generate a user token at https://central.sonatype.com/account
 
 ### 2. GPG Key Setup
 
@@ -28,10 +28,11 @@ gpg --keyserver keyserver.ubuntu.com --send-keys YOUR_KEY_ID
 Add to `~/.gradle/gradle.properties`:
 
 ```properties
-ossrhUsername=your-sonatype-username
-ossrhPassword=your-sonatype-password
-signing.keyId=ABCD1234
-signing.password=your-gpg-passphrase
+mavenCentralUsername=your-token-username
+mavenCentralPassword=your-token-password
+signingInMemoryKeyId=ABCD1234
+signingInMemoryKey=exported-ascii-armored-key
+signingInMemoryKeyPassword=your-gpg-passphrase
 ```
 
 ### 4. GitHub Secrets (for CI)
@@ -40,15 +41,15 @@ Add these repository secrets:
 
 | Secret | Description |
 |--------|-------------|
-| `OSSRH_USERNAME` | Sonatype JIRA username |
-| `OSSRH_PASSWORD` | Sonatype JIRA password |
+| `MAVEN_CENTRAL_USERNAME` | Maven Central Portal token username |
+| `MAVEN_CENTRAL_PASSWORD` | Maven Central Portal token password |
 | `SIGNING_KEY_ID` | Last 8 chars of GPG key ID |
-| `SIGNING_KEY` | Base64-encoded GPG private key |
+| `SIGNING_KEY` | ASCII-armored GPG private key |
 | `SIGNING_PASSWORD` | GPG key passphrase |
 
 To export the signing key for CI:
 ```bash
-gpg --armor --export-secret-keys YOUR_KEY_ID | base64
+gpg --armor --export-secret-keys YOUR_KEY_ID
 ```
 
 ## Version Numbering
@@ -81,23 +82,20 @@ AMPERE follows [Semantic Versioning](https://semver.org/):
    - Publish to Maven Central staging
    - Create a GitHub Release
 
-4. Release from staging:
-   - Log in to https://s01.oss.sonatype.org
-   - Navigate to Staging Repositories
-   - Find your repository (linksocket-XXXX)
-   - Click "Close" and wait for validation
-   - Click "Release" if validation passes
+4. The vanniktech plugin publishes directly via the Maven Central Portal API.
+   Monitor status at https://central.sonatype.com/publishing
 
 ### Manual Release
 
 If CI fails or you need to publish manually:
 
 ```bash
-./gradlew :ampere-core:publishAllPublicationsToOssrhRepository \
-  -PossrhUsername=YOUR_USERNAME \
-  -PossrhPassword=YOUR_PASSWORD \
-  -Psigning.keyId=KEY_ID \
-  -Psigning.password=KEY_PASSPHRASE
+./gradlew :ampere-core:publishAllPublicationsToMavenCentralRepository \
+  -PmavenCentralUsername=YOUR_TOKEN_USERNAME \
+  -PmavenCentralPassword=YOUR_TOKEN_PASSWORD \
+  -PsigningInMemoryKeyId=KEY_ID \
+  -PsigningInMemoryKey="$(gpg --armor --export-secret-keys KEY_ID)" \
+  -PsigningInMemoryKeyPassword=KEY_PASSPHRASE
 ```
 
 ## Prepare Next Development Cycle
@@ -122,8 +120,8 @@ After release, artifacts appear on Maven Central within ~30 minutes:
 
 ## Troubleshooting
 
-### Staging repository not found
-Wait a few minutes and refresh. Sonatype can be slow.
+### Publishing not appearing
+Wait a few minutes and check https://central.sonatype.com/publishing. The Portal can be slow.
 
 ### Signature verification failed
 Ensure your GPG public key is published to `keyserver.ubuntu.com`:


### PR DESCRIPTION
## Summary

Fixed the Maven Central publish workflow to use the correct Gradle task name and environment variable conventions for vanniktech maven-publish plugin v0.30.0. The task name is `publishAllPublicationsToMavenCentralRepository` (not `publishAllPublicationsToOssrhRepository`), and credentials now use Maven Central Portal tokens instead of OSSRH.

## Changes

- **CI Workflow** (.github/workflows/publish.yml): Updated task name and env vars to match vanniktech plugin API
- **Build files** (ampere-core, ampere-cli): Removed conflicting `signing` plugin and `useGpgCmd()` (vanniktech handles signing)
- **Documentation** (docs/RELEASING.md): Updated for Maven Central Portal (not legacy OSSRH) and correct secret names

## Why

The vanniktech maven-publish plugin v0.30.0 with `SonatypeHost.CENTRAL_PORTAL` uses different environment variable names and creates different Gradle tasks than the legacy OSSRH setup. The old config would fail with "task not found" errors when attempting to publish.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)