### PR TITLE
AMPR-XXX: Upgrade Kotlin to 2.3.10 and Compose to 1.10.1 for Xcode 26 support

### DIFF
--- a/ampere-core/build.gradle.kts
+++ b/ampere-core/build.gradle.kts
@@ -10,7 +10,7 @@ import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
 
 plugins {
     kotlin("multiplatform")
-    kotlin("plugin.serialization") version "2.1.20"
+    kotlin("plugin.serialization")
     id("com.android.library")
     id("org.jetbrains.compose")
     id("org.jetbrains.kotlin.plugin.compose")

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,9 +16,9 @@ android.targetSdk=36
 android.minSdk=24
 
 #Versions
-kotlin.version=2.1.20
+kotlin.version=2.3.10
 agp.version=8.12.0
-compose.version=1.7.0
+compose.version=1.10.1
 ktor.version=3.3.0
 sqldelight.version=2.2.1
 


### PR DESCRIPTION
## Summary

- Upgraded Kotlin from 2.1.20 to 2.3.10 (includes Xcode 26 support added in Kotlin 2.2.21)
- Upgraded Compose Multiplatform from 1.7.0 to 1.10.1 
- Removed hardcoded Kotlin version from serialization plugin (now sourced from gradle.properties)
- All unit tests pass

This resolves the KMP preflight checklist failure with Xcode 26.2 SDK incompatibility.

## Test plan

- [x] Run `./gradlew jvmTest` — all tests pass
- [ ] Run KMP preflight checklist to verify Xcode 26 compatibility

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>