### PR TITLE
AMPR-140 #439 expose per-call telemetry in EventService

### DIFF
--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/watch/presentation/EventCategorizer.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/watch/presentation/EventCategorizer.kt
@@ -9,6 +9,8 @@ import link.socket.ampere.agents.domain.event.MemoryEvent
 import link.socket.ampere.agents.domain.event.MessageEvent
 import link.socket.ampere.agents.domain.event.NotificationEvent
 import link.socket.ampere.agents.domain.event.PlanEvent
+import link.socket.ampere.agents.domain.event.ProviderCallCompletedEvent
+import link.socket.ampere.agents.domain.event.ProviderCallStartedEvent
 import link.socket.ampere.agents.domain.event.ProductEvent
 import link.socket.ampere.agents.domain.event.RoutingEvent
 import link.socket.ampere.agents.domain.event.SparkEvent
@@ -80,6 +82,7 @@ object EventCategorizer {
         is ProductEvent.FeatureRequested,
         is ProductEvent.EpicDefined,
         is ProductEvent.PhaseDefined,
+        is ProviderCallCompletedEvent,
         is TicketEvent.TicketCreated,
         is TicketEvent.TicketStatusChanged,
         is TicketEvent.TicketAssigned,
@@ -101,9 +104,16 @@ object EventCategorizer {
         is TaskEvent.TaskProgressed,
         is ToolEvent.ToolExecutionStarted,
         is ToolEvent.ToolExecutionCompleted,
+        is ProviderCallStartedEvent,
         is RoutingEvent.RouteSelected,
         is SparkEvent -> EventSignificance.ROUTINE
 
         is RoutingEvent.RouteFallback -> EventSignificance.SIGNIFICANT
+    }.let { significance ->
+        if (event is ProviderCallCompletedEvent && !event.success) {
+            EventSignificance.SIGNIFICANT
+        } else {
+            significance
+        }
     }
 }

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/renderer/EventRenderer.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/renderer/EventRenderer.kt
@@ -22,6 +22,8 @@ import link.socket.ampere.agents.domain.event.MemoryEvent
 import link.socket.ampere.agents.domain.event.MessageEvent
 import link.socket.ampere.agents.domain.event.NotificationEvent
 import link.socket.ampere.agents.domain.event.PlanEvent
+import link.socket.ampere.agents.domain.event.ProviderCallCompletedEvent
+import link.socket.ampere.agents.domain.event.ProviderCallStartedEvent
 import link.socket.ampere.agents.domain.event.ProductEvent
 import link.socket.ampere.agents.domain.event.RoutingEvent
 import link.socket.ampere.agents.domain.event.CognitiveStateSnapshot
@@ -139,6 +141,8 @@ class EventRenderer(
             is MessageEvent -> "💬" to blue
             is NotificationEvent<*> -> "🔔" to gray
             is PlanEvent -> "📋" to magenta
+            is ProviderCallStartedEvent -> "📡" to cyan
+            is ProviderCallCompletedEvent -> "📡" to if (event.success) blue else red
             is ProductEvent -> "💡" to green
             is TicketEvent -> "🎫" to green
             is ToolEvent -> "🔧" to yellow

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/CodeAgent.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/CodeAgent.kt
@@ -118,7 +118,11 @@ open class CodeAgent(
     // Unified Reasoning - All cognitive logic in one place
     // ========================================================================
 
-    private val reasoning: AgentReasoning = reasoningOverride ?: AgentReasoning.create(agentConfiguration, id) {
+    private val reasoning: AgentReasoning = reasoningOverride ?: AgentReasoning.create(
+        agentConfiguration,
+        id,
+        eventApiOverride,
+    ) {
         agentRole = "Code Writer"
         availableTools = requiredTools
         this.executor = this@CodeAgent.executor

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/ProductAgent.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/ProductAgent.kt
@@ -74,7 +74,7 @@ class ProductAgent(
     // Unified Reasoning - All cognitive logic in one place
     // ========================================================================
 
-    private val reasoning = AgentReasoning.create(agentConfiguration, id) {
+    private val reasoning = AgentReasoning.create(agentConfiguration, id, eventApiOverride) {
         agentRole = "Product Manager"
         availableTools = requiredTools
         this.executor = this@ProductAgent.executor

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/ProjectAgent.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/ProjectAgent.kt
@@ -82,7 +82,11 @@ open class ProjectAgent(
     // Unified Reasoning - All cognitive logic in one place
     // ========================================================================
 
-    private val reasoning: AgentReasoning = reasoningOverride ?: AgentReasoning.create(agentConfiguration, id) {
+    private val reasoning: AgentReasoning = reasoningOverride ?: AgentReasoning.create(
+        agentConfiguration,
+        id,
+        eventApiOverride,
+    ) {
         agentRole = "Project Manager"
         availableTools = requiredTools
         this.executor = this@ProjectAgent.executor

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/QualityAgent.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/QualityAgent.kt
@@ -70,7 +70,7 @@ class QualityAgent(
     // Unified Reasoning - All cognitive logic in one place
     // ========================================================================
 
-    private val reasoning = AgentReasoning.create(agentConfiguration, id) {
+    private val reasoning = AgentReasoning.create(agentConfiguration, id, eventApiOverride) {
         agentRole = "Quality Assurance"
         availableTools = requiredTools
         this.executor = this@QualityAgent.executor

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/SparkBasedAgent.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/SparkBasedAgent.kt
@@ -94,7 +94,7 @@ class SparkBasedAgent(
     // ========================================================================
 
     private val reasoning: AgentReasoning by lazy {
-        AgentReasoning.create(agentConfiguration, id) {
+        AgentReasoning.create(agentConfiguration, id, _eventApi) {
             agentRole = "Spark-Based Agent (${affinity.name})"
             availableTools = requiredTools
 

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/EventRegistry.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/EventRegistry.kt
@@ -91,6 +91,10 @@ object EventRegistry {
         // RoutingEvent types
         RoutingEvent.RouteSelected.EVENT_TYPE,
         RoutingEvent.RouteFallback.EVENT_TYPE,
+
+        // TelemetryEvent types
+        ProviderCallStartedEvent.EVENT_TYPE,
+        ProviderCallCompletedEvent.EVENT_TYPE,
     )
 
     /**

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/TelemetryEvent.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/TelemetryEvent.kt
@@ -1,0 +1,103 @@
+package link.socket.ampere.agents.domain.event
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import link.socket.ampere.agents.definition.AgentId
+import link.socket.ampere.agents.domain.Urgency
+import link.socket.ampere.agents.domain.cognition.sparks.CognitivePhase
+import link.socket.ampere.api.model.TokenUsage
+import link.socket.ampere.domain.ai.provider.ProviderId
+
+/**
+ * Public telemetry events emitted around each LLM call.
+ *
+ * These events are intentionally shaped as stable API-facing contracts so
+ * external consumers can observe provider routing, token usage, and latency
+ * without depending on internal relay implementation details.
+ */
+@Serializable
+sealed interface TelemetryEvent : Event {
+
+    val workflowId: String?
+    val agentId: AgentId
+    val cognitivePhase: CognitivePhase?
+    val providerId: ProviderId
+    val modelId: String
+}
+
+@Serializable
+@SerialName("ProviderCallStartedEvent")
+data class ProviderCallStartedEvent(
+    override val eventId: EventId,
+    override val timestamp: Instant,
+    override val eventSource: EventSource,
+    override val urgency: Urgency = Urgency.LOW,
+    override val workflowId: String? = null,
+    override val agentId: AgentId,
+    override val cognitivePhase: CognitivePhase? = null,
+    override val providerId: ProviderId,
+    override val modelId: String,
+    val routingReason: String,
+) : TelemetryEvent {
+
+    override val eventType: EventType = EVENT_TYPE
+
+    override fun getSummary(
+        formatUrgency: (Urgency) -> String,
+        formatSource: (EventSource) -> String,
+    ): String = buildString {
+        append("LLM call started: $providerId/$modelId")
+        cognitivePhase?.let { append(" [${it.name}]") }
+        append(" (route: $routingReason)")
+        workflowId?.let { append(" workflow=$it") }
+        append(" ${formatUrgency(urgency)}")
+        append(" from ${formatSource(eventSource)}")
+    }
+
+    companion object {
+        const val EVENT_TYPE: EventType = "ProviderCallStarted"
+    }
+}
+
+@Serializable
+@SerialName("ProviderCallCompletedEvent")
+data class ProviderCallCompletedEvent(
+    override val eventId: EventId,
+    override val timestamp: Instant,
+    override val eventSource: EventSource,
+    override val urgency: Urgency = Urgency.LOW,
+    override val workflowId: String? = null,
+    override val agentId: AgentId,
+    override val cognitivePhase: CognitivePhase? = null,
+    override val providerId: ProviderId,
+    override val modelId: String,
+    val usage: TokenUsage = TokenUsage(),
+    val latencyMs: Long,
+    val success: Boolean,
+    val errorType: String? = null,
+) : TelemetryEvent {
+
+    override val eventType: EventType = EVENT_TYPE
+
+    override fun getSummary(
+        formatUrgency: (Urgency) -> String,
+        formatSource: (EventSource) -> String,
+    ): String = buildString {
+        append("LLM call ${if (success) "completed" else "failed"}: $providerId/$modelId")
+        cognitivePhase?.let { append(" [${it.name}]") }
+        append(" (${latencyMs}ms")
+        if (usage.inputTokens != null || usage.outputTokens != null) {
+            append(", in=${usage.inputTokens ?: "?"}, out=${usage.outputTokens ?: "?"}")
+        }
+        append(")")
+        errorType?.let { append(" [$it]") }
+        workflowId?.let { append(" workflow=$it") }
+        append(" ${formatUrgency(urgency)}")
+        append(" from ${formatSource(eventSource)}")
+    }
+
+    companion object {
+        const val EVENT_TYPE: EventType = "ProviderCallCompleted"
+    }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/reasoning/AgentLLMService.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/reasoning/AgentLLMService.kt
@@ -5,10 +5,18 @@ import com.aallam.openai.api.chat.ChatCompletionRequest
 import com.aallam.openai.api.chat.ChatMessage
 import com.aallam.openai.api.chat.ChatRole
 import kotlinx.coroutines.withContext
+import kotlinx.datetime.Clock
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import link.socket.ampere.agents.config.AgentConfiguration
+import link.socket.ampere.agents.domain.event.EventSource
+import link.socket.ampere.agents.domain.event.ProviderCallCompletedEvent
+import link.socket.ampere.agents.domain.event.ProviderCallStartedEvent
 import link.socket.ampere.agents.domain.routing.RoutingContext
+import link.socket.ampere.agents.domain.routing.RoutingResolution
+import link.socket.ampere.agents.events.api.AgentEventApi
+import link.socket.ampere.agents.events.utils.generateUUID
+import link.socket.ampere.api.model.TokenUsage
 import link.socket.ampere.domain.llm.LlmProvider
 import link.socket.ampere.domain.util.toClientModelId
 import link.socket.ampere.util.ioDispatcher
@@ -52,9 +60,13 @@ import link.socket.ampere.util.logWith
  */
 class AgentLLMService(
     private val agentConfiguration: AgentConfiguration,
+    private val eventApi: AgentEventApi? = null,
 ) {
 
     private val logger: Logger = logWith("AgentLLMService")
+
+    val agentId: String?
+        get() = eventApi?.agentId
 
     /**
      * Calls the LLM with a prompt and returns the raw response text.
@@ -84,20 +96,59 @@ class AgentLLMService(
         agentConfiguration.llmProvider?.let { provider ->
             logger.d { "[LLM] Using custom provider" }
             val combinedPrompt = buildCombinedPrompt(systemMessage, prompt)
-            return withContext(ioDispatcher) {
-                provider(combinedPrompt)
+            val providerId = resolveCustomProviderId()
+            val modelId = resolveCustomModelId()
+            emitStartedTelemetry(
+                routingContext = routingContext,
+                providerId = providerId,
+                modelId = modelId,
+                routingReason = "custom_provider",
+            )
+
+            val startedAt = Clock.System.now()
+            return try {
+                val response = withContext(ioDispatcher) {
+                    provider(combinedPrompt)
+                }
+                emitCompletedTelemetry(
+                    routingContext = routingContext,
+                    providerId = providerId,
+                    modelId = modelId,
+                    usage = TokenUsage(),
+                    success = true,
+                    startedAt = startedAt,
+                )
+                response
+            } catch (t: Throwable) {
+                emitCompletedTelemetry(
+                    routingContext = routingContext,
+                    providerId = providerId,
+                    modelId = modelId,
+                    usage = TokenUsage(),
+                    success = false,
+                    startedAt = startedAt,
+                    errorType = t::class.simpleName ?: "UnknownError",
+                )
+                throw t
             }
         }
 
         // Resolve configuration through CognitiveRelay if available
-        val effectiveConfig = if (routingContext != null) {
-            agentConfiguration.cognitiveRelay?.resolve(
+        val routingResolution = if (routingContext != null) {
+            agentConfiguration.cognitiveRelay?.resolveWithMetadata(
                 context = routingContext,
                 fallbackConfiguration = agentConfiguration.aiConfiguration,
-            ) ?: agentConfiguration.aiConfiguration
+            ) ?: RoutingResolution(
+                configuration = agentConfiguration.aiConfiguration,
+                reason = "agent_configuration",
+            )
         } else {
-            agentConfiguration.aiConfiguration
+            RoutingResolution(
+                configuration = agentConfiguration.aiConfiguration,
+                reason = "agent_configuration",
+            )
         }
+        val effectiveConfig = routingResolution.configuration
 
         val client = effectiveConfig.provider.client
         val model = effectiveConfig.model
@@ -120,8 +171,29 @@ class AgentLLMService(
             maxTokens = maxTokens,
         )
 
-        val completion = withContext(ioDispatcher) {
-            client.chatCompletion(request)
+        emitStartedTelemetry(
+            routingContext = routingContext,
+            providerId = effectiveConfig.provider.id,
+            modelId = model.name,
+            routingReason = routingResolution.reason,
+        )
+
+        val startedAt = Clock.System.now()
+        val completion = try {
+            withContext(ioDispatcher) {
+                client.chatCompletion(request)
+            }
+        } catch (t: Throwable) {
+            emitCompletedTelemetry(
+                routingContext = routingContext,
+                providerId = effectiveConfig.provider.id,
+                modelId = model.name,
+                usage = TokenUsage(),
+                success = false,
+                startedAt = startedAt,
+                errorType = t::class.simpleName ?: "UnknownError",
+            )
+            throw t
         }
 
         // Log token usage for monitoring
@@ -132,6 +204,20 @@ class AgentLLMService(
                     "Total: ${usage.totalTokens} (limit: $maxTokens)"
             }
         }
+
+        emitCompletedTelemetry(
+            routingContext = routingContext,
+            providerId = effectiveConfig.provider.id,
+            modelId = model.name,
+            usage = completion.usage?.let { usage ->
+                TokenUsage(
+                    inputTokens = usage.promptTokens,
+                    outputTokens = usage.completionTokens,
+                )
+            } ?: TokenUsage(),
+            success = true,
+            startedAt = startedAt,
+        )
 
         return completion.choices.firstOrNull()?.message?.content
             ?: throw IllegalStateException("No response from LLM")
@@ -242,6 +328,65 @@ class AgentLLMService(
             """.trimMargin()
         }
     }
+
+    private suspend fun emitStartedTelemetry(
+        routingContext: RoutingContext?,
+        providerId: String,
+        modelId: String,
+        routingReason: String,
+    ) {
+        val publishingAgentId = eventApi?.agentId ?: return
+        eventApi.publish(
+            ProviderCallStartedEvent(
+                eventId = generateUUID("llm-start", publishingAgentId),
+                timestamp = Clock.System.now(),
+                eventSource = EventSource.Agent(publishingAgentId),
+                workflowId = routingContext?.workflowId,
+                agentId = routingContext?.agentId ?: publishingAgentId,
+                cognitivePhase = routingContext?.phase,
+                providerId = providerId,
+                modelId = modelId,
+                routingReason = routingReason,
+            ),
+        )
+    }
+
+    private suspend fun emitCompletedTelemetry(
+        routingContext: RoutingContext?,
+        providerId: String,
+        modelId: String,
+        usage: TokenUsage,
+        success: Boolean,
+        startedAt: kotlinx.datetime.Instant,
+        errorType: String? = null,
+    ) {
+        val publishingAgentId = eventApi?.agentId ?: return
+        val completedAt = Clock.System.now()
+        eventApi.publish(
+            ProviderCallCompletedEvent(
+                eventId = generateUUID("llm-complete", publishingAgentId),
+                timestamp = completedAt,
+                eventSource = EventSource.Agent(publishingAgentId),
+                workflowId = routingContext?.workflowId,
+                agentId = routingContext?.agentId ?: publishingAgentId,
+                cognitivePhase = routingContext?.phase,
+                providerId = providerId,
+                modelId = modelId,
+                usage = usage,
+                latencyMs = (completedAt - startedAt).inWholeMilliseconds,
+                success = success,
+                errorType = errorType,
+            ),
+        )
+    }
+
+    private fun resolveCustomModelId(): String =
+        runCatching { agentConfiguration.aiConfiguration.model.name }
+            .getOrDefault("custom")
+
+    private fun resolveCustomProviderId(): String =
+        runCatching { agentConfiguration.aiConfiguration.provider.id }
+            .getOrDefault("custom")
 }
 
 /**

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/reasoning/AgentReasoning.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/reasoning/AgentReasoning.kt
@@ -7,8 +7,10 @@ import link.socket.ampere.agents.domain.memory.AgentMemoryService
 import link.socket.ampere.agents.domain.memory.KnowledgeWithScore
 import link.socket.ampere.agents.domain.outcome.ExecutionOutcome
 import link.socket.ampere.agents.domain.outcome.Outcome
+import link.socket.ampere.agents.domain.routing.RoutingContext
 import link.socket.ampere.agents.domain.state.AgentState
 import link.socket.ampere.agents.domain.task.Task
+import link.socket.ampere.agents.events.api.AgentEventApi
 import link.socket.ampere.agents.execution.ParameterStrategy
 import link.socket.ampere.agents.execution.ToolExecutionEngine
 import link.socket.ampere.agents.execution.executor.Executor
@@ -63,9 +65,10 @@ import link.socket.ampere.agents.execution.tools.Tool
 class AgentReasoning private constructor(
     private val config: AgentConfiguration?,
     private val settings: ReasoningSettings,
+    private val eventApi: AgentEventApi? = null,
     private val mockResponses: MockReasoningResponses? = null,
 ) {
-    private val llmService: AgentLLMService? = config?.let { AgentLLMService(it) }
+    private val llmService: AgentLLMService? = config?.let { AgentLLMService(it, eventApi) }
     private val perceptionEvaluator: PerceptionEvaluator? = llmService?.let { PerceptionEvaluator(it) }
     private val planGenerator: PlanGenerator? = llmService?.let { PlanGenerator(it) }
     private val outcomeEvaluator: OutcomeEvaluator? = llmService?.let { OutcomeEvaluator(it) }
@@ -235,6 +238,10 @@ class AgentReasoning private constructor(
         return llmService?.call(
             prompt = prompt,
             systemMessage = systemMessage ?: "You are a ${settings.agentRole} agent.",
+            routingContext = RoutingContext(
+                agentId = settings.executorId,
+                agentRole = settings.agentRole,
+            ),
         ) ?: throw IllegalStateException("No LLM service configured")
     }
 
@@ -242,7 +249,13 @@ class AgentReasoning private constructor(
      * Calls the LLM expecting a JSON response.
      */
     suspend fun callLLMForJson(prompt: String): LLMJsonResponse {
-        return llmService?.callForJson(prompt)
+        return llmService?.callForJson(
+            prompt = prompt,
+            routingContext = RoutingContext(
+                agentId = settings.executorId,
+                agentRole = settings.agentRole,
+            ),
+        )
             ?: throw IllegalStateException("No LLM service configured")
     }
 
@@ -253,11 +266,12 @@ class AgentReasoning private constructor(
         fun create(
             config: AgentConfiguration,
             executorId: ExecutorId,
+            eventApi: AgentEventApi? = null,
             configure: ReasoningSettingsBuilder.() -> Unit,
         ): AgentReasoning {
             val builder = ReasoningSettingsBuilder(executorId)
             builder.configure()
-            return AgentReasoning(config, builder.build())
+            return AgentReasoning(config, builder.build(), eventApi = eventApi)
         }
 
         /**
@@ -294,7 +308,12 @@ class AgentReasoning private constructor(
                 outcomeContextBuilder = null,
                 knowledgeExtractor = null,
             )
-            return AgentReasoning(null, settings, builder.build())
+            return AgentReasoning(
+                config = null,
+                settings = settings,
+                eventApi = null,
+                mockResponses = builder.build(),
+            )
         }
     }
 }

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/reasoning/OutcomeEvaluator.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/reasoning/OutcomeEvaluator.kt
@@ -3,9 +3,11 @@ package link.socket.ampere.agents.domain.reasoning
 import kotlinx.datetime.Clock
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import link.socket.ampere.agents.domain.cognition.sparks.CognitivePhase
 import link.socket.ampere.agents.domain.knowledge.Knowledge
 import link.socket.ampere.agents.domain.outcome.ExecutionOutcome
 import link.socket.ampere.agents.domain.outcome.Outcome
+import link.socket.ampere.agents.domain.routing.RoutingContext
 
 /**
  * Evaluates execution outcomes and generates learnings.
@@ -83,6 +85,13 @@ class OutcomeEvaluator(
                 prompt = prompt,
                 systemMessage = EVALUATION_SYSTEM_MESSAGE,
                 maxTokens = 1000,
+                routingContext = RoutingContext(
+                    phase = CognitivePhase.LEARN,
+                    agentId = llmService.agentId,
+                    agentRole = agentRole,
+                    workflowId = outcomes.filterIsInstance<ExecutionOutcome>().firstOrNull()?.taskId
+                        ?: outcomes.firstOrNull()?.id,
+                ),
             )
             val knowledge = parseLearningsFromResponse(jsonResponse.rawJson, outcomes)
             val summaryIdea = createSummaryIdea(knowledge, outcomes)

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/reasoning/PerceptionEvaluator.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/reasoning/PerceptionEvaluator.kt
@@ -2,6 +2,8 @@ package link.socket.ampere.agents.domain.reasoning
 
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import link.socket.ampere.agents.domain.cognition.sparks.CognitivePhase
+import link.socket.ampere.agents.domain.routing.RoutingContext
 import link.socket.ampere.agents.domain.state.AgentState
 import link.socket.ampere.agents.execution.tools.Tool
 
@@ -63,6 +65,12 @@ class PerceptionEvaluator(
                 prompt = prompt,
                 systemMessage = PERCEPTION_SYSTEM_MESSAGE,
                 maxTokens = 500,
+                routingContext = RoutingContext(
+                    phase = CognitivePhase.PERCEIVE,
+                    agentId = llmService.agentId,
+                    agentRole = agentRole,
+                    workflowId = perception.id,
+                ),
             )
             parseInsightsIntoIdea(jsonResponse.rawJson, agentRole)
         } catch (e: Exception) {

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/reasoning/PlanGenerator.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/reasoning/PlanGenerator.kt
@@ -3,8 +3,10 @@ package link.socket.ampere.agents.domain.reasoning
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import link.socket.ampere.agents.domain.cognition.sparks.CognitivePhase
 import link.socket.ampere.agents.domain.expectation.Expectations
 import link.socket.ampere.agents.domain.memory.KnowledgeWithScore
+import link.socket.ampere.agents.domain.routing.RoutingContext
 import link.socket.ampere.agents.domain.status.TaskStatus
 import link.socket.ampere.agents.domain.task.Task
 import link.socket.ampere.agents.execution.tools.Tool
@@ -85,6 +87,12 @@ class PlanGenerator(
                 prompt = prompt,
                 systemMessage = PLANNING_SYSTEM_MESSAGE,
                 maxTokens = 1000,
+                routingContext = RoutingContext(
+                    phase = CognitivePhase.PLAN,
+                    agentId = llmService.agentId,
+                    agentRole = agentRole,
+                    workflowId = task.id,
+                ),
             )
             parsePlanFromResponse(jsonResponse.rawJson, task, taskFactory)
         } catch (e: Exception) {

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/CognitiveRelay.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/CognitiveRelay.kt
@@ -32,9 +32,28 @@ interface CognitiveRelay {
     ): AIConfiguration
 
     /**
+     * Resolves routing and returns metadata suitable for external telemetry.
+     *
+     * The default implementation preserves compatibility for relays that only
+     * care about the selected configuration.
+     */
+    suspend fun resolveWithMetadata(
+        context: RoutingContext,
+        fallbackConfiguration: AIConfiguration,
+    ): RoutingResolution = RoutingResolution(
+        configuration = resolve(context, fallbackConfiguration),
+        reason = "relay",
+    )
+
+    /**
      * Updates the relay configuration at runtime (hot-swap).
      *
      * @param newConfig The new relay configuration.
      */
     suspend fun updateConfig(newConfig: RelayConfig)
 }
+
+data class RoutingResolution(
+    val configuration: AIConfiguration,
+    val reason: String,
+)

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/CognitiveRelayImpl.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/CognitiveRelayImpl.kt
@@ -38,7 +38,13 @@ class CognitiveRelayImpl(
     override suspend fun resolve(
         context: RoutingContext,
         fallbackConfiguration: AIConfiguration,
-    ): AIConfiguration {
+    ): AIConfiguration =
+        resolveWithMetadata(context, fallbackConfiguration).configuration
+
+    override suspend fun resolveWithMetadata(
+        context: RoutingContext,
+        fallbackConfiguration: AIConfiguration,
+    ): RoutingResolution {
         val currentConfig = mutex.withLock { _config }
 
         val matchedRule = currentConfig.rules.firstOrNull { rule ->
@@ -64,7 +70,10 @@ class CognitiveRelayImpl(
 
         emitRouteSelected(context, decision)
 
-        return selectedConfig
+        return RoutingResolution(
+            configuration = selectedConfig,
+            reason = ruleDescription,
+        )
     }
 
     override suspend fun updateConfig(newConfig: RelayConfig) {

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/CognitiveRelayPassthrough.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/CognitiveRelayPassthrough.kt
@@ -17,6 +17,14 @@ object CognitiveRelayPassthrough : CognitiveRelay {
         fallbackConfiguration: AIConfiguration,
     ): AIConfiguration = fallbackConfiguration
 
+    override suspend fun resolveWithMetadata(
+        context: RoutingContext,
+        fallbackConfiguration: AIConfiguration,
+    ): RoutingResolution = RoutingResolution(
+        configuration = fallbackConfiguration,
+        reason = "passthrough",
+    )
+
     override suspend fun updateConfig(newConfig: RelayConfig) {
         // No-op: passthrough does not support reconfiguration.
     }

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/RoutingContext.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/RoutingContext.kt
@@ -16,6 +16,7 @@ import link.socket.ampere.domain.ai.model.AIModelFeatures.RelativeSpeed
  * @property phase The cognitive phase active during this call, if any.
  * @property agentId The agent making the call.
  * @property agentRole The agent definition name (e.g., "CodeAgent", "ProductAgent").
+ * @property workflowId Optional correlation ID for the broader reasoning unit being executed.
  * @property preferredReasoning Hint for desired reasoning level.
  * @property preferredSpeed Hint for desired speed.
  * @property tags Free-form tags for task-based routing (e.g., "code-generation", "summarization").
@@ -25,6 +26,7 @@ data class RoutingContext(
     val phase: CognitivePhase? = null,
     val agentId: AgentId? = null,
     val agentRole: String? = null,
+    val workflowId: String? = null,
     val preferredReasoning: RelativeReasoning? = null,
     val preferredSpeed: RelativeSpeed? = null,
     val tags: Set<String> = emptySet(),

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/utils/SignificanceAwareEventLogger.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/utils/SignificanceAwareEventLogger.kt
@@ -14,6 +14,8 @@ import link.socket.ampere.agents.domain.event.MessageEvent
 import link.socket.ampere.agents.domain.event.NotificationEvent
 import link.socket.ampere.agents.domain.event.PlanEvent
 import link.socket.ampere.agents.domain.event.ProductEvent
+import link.socket.ampere.agents.domain.event.ProviderCallCompletedEvent
+import link.socket.ampere.agents.domain.event.ProviderCallStartedEvent
 import link.socket.ampere.agents.domain.event.RoutingEvent
 import link.socket.ampere.agents.domain.event.SparkEvent
 import link.socket.ampere.agents.domain.event.TaskEvent
@@ -143,6 +145,8 @@ class SignificanceAwareEventLogger(
         is ToolEvent.ToolDiscoveryComplete -> EventSignificance.ROUTINE
         is ToolEvent.ToolExecutionStarted -> EventSignificance.ROUTINE
         is ToolEvent.ToolExecutionCompleted -> EventSignificance.ROUTINE
+        is ProviderCallStartedEvent -> EventSignificance.ROUTINE
+        is ProviderCallCompletedEvent -> if (event.success) EventSignificance.ROUTINE else EventSignificance.SIGNIFICANT
         is HumanInteractionEvent.InputRequested -> EventSignificance.CRITICAL
         is HumanInteractionEvent.InputProvided -> EventSignificance.SIGNIFICANT
         is HumanInteractionEvent.RequestTimedOut -> EventSignificance.SIGNIFICANT

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/api/model/TokenUsage.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/api/model/TokenUsage.kt
@@ -1,0 +1,16 @@
+package link.socket.ampere.api.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Per-call token accounting emitted through telemetry events.
+ *
+ * Values are nullable because custom or mocked providers may not expose
+ * usage metadata for every invocation.
+ */
+@Serializable
+data class TokenUsage(
+    val inputTokens: Int? = null,
+    val outputTokens: Int? = null,
+    val estimatedCost: Double? = null,
+)

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/api/service/EventService.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/api/service/EventService.kt
@@ -1,8 +1,25 @@
 package link.socket.ampere.api.service
 
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filter
 import kotlinx.datetime.Instant
 import link.socket.ampere.agents.domain.event.Event
+import link.socket.ampere.agents.domain.event.FileSystemEvent
+import link.socket.ampere.agents.domain.event.GitEvent
+import link.socket.ampere.agents.domain.event.HumanInteractionEvent
+import link.socket.ampere.agents.domain.event.MeetingEvent
+import link.socket.ampere.agents.domain.event.MemoryEvent
+import link.socket.ampere.agents.domain.event.MessageEvent
+import link.socket.ampere.agents.domain.event.NotificationEvent
+import link.socket.ampere.agents.domain.event.PlanEvent
+import link.socket.ampere.agents.domain.event.ProductEvent
+import link.socket.ampere.agents.domain.event.ProviderCallCompletedEvent
+import link.socket.ampere.agents.domain.event.ProviderCallStartedEvent
+import link.socket.ampere.agents.domain.event.RoutingEvent
+import link.socket.ampere.agents.domain.event.SparkEvent
+import link.socket.ampere.agents.domain.event.TaskEvent
+import link.socket.ampere.agents.domain.event.TicketEvent
+import link.socket.ampere.agents.domain.event.ToolEvent
 import link.socket.ampere.agents.events.relay.EventRelayFilters
 
 /**
@@ -61,6 +78,18 @@ interface EventService {
     fun observe(filters: EventRelayFilters = EventRelayFilters()): Flow<Event>
 
     /**
+     * Observe the live event stream using coarse-grained event categories.
+     *
+     * This is an additive convenience API for external consumers that want
+     * stable subscription groups like telemetry without constructing explicit
+     * [EventRelayFilters] instances.
+     */
+    fun observe(filter: EventStreamFilter): Flow<Event> = when (filter) {
+        EventStreamFilter.ALL -> observe()
+        else -> observe().filter(filter::matches)
+    }
+
+    /**
      * Query historical events from persistent storage.
      *
      * ```
@@ -100,4 +129,61 @@ interface EventService {
         to: Instant,
         filters: EventRelayFilters = EventRelayFilters(),
     ): Flow<Event>
+
+    /**
+     * Replay historical events using coarse-grained event categories.
+     */
+    fun replay(
+        from: Instant,
+        to: Instant,
+        filter: EventStreamFilter,
+    ): Flow<Event> = when (filter) {
+        EventStreamFilter.ALL -> replay(from, to)
+        else -> replay(from, to).filter(filter::matches)
+    }
+}
+
+@link.socket.ampere.api.AmpereStableApi
+enum class EventStreamFilter {
+    ALL,
+    TELEMETRY,
+    LIFECYCLE,
+    COORDINATION,
+    COGNITIVE,
+    ;
+
+    fun matches(event: Event): Boolean = when (this) {
+        ALL -> true
+        TELEMETRY -> event is ProviderCallStartedEvent || event is ProviderCallCompletedEvent
+        LIFECYCLE -> when (event) {
+            is Event.TaskCreated,
+            is TaskEvent,
+            is TicketEvent,
+            is MeetingEvent,
+            is FileSystemEvent,
+            is GitEvent,
+            is ToolEvent.ToolExecutionStarted,
+            is ToolEvent.ToolExecutionCompleted,
+            -> true
+            else -> false
+        }
+        COORDINATION -> when (event) {
+            is MessageEvent,
+            is NotificationEvent<*>,
+            is HumanInteractionEvent,
+            -> true
+            else -> false
+        }
+        COGNITIVE -> when (event) {
+            is Event.QuestionRaised,
+            is Event.CodeSubmitted,
+            is MemoryEvent,
+            is PlanEvent,
+            is ProductEvent,
+            is RoutingEvent,
+            is SparkEvent,
+            -> true
+            else -> false
+        }
+    }
 }

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/routing/CognitiveRelayImplTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/routing/CognitiveRelayImplTest.kt
@@ -219,4 +219,23 @@ class CognitiveRelayImplTest {
         )
         assertEquals(AIModel_OpenAI.GPT_4_1, relay.resolve(tagContext, claudeConfig).model)
     }
+
+    @Test
+    fun `resolveWithMetadata exposes matched rule description`() = runTest {
+        val relay = CognitiveRelayImpl(
+            initialConfig = RelayConfig(
+                rules = listOf(
+                    RoutingRule.ByPhase(CognitivePhase.PERCEIVE, geminiConfig),
+                ),
+            ),
+        )
+
+        val result = relay.resolveWithMetadata(
+            context = RoutingContext(phase = CognitivePhase.PERCEIVE),
+            fallbackConfiguration = openaiConfig,
+        )
+
+        assertEquals(AIModel_Gemini.Flash_2_5, result.configuration.model)
+        assertEquals("phase:PERCEIVE", result.reason)
+    }
 }

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/api/ConsumerSimulationTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/api/ConsumerSimulationTest.kt
@@ -40,6 +40,7 @@ import link.socket.ampere.api.model.ThreadFilter
 import link.socket.ampere.api.model.TicketFilter
 import link.socket.ampere.api.service.AgentService
 import link.socket.ampere.api.service.EventService
+import link.socket.ampere.api.service.EventStreamFilter
 import link.socket.ampere.api.service.KnowledgeService
 import link.socket.ampere.api.service.OutcomeService
 import link.socket.ampere.api.service.StatusService
@@ -215,7 +216,13 @@ class ConsumerSimulationTest {
             )
         override suspend fun get(id: String) = Result.success<KnowledgeEntry?>(null)
         override suspend fun recall(query: String, limit: Int) = Result.success(emptyList<KnowledgeEntry>())
-        override suspend fun search(query: String?, type: KnowledgeType?, taskType: String?, tags: List<String>?, limit: Int) = Result.success(emptyList<KnowledgeEntry>())
+        override suspend fun search(
+            query: String?,
+            type: KnowledgeType?,
+            taskType: String?,
+            tags: List<String>?,
+            limit: Int,
+        ) = Result.success(emptyList<KnowledgeEntry>())
         override suspend fun tags(knowledgeId: String) = Result.success(emptyList<String>())
         override suspend fun provenance(knowledgeId: String) = Result.success(emptyList<KnowledgeEntry>())
     }
@@ -343,6 +350,8 @@ class ConsumerSimulationTest {
         // Observe with filters
         val filtered: Flow<Event> = stubEventService.observe(EventRelayFilters())
         assertNotNull(filtered)
+        val telemetryOnly: Flow<Event> = stubEventService.observe(EventStreamFilter.TELEMETRY)
+        assertNotNull(telemetryOnly)
 
         // Query time range
         val from = now - kotlin.time.Duration.parse("1h")

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/api/ExternalConsumerTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/api/ExternalConsumerTest.kt
@@ -9,6 +9,7 @@ import link.socket.ampere.agents.domain.status.TicketStatus
 import link.socket.ampere.agents.events.tickets.TicketPriority
 import link.socket.ampere.agents.events.tickets.TicketType
 import link.socket.ampere.api.model.TicketFilter
+import link.socket.ampere.api.service.EventStreamFilter
 
 /**
  * External consumer integration test.
@@ -61,6 +62,7 @@ class ExternalConsumerTest {
         val eventResult = ampere.events.get("nonexistent-event")
         assertTrue(eventResult.isSuccess)
         assertNotNull(ampere.events.observe())
+        assertNotNull(ampere.events.observe(EventStreamFilter.TELEMETRY))
         val from = kotlinx.datetime.Clock.System.now() - kotlin.time.Duration.parse("1h")
         val to = kotlinx.datetime.Clock.System.now()
         ampere.events.query(from, to).getOrThrow()

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/llm/AgentLlmTelemetryTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/llm/AgentLlmTelemetryTest.kt
@@ -1,0 +1,192 @@
+package link.socket.ampere.llm
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import link.socket.ampere.agents.config.AgentConfiguration
+import link.socket.ampere.agents.config.CognitiveConfig
+import link.socket.ampere.agents.domain.Urgency
+import link.socket.ampere.agents.domain.cognition.sparks.CognitivePhase
+import link.socket.ampere.agents.domain.event.Event
+import link.socket.ampere.agents.domain.event.ProviderCallCompletedEvent
+import link.socket.ampere.agents.domain.event.ProviderCallStartedEvent
+import link.socket.ampere.agents.domain.reasoning.AgentLLMService
+import link.socket.ampere.agents.domain.routing.RoutingContext
+import link.socket.ampere.agents.events.EventRepository
+import link.socket.ampere.agents.events.api.AgentEventApi
+import link.socket.ampere.agents.events.bus.EventSerialBus
+import link.socket.ampere.agents.events.relay.EventRelayServiceImpl
+import link.socket.ampere.api.internal.DefaultEventService
+import link.socket.ampere.api.service.EventStreamFilter
+import link.socket.ampere.data.DEFAULT_JSON
+import link.socket.ampere.db.Database
+import link.socket.ampere.domain.agent.bundled.WriteCodeAgent
+import link.socket.ampere.domain.ai.configuration.AIConfiguration_Default
+import link.socket.ampere.domain.ai.model.AIModel_OpenAI
+import link.socket.ampere.domain.ai.provider.AIProvider_OpenAI
+import link.socket.ampere.domain.llm.LlmProvider
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AgentLlmTelemetryTest {
+
+    private val scope = TestScope(UnconfinedTestDispatcher())
+
+    private lateinit var driver: JdbcSqliteDriver
+    private lateinit var eventRepository: EventRepository
+    private lateinit var eventBus: EventSerialBus
+    private lateinit var eventApi: AgentEventApi
+    private lateinit var eventService: DefaultEventService
+
+    @BeforeTest
+    fun setUp() {
+        driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        Database.Schema.create(driver)
+        val database = Database(driver)
+
+        eventRepository = EventRepository(DEFAULT_JSON, scope, database)
+        eventBus = EventSerialBus(scope)
+        eventApi = AgentEventApi(
+            agentId = "telemetry-agent",
+            eventRepository = eventRepository,
+            eventSerialBus = eventBus,
+        )
+        eventService = DefaultEventService(
+            eventRelayService = EventRelayServiceImpl(eventBus, eventRepository),
+            eventRepository = eventRepository,
+        )
+    }
+
+    @AfterTest
+    fun tearDown() {
+        driver.close()
+    }
+
+    @Test
+    fun `custom provider telemetry reaches SDK event filter`() = runTest {
+        val telemetryEvents = mutableListOf<Event>()
+        val provider: LlmProvider = {
+            delay(10)
+            "telemetry-response"
+        }
+        val llmService = AgentLLMService(
+            agentConfiguration = telemetryConfig(provider),
+            eventApi = eventApi,
+        )
+
+        val job = launch {
+            eventService.observe(EventStreamFilter.TELEMETRY)
+                .take(2)
+                .toList(telemetryEvents)
+        }
+
+        delay(100)
+        eventApi.publishTaskCreated(
+            taskId = "task-ignored",
+            urgency = Urgency.LOW,
+            description = "This should not appear in telemetry filter",
+        )
+
+        val response = llmService.call(
+            prompt = "Say hello",
+            systemMessage = "You are a test provider.",
+            routingContext = RoutingContext(
+                phase = CognitivePhase.PLAN,
+                agentId = eventApi.agentId,
+                agentRole = "Telemetry Test Agent",
+                workflowId = "wf-123",
+            ),
+        )
+
+        job.join()
+
+        assertEquals("telemetry-response", response)
+        assertEquals(2, telemetryEvents.size)
+        assertTrue(telemetryEvents.none { it is Event.TaskCreated })
+
+        val started = telemetryEvents[0] as ProviderCallStartedEvent
+        val completed = telemetryEvents[1] as ProviderCallCompletedEvent
+
+        assertEquals("wf-123", started.workflowId)
+        assertEquals(CognitivePhase.PLAN, started.cognitivePhase)
+        assertEquals("telemetry-agent", started.agentId)
+        assertEquals("openai", started.providerId)
+        assertEquals(AIModel_OpenAI.GPT_4_1.name, started.modelId)
+        assertEquals("custom_provider", started.routingReason)
+
+        assertTrue(completed.success)
+        assertEquals("wf-123", completed.workflowId)
+        assertEquals(CognitivePhase.PLAN, completed.cognitivePhase)
+        assertEquals("telemetry-agent", completed.agentId)
+        assertEquals("openai", completed.providerId)
+        assertEquals(AIModel_OpenAI.GPT_4_1.name, completed.modelId)
+        assertEquals(null, completed.usage.inputTokens)
+        assertEquals(null, completed.usage.outputTokens)
+        assertTrue(completed.latencyMs >= 0)
+    }
+
+    @Test
+    fun `failed provider emits failed completion telemetry`() = runTest {
+        val telemetryEvents = mutableListOf<Event>()
+        val provider: LlmProvider = {
+            delay(5)
+            throw IllegalStateException("boom")
+        }
+        val llmService = AgentLLMService(
+            agentConfiguration = telemetryConfig(provider),
+            eventApi = eventApi,
+        )
+
+        val job = launch {
+            eventService.observe(EventStreamFilter.TELEMETRY)
+                .take(2)
+                .toList(telemetryEvents)
+        }
+
+        delay(100)
+
+        val error = assertFailsWith<IllegalStateException> {
+            llmService.call(
+                prompt = "Fail",
+                routingContext = RoutingContext(
+                    phase = CognitivePhase.EXECUTE,
+                    agentId = eventApi.agentId,
+                    agentRole = "Telemetry Test Agent",
+                    workflowId = "wf-fail",
+                ),
+            )
+        }
+
+        job.join()
+
+        assertEquals("boom", error.message)
+        val completed = telemetryEvents.filterIsInstance<ProviderCallCompletedEvent>().single()
+        assertFalse(completed.success)
+        assertEquals("wf-fail", completed.workflowId)
+        assertEquals(CognitivePhase.EXECUTE, completed.cognitivePhase)
+        assertEquals("IllegalStateException", completed.errorType)
+    }
+
+    private fun telemetryConfig(provider: LlmProvider): AgentConfiguration =
+        AgentConfiguration(
+            agentDefinition = WriteCodeAgent,
+            aiConfiguration = AIConfiguration_Default(
+                provider = AIProvider_OpenAI,
+                model = AIModel_OpenAI.GPT_4_1,
+            ),
+            cognitiveConfig = CognitiveConfig(),
+            llmProvider = provider,
+        )
+}


### PR DESCRIPTION
Closes #439

Adds public provider-call telemetry events, a stable `EventStreamFilter.TELEMETRY` subscription path on `EventService`, and a public `TokenUsage` model so external consumers can observe per-call LLM usage through the API. Threads workflow, phase, agent, and routing metadata through the reasoning stack, emits started and completed telemetry for routed and custom-provider calls, and keeps the CLI event stream/significance handling in sync with the new events. Adds tests for telemetry filtering, routing metadata, external-consumer API shape, and success/failure telemetry emission, with `./gradlew jvmTest` passing in this workspace. `./gradlew ktlintFormat` still fails on unrelated pre-existing ktlint issues in the Android MCP connection files.