### PR TITLE
Fix GitHub release permissions in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,9 @@ on:
         default: 'false'
         type: boolean
 
+permissions:
+  contents: write
+
 jobs:
   publish:
     name: Publish to Maven Central


### PR DESCRIPTION
## Summary
Added missing `permissions: contents: write` to the publish workflow. The repository's default workflow permissions are set to read-only, which caused the GitHub release creation step to fail with a 403 error.

## Changes
- Added `permissions` block to grant GITHUB_TOKEN write access to repository contents
- This allows `softprops/action-gh-release` to successfully create releases when tags are pushed

## Testing
To re-trigger the v0.2.2 release after this merge, delete and re-push the tag:
```
git tag -d v0.2.2
git push origin :refs/tags/v0.2.2
git tag v0.2.2
git push origin v0.2.2
```

Generated by Claude Opus 4.6