### PR TITLE
Bump version to 0.2.3 for Maven Central publish

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,4 +26,4 @@ sqldelight.version=2.2.1
 mosaic.version=0.18.0
 
 #Ampere
-ampereVersion=0.2.2
+ampereVersion=0.2.3


### PR DESCRIPTION
## Summary
- Bumps `ampereVersion` from 0.2.2 to 0.2.3 in `gradle.properties`
- Release includes Kotlin 2.3.10 and Compose Multiplatform 1.10.1 upgrades for Xcode 26 support

## Release steps after merge
```bash
git tag v0.2.3 <merge-commit-sha>
git push origin v0.2.3
```
The CI publish workflow will then automatically run tests, publish to Maven Central, and create a GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)