### PR TITLE
[AMPR-149 #458] Codex: plugin permission schema

### DIFF
--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/watch/presentation/EventCategorizer.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/watch/presentation/EventCategorizer.kt
@@ -9,6 +9,7 @@ import link.socket.ampere.agents.domain.event.MemoryEvent
 import link.socket.ampere.agents.domain.event.MessageEvent
 import link.socket.ampere.agents.domain.event.NotificationEvent
 import link.socket.ampere.agents.domain.event.PlanEvent
+import link.socket.ampere.agents.domain.event.PermissionDeniedEvent
 import link.socket.ampere.agents.domain.event.ProviderCallCompletedEvent
 import link.socket.ampere.agents.domain.event.ProviderCallStartedEvent
 import link.socket.ampere.agents.domain.event.ProductEvent
@@ -53,6 +54,7 @@ object EventCategorizer {
         is TicketEvent.TicketBlocked,
         is MessageEvent.EscalationRequested,
         is HumanInteractionEvent.InputRequested,
+        is PermissionDeniedEvent,
         is TaskEvent.TaskFailed -> EventSignificance.CRITICAL
 
         // Significant events represent state changes worth noting

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/renderer/EventRenderer.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/renderer/EventRenderer.kt
@@ -22,6 +22,7 @@ import link.socket.ampere.agents.domain.event.MemoryEvent
 import link.socket.ampere.agents.domain.event.MessageEvent
 import link.socket.ampere.agents.domain.event.NotificationEvent
 import link.socket.ampere.agents.domain.event.PlanEvent
+import link.socket.ampere.agents.domain.event.PermissionDeniedEvent
 import link.socket.ampere.agents.domain.event.ProviderCallCompletedEvent
 import link.socket.ampere.agents.domain.event.ProviderCallStartedEvent
 import link.socket.ampere.agents.domain.event.ProductEvent
@@ -141,6 +142,7 @@ class EventRenderer(
             is MessageEvent -> "💬" to blue
             is NotificationEvent<*> -> "🔔" to gray
             is PlanEvent -> "📋" to magenta
+            is PermissionDeniedEvent -> "⛔" to red
             is ProviderCallStartedEvent -> "📡" to cyan
             is ProviderCallCompletedEvent -> "📡" to if (event.success) blue else red
             is ProductEvent -> "💡" to green

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/EventRegistry.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/EventRegistry.kt
@@ -95,6 +95,9 @@ object EventRegistry {
         // TelemetryEvent types
         ProviderCallStartedEvent.EVENT_TYPE,
         ProviderCallCompletedEvent.EVENT_TYPE,
+
+        // PermissionEvent types
+        PermissionDeniedEvent.EVENT_TYPE,
     )
 
     /**

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/PermissionDeniedEvent.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/PermissionDeniedEvent.kt
@@ -1,0 +1,47 @@
+package link.socket.ampere.agents.domain.event
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import link.socket.ampere.agents.domain.Urgency
+import link.socket.ampere.agents.execution.tools.ToolId
+import link.socket.ampere.plugin.permission.PluginPermission
+
+@Serializable
+enum class PermissionDeniedReason {
+    MISSING_GRANT,
+    REVOKED_GRANT,
+}
+
+@Serializable
+@SerialName("PermissionDeniedEvent")
+data class PermissionDeniedEvent(
+    override val eventId: EventId,
+    override val timestamp: Instant,
+    override val eventSource: EventSource,
+    override val urgency: Urgency = Urgency.HIGH,
+    val pluginId: String,
+    val toolId: ToolId,
+    val toolName: String,
+    val permission: PluginPermission,
+    val reason: PermissionDeniedReason,
+) : Event {
+
+    override val eventType: EventType = EVENT_TYPE
+
+    override fun getSummary(
+        formatUrgency: (Urgency) -> String,
+        formatSource: (EventSource) -> String,
+    ): String = buildString {
+        append("Permission denied: $toolName ($toolId)")
+        append(" plugin=$pluginId")
+        append(" reason=$reason")
+        append(" permission=$permission")
+        append(" ${formatUrgency(urgency)}")
+        append(" from ${formatSource(eventSource)}")
+    }
+
+    companion object {
+        const val EVENT_TYPE: EventType = "PermissionDenied"
+    }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/reasoning/AgentReasoning.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/reasoning/AgentReasoning.kt
@@ -17,6 +17,8 @@ import link.socket.ampere.agents.execution.executor.Executor
 import link.socket.ampere.agents.execution.executor.ExecutorId
 import link.socket.ampere.agents.execution.request.ExecutionRequest
 import link.socket.ampere.agents.execution.tools.Tool
+import link.socket.ampere.plugin.PluginManifest
+import link.socket.ampere.plugin.permission.UserGrants
 
 /**
  * Unified reasoning facade that composes all cognitive services.
@@ -75,7 +77,13 @@ class AgentReasoning private constructor(
     private val planExecutor = PlanExecutor(settings.executorId)
 
     private val toolExecutionEngine: ToolExecutionEngine? = if (llmService != null && settings.executor != null) {
-        ToolExecutionEngine(llmService, settings.executor, settings.executorId).also { engine ->
+        ToolExecutionEngine(
+            llmService = llmService,
+            executor = settings.executor,
+            executorId = settings.executorId,
+            eventApi = eventApi,
+            userGrantProvider = settings.userGrantProvider,
+        ).also { engine ->
             settings.parameterStrategies.forEach { (toolId, strategy) ->
                 engine.registerStrategy(toolId, strategy)
             }
@@ -305,6 +313,7 @@ class AgentReasoning private constructor(
                 planningPromptBuilder = null,
                 taskFactory = DefaultTaskFactory,
                 parameterStrategies = emptyMap(),
+                userGrantProvider = { UserGrants() },
                 outcomeContextBuilder = null,
                 knowledgeExtractor = null,
             )
@@ -380,6 +389,7 @@ data class ReasoningSettings(
     val planningPromptBuilder: ((Task, List<Idea>, Set<Tool<*>>, List<KnowledgeWithScore>) -> String)?,
     val taskFactory: TaskFactory,
     val parameterStrategies: Map<String, ParameterStrategy>,
+    val userGrantProvider: suspend (PluginManifest) -> UserGrants,
     val outcomeContextBuilder: ((List<Outcome>) -> String)?,
     val knowledgeExtractor: ((Outcome, Task, Plan) -> Knowledge.FromOutcome)?,
 )
@@ -396,6 +406,7 @@ class ReasoningSettingsBuilder(private val executorId: ExecutorId) {
     private var planningPromptBuilder: ((Task, List<Idea>, Set<Tool<*>>, List<KnowledgeWithScore>) -> String)? = null
     private var taskFactory: TaskFactory = DefaultTaskFactory
     private val parameterStrategies = mutableMapOf<String, ParameterStrategy>()
+    private var userGrantProvider: suspend (PluginManifest) -> UserGrants = { UserGrants() }
     private var outcomeContextBuilder: ((List<Outcome>) -> String)? = null
     private var knowledgeExtractor: ((Outcome, Task, Plan) -> Knowledge.FromOutcome)? = null
 
@@ -425,6 +436,7 @@ class ReasoningSettingsBuilder(private val executorId: ExecutorId) {
         val builder = ExecutionSettingsBuilder()
         builder.configure()
         parameterStrategies.putAll(builder.strategies)
+        userGrantProvider = builder.userGrantProvider
     }
 
     /**
@@ -455,6 +467,7 @@ class ReasoningSettingsBuilder(private val executorId: ExecutorId) {
             planningPromptBuilder = planningPromptBuilder,
             taskFactory = taskFactory,
             parameterStrategies = parameterStrategies.toMap(),
+            userGrantProvider = userGrantProvider,
             outcomeContextBuilder = outcomeContextBuilder,
             knowledgeExtractor = knowledgeExtractor,
         )
@@ -472,9 +485,14 @@ class PlanningSettingsBuilder {
 
 class ExecutionSettingsBuilder {
     internal val strategies = mutableMapOf<String, ParameterStrategy>()
+    internal var userGrantProvider: suspend (PluginManifest) -> UserGrants = { UserGrants() }
 
     fun registerStrategy(toolId: String, strategy: ParameterStrategy) {
         strategies[toolId] = strategy
+    }
+
+    fun userGrants(provider: suspend (PluginManifest) -> UserGrants) {
+        userGrantProvider = provider
     }
 }
 

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/api/AgentEventApi.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/api/AgentEventApi.kt
@@ -9,6 +9,8 @@ import link.socket.ampere.agents.domain.event.Event
 import link.socket.ampere.agents.domain.event.EventSource
 import link.socket.ampere.agents.domain.event.EventType
 import link.socket.ampere.agents.domain.event.MessageEvent
+import link.socket.ampere.agents.domain.event.PermissionDeniedEvent
+import link.socket.ampere.agents.domain.event.PermissionDeniedReason
 import link.socket.ampere.agents.domain.event.TaskEvent
 import link.socket.ampere.agents.domain.event.ToolEvent
 import link.socket.ampere.agents.domain.task.TaskId
@@ -22,6 +24,7 @@ import link.socket.ampere.agents.events.subscription.Subscription
 import link.socket.ampere.agents.events.utils.ConsoleEventLogger
 import link.socket.ampere.agents.events.utils.EventLogger
 import link.socket.ampere.agents.events.utils.generateUUID
+import link.socket.ampere.plugin.permission.PluginPermission
 
 open class EventHandler<E : Event, S : Subscription>(
     private val executeOverride: (suspend (E, S?) -> Unit)? = null,
@@ -546,6 +549,42 @@ class AgentEventApi(
         eventSerialBus.subscribe<ToolEvent.ToolDiscoveryComplete, EventSubscription.ByEventClassType>(
             agentId = agentId,
             eventType = ToolEvent.ToolDiscoveryComplete.EVENT_TYPE,
+        ) { event, subscription ->
+            if (filter.execute(event)) {
+                handler(event, subscription)
+            }
+        }
+
+    suspend fun publishPermissionDenied(
+        pluginId: String,
+        toolId: String,
+        toolName: String,
+        permission: PluginPermission,
+        reason: PermissionDeniedReason,
+        urgency: Urgency = Urgency.HIGH,
+    ) {
+        val event = PermissionDeniedEvent(
+            eventId = generateUUID("permission-denied", pluginId, toolId, agentId),
+            timestamp = Clock.System.now(),
+            eventSource = EventSource.Agent(agentId),
+            urgency = urgency,
+            pluginId = pluginId,
+            toolId = toolId,
+            toolName = toolName,
+            permission = permission,
+            reason = reason,
+        )
+
+        publish(event)
+    }
+
+    fun onPermissionDenied(
+        filter: EventFilter<PermissionDeniedEvent> = EventFilter.noFilter(),
+        handler: suspend (PermissionDeniedEvent, Subscription?) -> Unit,
+    ): Subscription =
+        eventSerialBus.subscribe<PermissionDeniedEvent, EventSubscription.ByEventClassType>(
+            agentId = agentId,
+            eventType = PermissionDeniedEvent.EVENT_TYPE,
         ) { event, subscription ->
             if (filter.execute(event)) {
                 handler(event, subscription)

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/utils/SignificanceAwareEventLogger.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/utils/SignificanceAwareEventLogger.kt
@@ -12,6 +12,7 @@ import link.socket.ampere.agents.domain.event.MeetingEvent
 import link.socket.ampere.agents.domain.event.MemoryEvent
 import link.socket.ampere.agents.domain.event.MessageEvent
 import link.socket.ampere.agents.domain.event.NotificationEvent
+import link.socket.ampere.agents.domain.event.PermissionDeniedEvent
 import link.socket.ampere.agents.domain.event.PlanEvent
 import link.socket.ampere.agents.domain.event.ProductEvent
 import link.socket.ampere.agents.domain.event.ProviderCallCompletedEvent
@@ -95,6 +96,7 @@ class SignificanceAwareEventLogger(
         is Event.QuestionRaised -> EventSignificance.CRITICAL
         is TicketEvent.TicketBlocked -> EventSignificance.CRITICAL
         is MessageEvent.EscalationRequested -> EventSignificance.CRITICAL
+        is PermissionDeniedEvent -> EventSignificance.CRITICAL
 
         // Task lifecycle events
         is TaskEvent.TaskCompleted -> EventSignificance.SIGNIFICANT

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/execution/ToolExecutionEngine.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/execution/ToolExecutionEngine.kt
@@ -3,9 +3,15 @@ package link.socket.ampere.agents.execution
 import kotlinx.coroutines.flow.last
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
+import link.socket.ampere.agents.domain.Urgency
+import link.socket.ampere.agents.domain.event.EventSource
+import link.socket.ampere.agents.domain.event.PermissionDeniedEvent
+import link.socket.ampere.agents.domain.event.PermissionDeniedReason
 import link.socket.ampere.agents.domain.outcome.ExecutionOutcome
 import link.socket.ampere.agents.domain.reasoning.AgentLLMService
 import link.socket.ampere.agents.domain.status.ExecutionStatus
+import link.socket.ampere.agents.events.api.AgentEventApi
+import link.socket.ampere.agents.events.utils.generateUUID
 import link.socket.ampere.agents.execution.executor.Executor
 import link.socket.ampere.agents.execution.executor.ExecutorId
 import link.socket.ampere.agents.execution.request.ExecutionContext
@@ -13,6 +19,12 @@ import link.socket.ampere.agents.execution.request.ExecutionRequest
 import link.socket.ampere.agents.execution.tools.FunctionTool
 import link.socket.ampere.agents.execution.tools.McpTool
 import link.socket.ampere.agents.execution.tools.Tool
+import link.socket.ampere.plugin.PluginManifest
+import link.socket.ampere.plugin.permission.GateResult
+import link.socket.ampere.plugin.permission.PluginPermission
+import link.socket.ampere.plugin.permission.PluginPermissionGate
+import link.socket.ampere.plugin.permission.PluginToolCall
+import link.socket.ampere.plugin.permission.UserGrants
 
 /**
  * Engine for executing tools with LLM-generated parameters.
@@ -49,6 +61,8 @@ class ToolExecutionEngine(
     private val llmService: AgentLLMService,
     private val executor: Executor,
     private val executorId: ExecutorId,
+    private val eventApi: AgentEventApi? = null,
+    private val userGrantProvider: suspend (PluginManifest) -> UserGrants = { UserGrants() },
 ) {
 
     private val strategies = mutableMapOf<String, ParameterStrategy>()
@@ -84,6 +98,11 @@ class ToolExecutionEngine(
                 startTime = startTime,
                 message = "Cannot execute tool: no intent found in request",
             )
+        }
+
+        val permissionFailure = checkPluginPermissions(tool, request, startTime)
+        if (permissionFailure != null) {
+            return permissionFailure
         }
 
         // Check for MCP tools (not yet supported)
@@ -206,6 +225,73 @@ class ToolExecutionEngine(
             executionStartTimestamp = startTime,
             executionEndTimestamp = Clock.System.now(),
             message = message,
+        )
+    }
+
+    private suspend fun checkPluginPermissions(
+        tool: Tool<*>,
+        request: ExecutionRequest<*>,
+        startTime: Instant,
+    ): ExecutionOutcome? {
+        val manifest = tool.pluginManifest ?: return null
+        val userGrants = userGrantProvider(manifest)
+        val gateResult = PluginPermissionGate.check(
+            toolCall = PluginToolCall(
+                pluginId = manifest.id,
+                toolId = tool.id,
+            ),
+            manifest = manifest,
+            userGrants = userGrants,
+        )
+
+        return when (gateResult) {
+            GateResult.Allow -> null
+            is GateResult.DenyMissing -> createPermissionDeniedFailure(
+                request = request,
+                startTime = startTime,
+                tool = tool,
+                manifest = manifest,
+                permission = gateResult.permission,
+                reason = PermissionDeniedReason.MISSING_GRANT,
+            )
+            is GateResult.DenyRevoked -> createPermissionDeniedFailure(
+                request = request,
+                startTime = startTime,
+                tool = tool,
+                manifest = manifest,
+                permission = gateResult.permission,
+                reason = PermissionDeniedReason.REVOKED_GRANT,
+            )
+        }
+    }
+
+    private suspend fun createPermissionDeniedFailure(
+        request: ExecutionRequest<*>,
+        startTime: Instant,
+        tool: Tool<*>,
+        manifest: PluginManifest,
+        permission: PluginPermission,
+        reason: PermissionDeniedReason,
+    ): ExecutionOutcome {
+        eventApi?.publish(
+            PermissionDeniedEvent(
+                eventId = generateUUID("permission-denied", manifest.id, tool.id, executorId),
+                timestamp = Clock.System.now(),
+                eventSource = EventSource.Agent(eventApi.agentId),
+                urgency = Urgency.HIGH,
+                pluginId = manifest.id,
+                toolId = tool.id,
+                toolName = tool.name,
+                permission = permission,
+                reason = reason,
+            ),
+        )
+
+        return createFailure(
+            request = request,
+            startTime = startTime,
+            message = "Permission denied for plugin '${manifest.id}' tool '${tool.id}': " +
+                "$reason for $permission",
         )
     }
 }

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/execution/tools/Tool.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/execution/tools/Tool.kt
@@ -8,6 +8,7 @@ import link.socket.ampere.agents.domain.outcome.Outcome
 import link.socket.ampere.agents.execution.request.ExecutionContext
 import link.socket.ampere.agents.execution.request.ExecutionRequest
 import link.socket.ampere.agents.tools.mcp.McpToolExecutor
+import link.socket.ampere.plugin.PluginManifest
 
 typealias ToolId = String
 typealias McpServerId = String
@@ -49,6 +50,13 @@ sealed interface Tool<Context : ExecutionContext> {
     val requiredAgentAutonomy: AgentActionAutonomy
 
     /**
+     * Optional plugin manifest for tools supplied by a plugin.
+     * Built-in tools leave this null and bypass plugin permission checks.
+     */
+    val pluginManifest: PluginManifest?
+        get() = null
+
+    /**
      * Executes the tool with the given request parameters.
      *
      * @param executionRequest parameters, context, and instructions for the execution.
@@ -73,6 +81,7 @@ data class FunctionTool<Context : ExecutionContext>(
     override val name: String,
     override val description: String,
     override val requiredAgentAutonomy: AgentActionAutonomy,
+    override val pluginManifest: PluginManifest? = null,
 
     /**
      * The actual executable function wrapped by this tool.
@@ -108,6 +117,7 @@ data class McpTool(
     override val name: String,
     override val description: String,
     override val requiredAgentAutonomy: AgentActionAutonomy,
+    override val pluginManifest: PluginManifest? = null,
 
     /**
      * Identifier of the MCP server that exposes this tool.

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/api/service/EventService.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/api/service/EventService.kt
@@ -12,6 +12,7 @@ import link.socket.ampere.agents.domain.event.MeetingEvent
 import link.socket.ampere.agents.domain.event.MemoryEvent
 import link.socket.ampere.agents.domain.event.MessageEvent
 import link.socket.ampere.agents.domain.event.NotificationEvent
+import link.socket.ampere.agents.domain.event.PermissionDeniedEvent
 import link.socket.ampere.agents.domain.event.PlanEvent
 import link.socket.ampere.agents.domain.event.ProductEvent
 import link.socket.ampere.agents.domain.event.ProviderCallCompletedEvent
@@ -173,6 +174,7 @@ enum class EventStreamFilter {
             is MeetingEvent,
             is FileSystemEvent,
             is GitEvent,
+            is PermissionDeniedEvent,
             is ToolEvent.ToolExecutionStarted,
             is ToolEvent.ToolExecutionCompleted,
             -> true

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/plugin/PluginManifest.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/plugin/PluginManifest.kt
@@ -1,0 +1,20 @@
+package link.socket.ampere.plugin
+
+import kotlinx.serialization.Serializable
+import link.socket.ampere.plugin.permission.PluginPermission
+
+/**
+ * Manifest metadata for a plugin and the permissions it requires at runtime.
+ *
+ * [requiredPermissions] defaults to empty so manifests created before the
+ * permission schema continue to decode unchanged.
+ */
+@Serializable
+data class PluginManifest(
+    val id: String,
+    val name: String,
+    val version: String,
+    val description: String? = null,
+    val entrypoint: String? = null,
+    val requiredPermissions: List<PluginPermission> = emptyList(),
+)

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/plugin/permission/PluginPermission.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/plugin/permission/PluginPermission.kt
@@ -1,0 +1,31 @@
+package link.socket.ampere.plugin.permission
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Declarative permissions a plugin must declare before Ampere dispatches its tools.
+ */
+@Serializable
+sealed interface PluginPermission {
+
+    @Serializable
+    @SerialName("network_domain")
+    data class NetworkDomain(val host: String) : PluginPermission
+
+    @Serializable
+    @SerialName("mcp_server")
+    data class MCPServer(val uri: String) : PluginPermission
+
+    @Serializable
+    @SerialName("knowledge_query")
+    data class KnowledgeQuery(val scope: String) : PluginPermission
+
+    @Serializable
+    @SerialName("native_action")
+    data class NativeAction(val actionId: String) : PluginPermission
+
+    @Serializable
+    @SerialName("link_access")
+    data class LinkAccess(val linkId: String) : PluginPermission
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/plugin/permission/PluginPermissionGate.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/plugin/permission/PluginPermissionGate.kt
@@ -1,0 +1,64 @@
+package link.socket.ampere.plugin.permission
+
+import kotlinx.serialization.Serializable
+import link.socket.ampere.plugin.PluginManifest
+
+/**
+ * Deterministic permission gate that runs before plugin-backed tool dispatch.
+ */
+object PluginPermissionGate {
+
+    fun check(
+        toolCall: PluginToolCall,
+        manifest: PluginManifest,
+        userGrants: UserGrants,
+    ): GateResult {
+        val requiredPermissions = (manifest.requiredPermissions + toolCall.requestedPermissions).distinct()
+
+        requiredPermissions.forEach { permission ->
+            if (permission in userGrants.revoked) {
+                return GateResult.DenyRevoked(permission)
+            }
+
+            if (permission !in userGrants.granted) {
+                return GateResult.DenyMissing(permission)
+            }
+        }
+
+        return GateResult.Allow
+    }
+}
+
+@Serializable
+data class PluginToolCall(
+    val pluginId: String,
+    val toolId: String,
+    val requestedPermissions: List<PluginPermission> = emptyList(),
+)
+
+@Serializable
+data class UserGrants(
+    val granted: List<PluginPermission> = emptyList(),
+    val revoked: List<PluginPermission> = emptyList(),
+) {
+    companion object {
+        fun granted(vararg permissions: PluginPermission): UserGrants =
+            UserGrants(granted = permissions.toList())
+
+        fun revoked(vararg permissions: PluginPermission): UserGrants =
+            UserGrants(revoked = permissions.toList())
+    }
+}
+
+@Serializable
+sealed interface GateResult {
+
+    @Serializable
+    data object Allow : GateResult
+
+    @Serializable
+    data class DenyMissing(val permission: PluginPermission) : GateResult
+
+    @Serializable
+    data class DenyRevoked(val permission: PluginPermission) : GateResult
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/plugin/permission/UserGrantStore.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/plugin/permission/UserGrantStore.kt
@@ -1,0 +1,99 @@
+package link.socket.ampere.plugin.permission
+
+import kotlinx.coroutines.withContext
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlinx.serialization.json.Json
+import link.socket.ampere.db.Database
+import link.socket.ampere.util.ioDispatcher
+
+interface UserGrantStore {
+
+    suspend fun grant(
+        pluginId: String,
+        permission: PluginPermission,
+        grantedAt: Instant = Clock.System.now(),
+    ): Result<Unit>
+
+    suspend fun revoke(
+        pluginId: String,
+        permission: PluginPermission,
+    ): Result<Unit>
+
+    suspend fun listGrants(pluginId: String): Result<UserGrants>
+
+    suspend fun hasGrant(
+        pluginId: String,
+        permission: PluginPermission,
+    ): Result<Boolean>
+}
+
+class SqlDelightUserGrantStore(
+    private val database: Database,
+    private val json: Json = Json {
+        classDiscriminator = "type"
+        encodeDefaults = true
+    },
+) : UserGrantStore {
+
+    private val queries
+        get() = database.pluginGrantsQueries
+
+    override suspend fun grant(
+        pluginId: String,
+        permission: PluginPermission,
+        grantedAt: Instant,
+    ): Result<Unit> =
+        withContext(ioDispatcher) {
+            runCatching {
+                queries.upsertGrant(
+                    plugin_id = pluginId,
+                    permission_json = encode(permission),
+                    granted_at = grantedAt.toEpochMilliseconds(),
+                )
+            }.map { }
+        }
+
+    override suspend fun revoke(
+        pluginId: String,
+        permission: PluginPermission,
+    ): Result<Unit> =
+        withContext(ioDispatcher) {
+            runCatching {
+                queries.revokeGrant(
+                    plugin_id = pluginId,
+                    permission_json = encode(permission),
+                )
+            }.map { }
+        }
+
+    override suspend fun listGrants(pluginId: String): Result<UserGrants> =
+        withContext(ioDispatcher) {
+            runCatching {
+                val granted = queries.listGrants(pluginId)
+                    .executeAsList()
+                    .map { row -> decode(row.permission_json) }
+
+                UserGrants(granted = granted)
+            }
+        }
+
+    override suspend fun hasGrant(
+        pluginId: String,
+        permission: PluginPermission,
+    ): Result<Boolean> =
+        withContext(ioDispatcher) {
+            runCatching {
+                queries.countGrant(
+                    plugin_id = pluginId,
+                    permission_json = encode(permission),
+                ).executeAsOne() > 0
+            }
+        }
+
+    private fun encode(permission: PluginPermission): String =
+        json.encodeToString(PluginPermission.serializer(), permission)
+
+    private fun decode(payload: String): PluginPermission =
+        json.decodeFromString(PluginPermission.serializer(), payload)
+}

--- a/ampere-core/src/commonMain/sqldelight/link/socket/ampere/db/PluginGrants.sq
+++ b/ampere-core/src/commonMain/sqldelight/link/socket/ampere/db/PluginGrants.sq
@@ -1,0 +1,31 @@
+CREATE TABLE PluginGrants (
+  plugin_id TEXT NOT NULL,
+  permission_json TEXT NOT NULL,
+  granted_at INTEGER NOT NULL,
+  PRIMARY KEY (plugin_id, permission_json)
+);
+
+CREATE INDEX idx_plugin_grants_plugin_id ON PluginGrants(plugin_id);
+
+upsertGrant:
+INSERT OR REPLACE INTO PluginGrants(plugin_id, permission_json, granted_at)
+VALUES (?, ?, ?);
+
+revokeGrant:
+DELETE FROM PluginGrants
+WHERE plugin_id = ? AND permission_json = ?;
+
+listGrants:
+SELECT plugin_id, permission_json, granted_at
+FROM PluginGrants
+WHERE plugin_id = ?
+ORDER BY granted_at ASC;
+
+countGrant:
+SELECT COUNT(*)
+FROM PluginGrants
+WHERE plugin_id = ? AND permission_json = ?;
+
+clearGrantsForPlugin:
+DELETE FROM PluginGrants
+WHERE plugin_id = ?;

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/plugin/permission/PluginPermissionGateTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/plugin/permission/PluginPermissionGateTest.kt
@@ -1,0 +1,53 @@
+package link.socket.ampere.plugin.permission
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import link.socket.ampere.plugin.PluginManifest
+
+class PluginPermissionGateTest {
+
+    private val permission = PluginPermission.NetworkDomain("api.example.com")
+    private val manifest = PluginManifest(
+        id = "example-plugin",
+        name = "Example Plugin",
+        version = "1.0.0",
+        requiredPermissions = listOf(permission),
+    )
+    private val toolCall = PluginToolCall(
+        pluginId = manifest.id,
+        toolId = "fetch-example",
+    )
+
+    @Test
+    fun `allows when required permission is granted`() {
+        val result = PluginPermissionGate.check(
+            toolCall = toolCall,
+            manifest = manifest,
+            userGrants = UserGrants.granted(permission),
+        )
+
+        assertEquals(GateResult.Allow, result)
+    }
+
+    @Test
+    fun `denies when required permission is missing`() {
+        val result = PluginPermissionGate.check(
+            toolCall = toolCall,
+            manifest = manifest,
+            userGrants = UserGrants(),
+        )
+
+        assertEquals(GateResult.DenyMissing(permission), result)
+    }
+
+    @Test
+    fun `denies revoked permission before treating it as missing`() {
+        val result = PluginPermissionGate.check(
+            toolCall = toolCall,
+            manifest = manifest,
+            userGrants = UserGrants.revoked(permission),
+        )
+
+        assertEquals(GateResult.DenyRevoked(permission), result)
+    }
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/plugin/permission/PluginPermissionSerializationTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/plugin/permission/PluginPermissionSerializationTest.kt
@@ -1,0 +1,65 @@
+package link.socket.ampere.plugin.permission
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.serialization.json.Json
+import link.socket.ampere.plugin.PluginManifest
+
+class PluginPermissionSerializationTest {
+
+    private val json = Json {
+        classDiscriminator = "type"
+        encodeDefaults = true
+    }
+
+    @Test
+    fun `round-trips all permission variants through json`() {
+        val permissions = listOf(
+            PluginPermission.NetworkDomain("api.example.com"),
+            PluginPermission.MCPServer("mcp://github"),
+            PluginPermission.KnowledgeQuery("workspace"),
+            PluginPermission.NativeAction("open-url"),
+            PluginPermission.LinkAccess("linear-AMPR-149"),
+        )
+
+        permissions.forEach { permission ->
+            val encoded = json.encodeToString(PluginPermission.serializer(), permission)
+            val decoded = json.decodeFromString(PluginPermission.serializer(), encoded)
+
+            assertEquals(permission, decoded)
+        }
+    }
+
+    @Test
+    fun `manifest missing required permissions defaults to empty list`() {
+        val manifest = json.decodeFromString<PluginManifest>(
+            """
+            {
+              "id": "test-plugin",
+              "name": "Test Plugin",
+              "version": "1.0.0"
+            }
+            """.trimIndent(),
+        )
+
+        assertEquals(emptyList(), manifest.requiredPermissions)
+    }
+
+    @Test
+    fun `manifest surfaces declared required permissions`() {
+        val original = PluginManifest(
+            id = "github-plugin",
+            name = "GitHub Plugin",
+            version = "1.0.0",
+            requiredPermissions = listOf(
+                PluginPermission.NetworkDomain("api.github.com"),
+                PluginPermission.MCPServer("mcp://github"),
+            ),
+        )
+
+        val encoded = json.encodeToString(original)
+        val decoded = json.decodeFromString<PluginManifest>(encoded)
+
+        assertEquals(original.requiredPermissions, decoded.requiredPermissions)
+    }
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/plugin/permission/ToolExecutionPermissionGateTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/plugin/permission/ToolExecutionPermissionGateTest.kt
@@ -1,0 +1,131 @@
+package link.socket.ampere.plugin.permission
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import link.socket.ampere.agents.config.AgentActionAutonomy
+import link.socket.ampere.agents.config.AgentConfiguration
+import link.socket.ampere.agents.domain.outcome.ExecutionOutcome
+import link.socket.ampere.agents.domain.reasoning.AgentLLMService
+import link.socket.ampere.agents.domain.status.TaskStatus
+import link.socket.ampere.agents.domain.status.TicketStatus
+import link.socket.ampere.agents.domain.task.Task
+import link.socket.ampere.agents.events.tickets.Ticket
+import link.socket.ampere.agents.events.tickets.TicketPriority
+import link.socket.ampere.agents.events.tickets.TicketType
+import link.socket.ampere.agents.execution.ParameterStrategy
+import link.socket.ampere.agents.execution.ToolExecutionEngine
+import link.socket.ampere.agents.execution.executor.FunctionExecutor
+import link.socket.ampere.agents.execution.request.ExecutionConstraints
+import link.socket.ampere.agents.execution.request.ExecutionContext
+import link.socket.ampere.agents.execution.request.ExecutionRequest
+import link.socket.ampere.agents.execution.tools.FunctionTool
+import link.socket.ampere.agents.execution.tools.Tool
+import link.socket.ampere.domain.agent.bundled.WriteCodeAgent
+import link.socket.ampere.domain.ai.configuration.AIConfiguration_Default
+import link.socket.ampere.domain.ai.model.AIModel_Claude
+import link.socket.ampere.domain.ai.provider.AIProvider_Anthropic
+import link.socket.ampere.plugin.PluginManifest
+
+class ToolExecutionPermissionGateTest {
+
+    @Test
+    fun `blocked plugin tool does not call LLM provider`() = runTest {
+        var llmCalls = 0
+        val executor = FunctionExecutor.create()
+        val permission = PluginPermission.NetworkDomain("api.example.com")
+        val manifest = PluginManifest(
+            id = "example-plugin",
+            name = "Example Plugin",
+            version = "1.0.0",
+            requiredPermissions = listOf(permission),
+        )
+        val tool = FunctionTool<ExecutionContext>(
+            id = "fetch-example",
+            name = "Fetch Example",
+            description = "Fetches example data",
+            requiredAgentAutonomy = AgentActionAutonomy.FULLY_AUTONOMOUS,
+            pluginManifest = manifest,
+            executionFunction = {
+                error("Blocked tool should not execute")
+            },
+        )
+        val llmService = AgentLLMService(
+            AgentConfiguration(
+                agentDefinition = WriteCodeAgent,
+                aiConfiguration = AIConfiguration_Default(
+                    provider = AIProvider_Anthropic,
+                    model = AIModel_Claude.Sonnet_4,
+                ),
+                llmProvider = {
+                    llmCalls += 1
+                    "{}"
+                },
+            ),
+        )
+        val engine = ToolExecutionEngine(
+            llmService = llmService,
+            executor = executor,
+            executorId = executor.id,
+        ).also { engine ->
+            engine.registerStrategy(tool.id, passthroughStrategy)
+        }
+
+        val outcome = engine.execute(tool, createRequest(executor.id))
+
+        val failure = assertIs<ExecutionOutcome.NoChanges.Failure>(outcome)
+        assertTrue(failure.message.contains("Permission denied"))
+        assertEquals(0, llmCalls)
+    }
+
+    private val passthroughStrategy = object : ParameterStrategy {
+        override fun buildPrompt(
+            tool: Tool<*>,
+            request: ExecutionRequest<*>,
+            intent: String,
+        ): String = "Generate parameters for ${tool.id}: $intent"
+
+        override fun parseAndEnrichRequest(
+            jsonResponse: String,
+            originalRequest: ExecutionRequest<*>,
+        ): ExecutionRequest<*> = originalRequest
+    }
+
+    private fun createRequest(executorId: String): ExecutionRequest<ExecutionContext.NoChanges> {
+        val now = Clock.System.now()
+        val ticket = Ticket(
+            id = "ticket-1",
+            title = "Test ticket",
+            description = "Test ticket description",
+            type = TicketType.TASK,
+            priority = TicketPriority.MEDIUM,
+            status = TicketStatus.InProgress,
+            assignedAgentId = "agent-1",
+            createdByAgentId = "agent-1",
+            createdAt = now,
+            updatedAt = now,
+            dueDate = null,
+        )
+        val task = Task.CodeChange(
+            id = "task-1",
+            status = TaskStatus.Pending,
+            description = "Fetch data",
+        )
+
+        return ExecutionRequest(
+            context = ExecutionContext.NoChanges(
+                executorId = executorId,
+                ticket = ticket,
+                task = task,
+                instructions = "Fetch example data",
+            ),
+            constraints = ExecutionConstraints(
+                requireTests = false,
+                requireLinting = false,
+            ),
+        )
+    }
+}

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/events/EventSerializationTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/events/EventSerializationTest.kt
@@ -8,6 +8,9 @@ import kotlinx.serialization.json.Json
 import link.socket.ampere.agents.domain.Urgency
 import link.socket.ampere.agents.domain.event.Event
 import link.socket.ampere.agents.domain.event.EventSource
+import link.socket.ampere.agents.domain.event.PermissionDeniedEvent
+import link.socket.ampere.agents.domain.event.PermissionDeniedReason
+import link.socket.ampere.plugin.permission.PluginPermission
 
 class EventSerializationTest {
 
@@ -68,6 +71,27 @@ class EventSerializationTest {
         val text = json.encodeToString(original)
         val decoded = json.decodeFromString<Event.CodeSubmitted>(text)
         assertIs<Event.CodeSubmitted>(decoded)
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun `serialize and deserialize permission denied event polymorphic`() {
+        val original: Event = PermissionDeniedEvent(
+            eventId = "44444444-4444-4444-4444-444444444444",
+            timestamp = stubTimestamp,
+            eventSource = stubEventSource,
+            urgency = Urgency.HIGH,
+            pluginId = "example-plugin",
+            toolId = "fetch-example",
+            toolName = "Fetch Example",
+            permission = PluginPermission.NetworkDomain("api.example.com"),
+            reason = PermissionDeniedReason.MISSING_GRANT,
+        )
+
+        val text = json.encodeToString(Event.serializer(), original)
+        val decoded = json.decodeFromString(Event.serializer(), text)
+
+        assertIs<PermissionDeniedEvent>(decoded)
         assertEquals(original, decoded)
     }
 }

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/plugin/permission/UserGrantStoreTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/plugin/permission/UserGrantStoreTest.kt
@@ -1,0 +1,63 @@
+package link.socket.ampere.plugin.permission
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import link.socket.ampere.db.Database
+
+class UserGrantStoreTest {
+
+    private lateinit var driver: JdbcSqliteDriver
+    private lateinit var store: UserGrantStore
+
+    @BeforeTest
+    fun setUp() {
+        driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        Database.Schema.create(driver)
+        store = SqlDelightUserGrantStore(Database(driver))
+    }
+
+    @AfterTest
+    fun tearDown() {
+        driver.close()
+    }
+
+    @Test
+    fun `grant persists and lists active permissions`() = runTest {
+        val permission = PluginPermission.KnowledgeQuery("workspace")
+
+        store.grant(
+            pluginId = "plugin-1",
+            permission = permission,
+            grantedAt = Instant.fromEpochMilliseconds(1_000),
+        ).getOrThrow()
+
+        val grants = store.listGrants("plugin-1").getOrThrow()
+
+        assertEquals(listOf(permission), grants.granted)
+        assertTrue(store.hasGrant("plugin-1", permission).getOrThrow())
+    }
+
+    @Test
+    fun `revoke removes persisted grant`() = runTest {
+        val permission = PluginPermission.NativeAction("open-url")
+
+        store.grant(
+            pluginId = "plugin-1",
+            permission = permission,
+            grantedAt = Instant.fromEpochMilliseconds(1_000),
+        ).getOrThrow()
+        store.revoke("plugin-1", permission).getOrThrow()
+
+        val grants = store.listGrants("plugin-1").getOrThrow()
+
+        assertEquals(emptyList(), grants.granted)
+        assertFalse(store.hasGrant("plugin-1", permission).getOrThrow())
+    }
+}


### PR DESCRIPTION
Closes #458 (AMPR-149).

This Codex-authored PR adds the plugin permission schema, manifest-required permissions, and a deterministic gate before plugin-backed tool dispatch.

It emits permission-denied events, adds persistent SQLDelight grant storage, and wires CLI/event surfaces for denial visibility.

Validated with `./gradlew ktlintFormat` and `./gradlew jvmTest`.