### PR TITLE
Fix hangs in jvmTest during CI publish workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,4 +41,5 @@ jobs:
           EOF
 
       - name: Run tests
+        timeout-minutes: 10
         run: ./gradlew test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,6 +55,7 @@ jobs:
           EOF
 
       - name: Run tests before publish
+        timeout-minutes: 10
         run: ./gradlew :ampere-core:jvmTest
 
       - name: Decode signing key

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/demo/CognitiveCycleDemo.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/demo/CognitiveCycleDemo.kt
@@ -1,6 +1,7 @@
 package link.socket.ampere.agents.demo
 
 import java.io.File
+import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -41,6 +42,7 @@ import link.socket.ampere.domain.ai.provider.AIProvider_Anthropic
  */
 class CognitiveCycleDemo {
 
+    @Ignore("Manual demo requiring real LLM API keys - not for CI")
     @Test
     fun `demonstrate complete PROPEL cognitive cycle`() {
         runBlocking {


### PR DESCRIPTION
## Summary

The `CognitiveCycleDemo` test makes real LLM API calls with placeholder credentials, causing 50+ minute hangs when running in the publish CI workflow. This fix prevents indefinite test execution.

## Changes

- Mark `CognitiveCycleDemo` as `@Ignore` (it's a manual demo requiring real API keys, not a unit test)
- Add 10-minute timeout to CI and publish workflow test steps to prevent indefinite hangs
- Ensure placeholder API keys don't cause runaway network requests

## Test Plan

- [x] Verify `jvmTest` task completes within 10 minutes locally
- [x] Confirm `CognitiveCycleDemo` is now in the ignored tests list
- [x] Verify all other tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)