### PR TITLE
Bump version to 0.2.1 for Maven Central publish

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,4 +26,4 @@ sqldelight.version=2.2.1
 mosaic.version=0.18.0
 
 #Ampere
-ampereVersion=0.2.0
+ampereVersion=0.2.1


### PR DESCRIPTION
## Summary

Bumps version from 0.2.0 to 0.2.1 so we can tag and publish with the corrected Maven Central workflow. The `v0.2.0` tag pointed to a commit before the publish task fix (#429), so it can't be used.

## Next steps

After merging, tag and push:
```bash
git tag v0.2.1
git push origin v0.2.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)