### PR TITLE
Bump version to 0.2.2 for Maven Central publish

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,4 +26,4 @@ sqldelight.version=2.2.1
 mosaic.version=0.18.0
 
 #Ampere
-ampereVersion=0.2.1
+ampereVersion=0.2.2


### PR DESCRIPTION
## Summary

Bumps version to 0.2.2 for a clean Maven Central publish. Previous versions (v0.2.0, v0.2.1) had tags pointing to commits before the workflow and signing fixes landed.

After merging, tag and push:
```bash
git tag v0.2.2
git push origin v0.2.2
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)