### PR TITLE
AMPR-144 / #443 bridge provider cost metadata to Phosphor

### DIFF
--- a/ampere-cli/build.gradle.kts
+++ b/ampere-cli/build.gradle.kts
@@ -84,7 +84,7 @@ kotlin {
         val jvmMain by getting {
             dependencies {
                 implementation(project(":ampere-core"))
-                implementation("link.socket:phosphor-core:0.2.3")
+                implementation("link.socket:phosphor-core:0.3.0")
 
                 // CLI argument parsing
                 implementation("com.github.ajalt.clikt:clikt:4.4.0")

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/DemoCommand.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/DemoCommand.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.runBlocking
 import link.socket.phosphor.choreography.AgentLayer
 import link.socket.phosphor.choreography.AgentLayoutOrientation
-import link.socket.phosphor.bridge.CognitiveEmitterBridge
 import link.socket.phosphor.emitter.EmitterManager
 import link.socket.phosphor.field.FlowLayer
 import link.socket.phosphor.field.SubstrateState
@@ -19,6 +18,7 @@ import link.socket.phosphor.timeline.PlaybackState
 import link.socket.phosphor.timeline.TimelineController
 import link.socket.phosphor.timeline.TimelineEvent
 import link.socket.phosphor.timeline.WaveformDemoTimeline
+import link.socket.ampere.cli.render.AmperePhosphorBridge
 import link.socket.ampere.cli.render.WaveformPaneRenderer
 import link.socket.ampere.repl.TerminalFactory
 
@@ -68,14 +68,14 @@ class WaveformDemoSubcommand : CliktCommand(
         val agents = AgentLayer(width, contentHeight, AgentLayoutOrientation.CIRCULAR)
         val flow = FlowLayer(width, contentHeight)
         val emitters = EmitterManager()
-        val emitterBridge = CognitiveEmitterBridge(emitters)
+        val emitterBridge = AmperePhosphorBridge(emitters)
         val substrate = SubstrateState.create(width, contentHeight, baseDensity = 0.2f)
 
         // Create waveform renderer
         val waveformPane = WaveformPaneRenderer(
             agentLayer = agents,
             emitterManager = emitters,
-            cognitiveEmitterBridge = emitterBridge
+            amperePhosphorBridge = emitterBridge
         )
 
         // Build timeline and controller

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/hybrid/HybridDashboardRenderer.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/hybrid/HybridDashboardRenderer.kt
@@ -1,11 +1,11 @@
 package link.socket.ampere.cli.hybrid
 
 import com.github.ajalt.mordant.terminal.Terminal
-import link.socket.phosphor.bridge.CognitiveEmitterBridge
 import link.socket.phosphor.emitter.EmitterManager
 import link.socket.phosphor.field.ParticleSystem
 import link.socket.ampere.cli.animation.render.AmperePalette
 import link.socket.ampere.cli.animation.render.CompositeRenderer
+import link.socket.ampere.cli.render.AmperePhosphorBridge
 import link.socket.phosphor.field.SubstrateAnimator
 import link.socket.phosphor.field.SubstrateGlyphs
 import link.socket.phosphor.field.SubstrateState
@@ -67,7 +67,7 @@ class HybridDashboardRenderer(
 
     // 3D waveform pipeline
     private lateinit var emitterManager: EmitterManager
-    private lateinit var cognitiveEmitterBridge: CognitiveEmitterBridge
+    private lateinit var amperePhosphorBridge: AmperePhosphorBridge
 
     /**
      * The waveform pane renderer for the middle pane. Callers can pass this
@@ -149,19 +149,22 @@ class HybridDashboardRenderer(
 
         // Initialize waveform pipeline
         emitterManager = EmitterManager()
-        cognitiveEmitterBridge = CognitiveEmitterBridge(emitterManager)
+        amperePhosphorBridge = AmperePhosphorBridge(emitterManager)
 
         if (config.enableWaveform) {
             val wfPane = WaveformPaneRenderer(
                 agentLayer = bridge.agentLayer,
                 emitterManager = emitterManager,
-                cognitiveEmitterBridge = cognitiveEmitterBridge
+                amperePhosphorBridge = amperePhosphorBridge
             )
             waveformPane = wfPane
 
             // Wire cognitive events from bridge to emitter bridge
             bridge.onCognitiveEvent = { event, position ->
-                cognitiveEmitterBridge.onCognitiveEvent(event, position)
+                amperePhosphorBridge.onCognitiveEvent(event, position)
+            }
+            bridge.onProviderTelemetry = { telemetry, position ->
+                amperePhosphorBridge.onProviderCallCompleted(telemetry, position)
             }
         }
 

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/hybrid/WatchStateAnimationBridge.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/hybrid/WatchStateAnimationBridge.kt
@@ -19,6 +19,7 @@ import link.socket.phosphor.field.SubstrateState
 import link.socket.phosphor.math.Vector2
 import link.socket.ampere.cli.watch.presentation.AgentState
 import link.socket.ampere.cli.watch.presentation.EventSignificance
+import link.socket.ampere.cli.watch.presentation.ProviderCallTelemetrySummary
 import link.socket.ampere.cli.watch.presentation.WatchViewState
 
 /**
@@ -44,6 +45,7 @@ class WatchStateAnimationBridge(
     private val maxParticles: Int = 30
 ) {
     private var previousEventCount = 0
+    private var previousProviderTelemetryIds = emptySet<String>()
     private var previousAgentStates = mapOf<String, AgentState>()
     private val burstEmitter = BurstEmitter()
 
@@ -70,6 +72,11 @@ class WatchStateAnimationBridge(
     var onCognitiveEvent: ((CognitiveEvent, Vector3) -> Unit)? = null
 
     /**
+     * Callback invoked when provider telemetry should generate metadata-rich emitters.
+     */
+    var onProviderTelemetry: ((ProviderCallTelemetrySummary, Vector3) -> Unit)? = null
+
+    /**
      * Update animation state based on current watch state.
      *
      * @param viewState Current snapshot from WatchPresenter (null-safe for graceful degradation)
@@ -89,14 +96,17 @@ class WatchStateAnimationBridge(
         // Update substrate hotspots based on active agents
         var result = updateHotspotsFromAgentActivity(viewState, substrate)
 
+        // Sync agent positions before event-driven emitters use them.
+        syncAgentLayer(viewState)
+
         // Detect new significant events and spawn particles
         detectNewEvents(viewState)
+        detectProviderTelemetry(viewState)
 
         // Detect agent state transitions and trigger pulses
         detectStateTransitions(viewState, result)?.let { result = it }
 
-        // Sync agent layer from view state and run choreographer
-        syncAgentLayer(viewState)
+        // Run phase-based choreography on the synchronized agent layer
         result = choreographer.update(agentLayer, result, deltaSeconds)
 
         // Apply ambient animation
@@ -110,6 +120,8 @@ class WatchStateAnimationBridge(
 
         // Track state for next frame
         previousEventCount = viewState.recentSignificantEvents.size
+        previousProviderTelemetryIds = viewState.recentProviderTelemetry
+            .mapTo(linkedSetOf()) { it.eventId }
         previousAgentStates = viewState.agentStates.mapValues { it.value.currentState }
 
         return result
@@ -257,6 +269,18 @@ class WatchStateAnimationBridge(
                 )
             }
         }
+    }
+
+    private fun detectProviderTelemetry(viewState: WatchViewState) {
+        if (viewState.recentProviderTelemetry.isEmpty()) return
+
+        viewState.recentProviderTelemetry
+            .asReversed()
+            .filter { it.eventId !in previousProviderTelemetryIds }
+            .forEach { telemetry ->
+                val agentPos = agentLayer.getAgent(telemetry.agentId)?.position3D ?: Vector3.ZERO
+                onProviderTelemetry?.invoke(telemetry, agentPos)
+            }
     }
 
     private fun detectStateTransitions(

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/render/AmperePhosphorBridge.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/render/AmperePhosphorBridge.kt
@@ -1,0 +1,59 @@
+package link.socket.ampere.cli.render
+
+import link.socket.ampere.agents.domain.cognition.sparks.CognitivePhase as AmperePhase
+import link.socket.ampere.cli.watch.presentation.ProviderCallTelemetrySummary
+import link.socket.phosphor.bridge.CognitiveEmitterBridge
+import link.socket.phosphor.bridge.CognitiveEvent
+import link.socket.phosphor.emitter.EmitterEffect
+import link.socket.phosphor.emitter.EmitterManager
+import link.socket.phosphor.emitter.MetadataKeys
+import link.socket.phosphor.math.Vector3
+import link.socket.phosphor.palette.AsciiLuminancePalette
+import link.socket.phosphor.palette.CognitiveColorRamp
+import link.socket.phosphor.signal.CognitivePhase as PhosphorPhase
+
+/**
+ * Preserves the existing cognitive emitter choreography and adds Ampere-specific
+ * provider-call metadata channels for Phosphor 0.3.0.
+ */
+class AmperePhosphorBridge(
+    private val emitterManager: EmitterManager,
+    private val cognitiveEmitterBridge: CognitiveEmitterBridge = CognitiveEmitterBridge(emitterManager)
+) {
+    fun onCognitiveEvent(event: CognitiveEvent, agentPosition: Vector3) {
+        cognitiveEmitterBridge.onCognitiveEvent(event, agentPosition)
+    }
+
+    fun onProviderCallCompleted(
+        event: ProviderCallTelemetrySummary,
+        agentPosition: Vector3,
+        currentTime: Float = 0f
+    ) {
+        emitterManager.emit(
+            effect = effectForPhase(event.cognitivePhase),
+            position = agentPosition,
+            currentTime = currentTime,
+            metadata = metadataFor(event)
+        )
+    }
+
+    internal fun metadataFor(event: ProviderCallTelemetrySummary): Map<String, Float> = buildMap {
+        event.estimatedCost?.let { put(MetadataKeys.HEAT, CostNormalizer.normalizeCost(it)) }
+        event.totalTokens?.let { put(MetadataKeys.DENSITY, CostNormalizer.normalizeTokens(it)) }
+        put(MetadataKeys.INTENSITY, CostNormalizer.normalizeLatency(event.latencyMs))
+    }
+
+    private fun effectForPhase(phase: AmperePhase?): EmitterEffect = when (phase) {
+        AmperePhase.PERCEIVE -> EmitterEffect.HeightPulse()
+        AmperePhase.PLAN -> EmitterEffect.ColorWash(
+            colorRamp = CognitiveColorRamp.forPhase(PhosphorPhase.PLAN)
+        )
+        AmperePhase.EXECUTE -> EmitterEffect.SparkBurst(
+            palette = AsciiLuminancePalette.EXECUTE
+        )
+        AmperePhase.LEARN -> EmitterEffect.ColorWash(
+            colorRamp = CognitiveColorRamp.forPhase(PhosphorPhase.EVALUATE)
+        )
+        null -> EmitterEffect.HeightPulse()
+    }
+}

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/render/CostNormalizer.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/render/CostNormalizer.kt
@@ -1,0 +1,35 @@
+package link.socket.ampere.cli.render
+
+import kotlin.math.log10
+
+/**
+ * Normalizes provider telemetry into 0.0-1.0 metadata channels for Phosphor.
+ */
+object CostNormalizer {
+    fun normalizeCost(costUsd: Double): Float {
+        if (costUsd <= 0.0) return 0f
+        return normalizeLog1p(value = costUsd, pivot = 0.0001, ceiling = 0.2)
+    }
+
+    fun normalizeLatency(latencyMs: Long): Float {
+        if (latencyMs <= 0L) return 0f
+        return normalizeLog1p(value = latencyMs.toDouble(), pivot = 100.0, ceiling = 15_000.0)
+    }
+
+    fun normalizeTokens(totalTokens: Int): Float {
+        if (totalTokens <= 0) return 0f
+        return normalizeLog1p(value = totalTokens.toDouble(), pivot = 250.0, ceiling = 150_000.0)
+    }
+
+    private fun normalizeLog1p(
+        value: Double,
+        pivot: Double,
+        ceiling: Double
+    ): Float {
+        val capped = value.coerceIn(0.0, ceiling)
+        if (capped == 0.0) return 0f
+
+        val normalized = log10(1.0 + capped / pivot) / log10(1.0 + ceiling / pivot)
+        return normalized.toFloat().coerceIn(0f, 1f)
+    }
+}

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/render/WaveformPaneRenderer.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/render/WaveformPaneRenderer.kt
@@ -2,7 +2,6 @@ package link.socket.ampere.cli.render
 
 import link.socket.phosphor.choreography.AgentLayer
 import link.socket.phosphor.choreography.AgentLayoutOrientation
-import link.socket.phosphor.bridge.CognitiveEmitterBridge
 import link.socket.phosphor.bridge.CognitiveEvent
 import link.socket.phosphor.emitter.EmitterManager
 import link.socket.phosphor.field.FlowLayer
@@ -33,7 +32,7 @@ import link.socket.ampere.cli.layout.PaneRenderer
 class WaveformPaneRenderer(
     private val agentLayer: AgentLayer,
     private val emitterManager: EmitterManager,
-    private val cognitiveEmitterBridge: CognitiveEmitterBridge
+    private val amperePhosphorBridge: AmperePhosphorBridge
 ) : PaneRenderer {
 
     private var cameraOrbit = CameraOrbit(
@@ -79,7 +78,7 @@ class WaveformPaneRenderer(
      * Fire a cognitive event through the emitter bridge.
      */
     fun onCognitiveEvent(event: CognitiveEvent, agentPosition: Vector3) {
-        cognitiveEmitterBridge.onCognitiveEvent(event, agentPosition)
+        amperePhosphorBridge.onCognitiveEvent(event, agentPosition)
     }
 
     override fun render(width: Int, height: Int): List<String> {

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/watch/presentation/WatchPresenter.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/watch/presentation/WatchPresenter.kt
@@ -17,6 +17,7 @@ import link.socket.ampere.agents.domain.event.MeetingEvent
 import link.socket.ampere.agents.domain.event.MemoryEvent
 import link.socket.ampere.agents.domain.event.MessageEvent
 import link.socket.ampere.agents.domain.event.ProductEvent
+import link.socket.ampere.agents.domain.event.ProviderCallCompletedEvent
 import link.socket.ampere.agents.domain.event.SparkAppliedEvent
 import link.socket.ampere.agents.domain.event.SparkEvent
 import link.socket.ampere.agents.domain.event.SparkRemovedEvent
@@ -45,6 +46,7 @@ class WatchPresenter(
     // Mutable state - only modified by event handler
     private val agentStates = mutableMapOf<String, AgentActivityState>()
     private val significantEvents = mutableListOf<SignificantEventSummary>()
+    private val providerTelemetry = mutableListOf<ProviderCallTelemetrySummary>()
     private var systemVitals = SystemVitals()
 
     private var eventCollectionJob: Job? = null
@@ -96,6 +98,10 @@ class WatchPresenter(
             // Add to significant events feed if warranted
             if (significance.shouldDisplayByDefault) {
                 addSignificantEvent(event, significance)
+            }
+
+            if (event is ProviderCallCompletedEvent) {
+                addProviderTelemetry(agentId, event)
             }
 
             // Update system vitals
@@ -224,6 +230,31 @@ class WatchPresenter(
         // Keep only most recent 20
         while (significantEvents.size > 20) {
             significantEvents.removeLast()
+        }
+
+        invalidateCache()
+    }
+
+    private fun addProviderTelemetry(agentId: String, event: ProviderCallCompletedEvent) {
+        val totalTokens = listOfNotNull(event.usage.inputTokens, event.usage.outputTokens)
+            .takeIf { it.isNotEmpty() }
+            ?.sum()
+
+        providerTelemetry.add(
+            0,
+            ProviderCallTelemetrySummary(
+                eventId = event.eventId,
+                agentId = agentId,
+                cognitivePhase = event.cognitivePhase,
+                latencyMs = event.latencyMs,
+                estimatedCost = event.usage.estimatedCost,
+                totalTokens = totalTokens,
+                success = event.success
+            )
+        )
+
+        while (providerTelemetry.size > 20) {
+            providerTelemetry.removeLast()
         }
 
         invalidateCache()
@@ -372,7 +403,8 @@ class WatchPresenter(
         val viewState = WatchViewState(
             systemVitals = systemVitals,
             agentStates = agentStates.toMap(), // Immutable copy
-            recentSignificantEvents = significantEvents.toList() // Immutable copy
+            recentSignificantEvents = significantEvents.toList(), // Immutable copy
+            recentProviderTelemetry = providerTelemetry.toList()
         )
 
         cachedViewState = viewState

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/watch/presentation/WatchViewState.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/watch/presentation/WatchViewState.kt
@@ -1,6 +1,7 @@
 package link.socket.ampere.cli.watch.presentation
 
 import kotlinx.datetime.Instant
+import link.socket.ampere.agents.domain.cognition.sparks.CognitivePhase
 
 /**
  * Immutable snapshot of watch state for rendering.
@@ -8,7 +9,8 @@ import kotlinx.datetime.Instant
 data class WatchViewState(
     val systemVitals: SystemVitals,
     val agentStates: Map<String, AgentActivityState>,
-    val recentSignificantEvents: List<SignificantEventSummary>
+    val recentSignificantEvents: List<SignificantEventSummary>,
+    val recentProviderTelemetry: List<ProviderCallTelemetrySummary> = emptyList()
 )
 
 /**
@@ -21,4 +23,17 @@ data class SignificantEventSummary(
     val sourceAgentName: String,
     val summaryText: String,
     val significance: EventSignificance
+)
+
+/**
+ * Telemetry summary for bridging provider calls into Phosphor emitter metadata.
+ */
+data class ProviderCallTelemetrySummary(
+    val eventId: String,
+    val agentId: String,
+    val cognitivePhase: CognitivePhase?,
+    val latencyMs: Long,
+    val estimatedCost: Double?,
+    val totalTokens: Int?,
+    val success: Boolean
 )

--- a/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/DemoCommandTest.kt
+++ b/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/DemoCommandTest.kt
@@ -2,13 +2,13 @@ package link.socket.ampere
 
 import link.socket.phosphor.choreography.AgentLayer
 import link.socket.phosphor.choreography.AgentLayoutOrientation
-import link.socket.phosphor.bridge.CognitiveEmitterBridge
 import link.socket.phosphor.emitter.EmitterManager
 import link.socket.phosphor.field.FlowLayer
 import link.socket.phosphor.field.SubstrateState
 import link.socket.phosphor.timeline.TimelineController
 import link.socket.phosphor.timeline.TimelineEvent
 import link.socket.phosphor.timeline.WaveformDemoTimeline
+import link.socket.ampere.cli.render.AmperePhosphorBridge
 import link.socket.ampere.cli.render.WaveformPaneRenderer
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -27,13 +27,13 @@ class DemoCommandTest {
         val agents = AgentLayer(width, height, AgentLayoutOrientation.CIRCULAR)
         val flow = FlowLayer(width, height)
         val emitters = EmitterManager()
-        val emitterBridge = CognitiveEmitterBridge(emitters)
+        val emitterBridge = AmperePhosphorBridge(emitters)
         val substrate = SubstrateState.create(width, height, baseDensity = 0.2f)
 
         val waveformPane = WaveformPaneRenderer(
             agentLayer = agents,
             emitterManager = emitters,
-            cognitiveEmitterBridge = emitterBridge
+            amperePhosphorBridge = emitterBridge
         )
 
         val timeline = WaveformDemoTimeline.build(agents, flow, emitters)

--- a/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/cli/hybrid/WatchStateAnimationBridgeTest.kt
+++ b/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/cli/hybrid/WatchStateAnimationBridgeTest.kt
@@ -1,12 +1,14 @@
 package link.socket.ampere.cli.hybrid
 
 import kotlinx.datetime.Clock
+import link.socket.ampere.agents.domain.cognition.sparks.CognitivePhase
 import link.socket.phosphor.field.ParticleSystem
 import link.socket.phosphor.field.SubstrateAnimator
 import link.socket.phosphor.field.SubstrateState
 import link.socket.ampere.cli.watch.presentation.AgentActivityState
 import link.socket.ampere.cli.watch.presentation.AgentState
 import link.socket.ampere.cli.watch.presentation.EventSignificance
+import link.socket.ampere.cli.watch.presentation.ProviderCallTelemetrySummary
 import link.socket.ampere.cli.watch.presentation.SignificantEventSummary
 import link.socket.ampere.cli.watch.presentation.SystemVitals
 import link.socket.ampere.cli.watch.presentation.WatchViewState
@@ -36,7 +38,8 @@ class WatchStateAnimationBridgeTest {
 
     private fun createViewState(
         agents: Map<String, AgentActivityState> = emptyMap(),
-        events: List<SignificantEventSummary> = emptyList()
+        events: List<SignificantEventSummary> = emptyList(),
+        telemetry: List<ProviderCallTelemetrySummary> = emptyList()
     ): WatchViewState {
         return WatchViewState(
             systemVitals = SystemVitals(
@@ -45,7 +48,8 @@ class WatchStateAnimationBridgeTest {
                 lastSignificantEventTime = now
             ),
             agentStates = agents,
-            recentSignificantEvents = events
+            recentSignificantEvents = events,
+            recentProviderTelemetry = telemetry
         )
     }
 
@@ -74,6 +78,18 @@ class WatchStateAnimationBridgeTest {
             sourceAgentName = "test-agent",
             summaryText = "Test event",
             significance = significance
+        )
+    }
+
+    private fun createTelemetry(agentId: String): ProviderCallTelemetrySummary {
+        return ProviderCallTelemetrySummary(
+            eventId = "provider-${System.nanoTime()}",
+            agentId = agentId,
+            cognitivePhase = CognitivePhase.EXECUTE,
+            latencyMs = 900,
+            estimatedCost = 0.01,
+            totalTokens = 4_000,
+            success = true
         )
     }
 
@@ -190,6 +206,32 @@ class WatchStateAnimationBridgeTest {
         }
 
         assertTrue(particles.count <= 30, "Particles should be bounded at max 30, got ${particles.count}")
+    }
+
+    @Test
+    fun `provider telemetry callback fires for new provider event`() {
+        val (bridge, substrate, _) = createBridge()
+        val agents = mapOf(
+            "agent-1" to createAgent("agent-1", AgentState.WORKING, idle = false)
+        )
+        val telemetry = mutableListOf<ProviderCallTelemetrySummary>()
+
+        bridge.onProviderTelemetry = { summary, _ ->
+            telemetry += summary
+        }
+
+        bridge.update(createViewState(agents = agents), substrate, 0.1f)
+        bridge.update(
+            createViewState(
+                agents = agents,
+                telemetry = listOf(createTelemetry("agent-1"))
+            ),
+            substrate,
+            0.1f
+        )
+
+        assertEquals(1, telemetry.size)
+        assertEquals("agent-1", telemetry.single().agentId)
     }
 
     @Test

--- a/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/cli/render/AmperePhosphorBridgeTest.kt
+++ b/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/cli/render/AmperePhosphorBridgeTest.kt
@@ -1,0 +1,73 @@
+package link.socket.ampere.cli.render
+
+import link.socket.ampere.agents.domain.cognition.sparks.CognitivePhase
+import link.socket.ampere.cli.watch.presentation.ProviderCallTelemetrySummary
+import link.socket.phosphor.emitter.EmitterManager
+import link.socket.phosphor.emitter.MetadataKeys
+import link.socket.phosphor.math.Vector3
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AmperePhosphorBridgeTest {
+    @Test
+    fun `provider telemetry emits metadata rich effect`() {
+        val emitterManager = EmitterManager()
+        val bridge = AmperePhosphorBridge(emitterManager)
+        val telemetry = ProviderCallTelemetrySummary(
+            eventId = "evt-provider-1",
+            agentId = "agent-1",
+            cognitivePhase = CognitivePhase.EXECUTE,
+            latencyMs = 1_200,
+            estimatedCost = 0.015,
+            totalTokens = 6_000,
+            success = true
+        )
+
+        bridge.onProviderCallCompleted(telemetry, Vector3(2f, 0f, 3f), currentTime = 1.5f)
+
+        assertEquals(1, emitterManager.activeCount)
+        val instance = emitterManager.instances.single()
+        assertEquals(1.5f, instance.activatedAt)
+        assertEquals(Vector3(2f, 0f, 3f), instance.position)
+        assertTrue(instance.metadata.containsKey(MetadataKeys.HEAT))
+        assertTrue(instance.metadata.containsKey(MetadataKeys.INTENSITY))
+        assertTrue(instance.metadata.containsKey(MetadataKeys.DENSITY))
+        assertEquals(
+            CostNormalizer.normalizeCost(0.015),
+            instance.metadata.getValue(MetadataKeys.HEAT)
+        )
+        assertEquals(
+            CostNormalizer.normalizeLatency(1_200),
+            instance.metadata.getValue(MetadataKeys.INTENSITY)
+        )
+        assertEquals(
+            CostNormalizer.normalizeTokens(6_000),
+            instance.metadata.getValue(MetadataKeys.DENSITY)
+        )
+    }
+
+    @Test
+    fun `provider telemetry without cost still emits latency metadata`() {
+        val emitterManager = EmitterManager()
+        val bridge = AmperePhosphorBridge(emitterManager)
+        val telemetry = ProviderCallTelemetrySummary(
+            eventId = "evt-provider-2",
+            agentId = "agent-2",
+            cognitivePhase = null,
+            latencyMs = 250,
+            estimatedCost = null,
+            totalTokens = null,
+            success = false
+        )
+
+        bridge.onProviderCallCompleted(telemetry, Vector3.ZERO)
+
+        val instance = emitterManager.instances.single()
+        assertEquals(setOf(MetadataKeys.INTENSITY), instance.metadata.keys)
+        assertEquals(
+            CostNormalizer.normalizeLatency(250),
+            instance.metadata.getValue(MetadataKeys.INTENSITY)
+        )
+    }
+}

--- a/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/cli/render/CostNormalizerTest.kt
+++ b/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/cli/render/CostNormalizerTest.kt
@@ -1,0 +1,51 @@
+package link.socket.ampere.cli.render
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CostNormalizerTest {
+    @Test
+    fun `cost normalization uses broad logarithmic bands`() {
+        val haikuCost = CostNormalizer.normalizeCost(0.0001)
+        val sonnetCost = CostNormalizer.normalizeCost(0.01)
+        val opusCost = CostNormalizer.normalizeCost(0.1)
+
+        assertTrue(haikuCost in 0.05f..0.2f, "Expected low-cost call to stay subtle, got $haikuCost")
+        assertTrue(sonnetCost in 0.45f..0.7f, "Expected mid-cost call near the middle, got $sonnetCost")
+        assertTrue(opusCost in 0.75f..0.95f, "Expected high-cost call to read as hot, got $opusCost")
+    }
+
+    @Test
+    fun `latency normalization spans interactive to slow calls`() {
+        val fast = CostNormalizer.normalizeLatency(100)
+        val medium = CostNormalizer.normalizeLatency(1_000)
+        val slow = CostNormalizer.normalizeLatency(10_000)
+
+        assertTrue(fast in 0.1f..0.2f, "Expected fast call to stay low intensity, got $fast")
+        assertTrue(medium in 0.4f..0.6f, "Expected medium call near midpoint, got $medium")
+        assertTrue(slow in 0.85f..0.95f, "Expected slow call to read as intense, got $slow")
+    }
+
+    @Test
+    fun `token normalization distinguishes sparse and dense calls`() {
+        val sparse = CostNormalizer.normalizeTokens(100)
+        val medium = CostNormalizer.normalizeTokens(5_000)
+        val dense = CostNormalizer.normalizeTokens(100_000)
+
+        assertTrue(sparse in 0.02f..0.1f, "Expected sparse call to remain faint, got $sparse")
+        assertTrue(medium in 0.4f..0.6f, "Expected medium call near midpoint, got $medium")
+        assertTrue(dense in 0.85f..0.95f, "Expected dense call to saturate strongly, got $dense")
+    }
+
+    @Test
+    fun `zero and extreme values stay clamped`() {
+        assertEquals(0f, CostNormalizer.normalizeCost(0.0))
+        assertEquals(0f, CostNormalizer.normalizeLatency(0))
+        assertEquals(0f, CostNormalizer.normalizeTokens(0))
+
+        assertEquals(1f, CostNormalizer.normalizeCost(10.0))
+        assertEquals(1f, CostNormalizer.normalizeLatency(60_000))
+        assertEquals(1f, CostNormalizer.normalizeTokens(500_000))
+    }
+}

--- a/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/cli/render/WaveformPaneRendererTest.kt
+++ b/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/cli/render/WaveformPaneRendererTest.kt
@@ -5,7 +5,6 @@ import link.socket.phosphor.choreography.AgentLayer
 import link.socket.phosphor.choreography.AgentLayoutOrientation
 import link.socket.phosphor.signal.AgentVisualState
 import link.socket.phosphor.signal.CognitivePhase
-import link.socket.phosphor.bridge.CognitiveEmitterBridge
 import link.socket.phosphor.emitter.EmitterManager
 import link.socket.phosphor.math.Vector3
 import link.socket.phosphor.render.AsciiCell
@@ -19,12 +18,12 @@ class WaveformPaneRendererTest {
 
     private val agentLayer = AgentLayer(80, 24, AgentLayoutOrientation.CUSTOM)
     private val emitterManager = EmitterManager()
-    private val cognitiveEmitterBridge = CognitiveEmitterBridge(emitterManager)
+    private val amperePhosphorBridge = AmperePhosphorBridge(emitterManager)
 
     private val renderer = WaveformPaneRenderer(
         agentLayer = agentLayer,
         emitterManager = emitterManager,
-        cognitiveEmitterBridge = cognitiveEmitterBridge
+        amperePhosphorBridge = amperePhosphorBridge
     )
 
     @Test

--- a/ampere-compose/build.gradle.kts
+++ b/ampere-compose/build.gradle.kts
@@ -23,7 +23,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation("link.socket:phosphor-core:0.2.3")
+                implementation("link.socket:phosphor-core:0.3.0")
                 implementation(compose.runtime)
                 implementation(compose.foundation)
                 implementation(compose.ui)

--- a/ampere-desktop/build.gradle.kts
+++ b/ampere-desktop/build.gradle.kts
@@ -21,7 +21,7 @@ kotlin {
                 implementation(project(":ampere-core"))
                 implementation(project(":ampere-compose"))
                 implementation(project(":ampere-cli"))
-                implementation("link.socket:phosphor-core:0.2.3")
+                implementation("link.socket:phosphor-core:0.3.0")
                 implementation(compose.desktop.currentOs)
             }
         }


### PR DESCRIPTION
Closes #443.

I wrote this PR to upgrade Ampere to Phosphor 0.3.0 and bridge provider completion telemetry into metadata-rich emitter effects.
It threads provider call telemetry through the watch presentation layer, maps cost, latency, and token usage into HEAT, INTENSITY, and DENSITY, and keeps the existing cognitive choreography in place.
It also updates the waveform and demo integrations to use the new Ampere-local bridge and adds tests covering normalization, metadata emission, and telemetry propagation.