### PR TITLE
Upgrade Phosphor to 0.2.3

### DIFF
--- a/ampere-cli/build.gradle.kts
+++ b/ampere-cli/build.gradle.kts
@@ -84,7 +84,7 @@ kotlin {
         val jvmMain by getting {
             dependencies {
                 implementation(project(":ampere-core"))
-                implementation("link.socket:phosphor-core:0.2.2")
+                implementation("link.socket:phosphor-core:0.2.3")
 
                 // CLI argument parsing
                 implementation("com.github.ajalt.clikt:clikt:4.4.0")

--- a/ampere-compose/build.gradle.kts
+++ b/ampere-compose/build.gradle.kts
@@ -23,7 +23,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation("link.socket:phosphor-core:0.2.2")
+                implementation("link.socket:phosphor-core:0.2.3")
                 implementation(compose.runtime)
                 implementation(compose.foundation)
                 implementation(compose.ui)

--- a/ampere-desktop/build.gradle.kts
+++ b/ampere-desktop/build.gradle.kts
@@ -21,7 +21,7 @@ kotlin {
                 implementation(project(":ampere-core"))
                 implementation(project(":ampere-compose"))
                 implementation(project(":ampere-cli"))
-                implementation("link.socket:phosphor-core:0.2.2")
+                implementation("link.socket:phosphor-core:0.2.3")
                 implementation(compose.desktop.currentOs)
             }
         }


### PR DESCRIPTION
## Summary
- Upgrade phosphor-core from 0.2.2 to 0.2.3 across all modules
- Verified with full test suite (./gradlew jvmTest)

All tests pass successfully.