### PR TITLE
AMPR-152 #461: add cognition trace read model

### DIFF
--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/EventRegistry.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/EventRegistry.kt
@@ -63,6 +63,8 @@ object EventRegistry {
         // ToolEvent types
         ToolEvent.ToolRegistered.EVENT_TYPE,
         ToolEvent.ToolUnregistered.EVENT_TYPE,
+        ToolEvent.ToolExecutionStarted.EVENT_TYPE,
+        ToolEvent.ToolExecutionCompleted.EVENT_TYPE,
         ToolEvent.ToolDiscoveryComplete.EVENT_TYPE,
 
         // FileSystemEvent types

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/MemoryEvent.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/MemoryEvent.kt
@@ -55,6 +55,7 @@ sealed interface MemoryEvent : Event {
         val approach: String? = null, // What approach was tried
         val learnings: String? = null, // What was learned
         val sourceId: String? = null, // The outcome/idea/task ID this came from
+        val runId: String? = null,
     ) : MemoryEvent {
 
         override val eventType: EventType = EVENT_TYPE
@@ -111,6 +112,7 @@ sealed interface MemoryEvent : Event {
         val topKnowledgeIds: List<String>,
         override val urgency: Urgency = Urgency.LOW,
         val retrievedKnowledge: List<RetrievedKnowledgeSummary> = emptyList(), // Summaries of what was retrieved
+        val runId: String? = null,
     ) : MemoryEvent {
 
         override val eventType: EventType = EVENT_TYPE

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/ToolEvent.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/ToolEvent.kt
@@ -131,6 +131,7 @@ sealed interface ToolEvent : Event {
         val invocationId: String,
         val toolId: ToolId,
         val toolName: String,
+        val runId: String? = null,
     ) : ToolEvent {
 
         override val eventType: EventType = EVENT_TYPE
@@ -172,6 +173,7 @@ sealed interface ToolEvent : Event {
         val success: Boolean,
         val durationMs: Long,
         val errorMessage: String? = null,
+        val runId: String? = null,
     ) : ToolEvent {
 
         override val eventType: EventType = EVENT_TYPE

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/EventRepository.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/EventRepository.kt
@@ -8,6 +8,10 @@ import kotlinx.serialization.json.Json
 import link.socket.ampere.agents.domain.event.Event
 import link.socket.ampere.agents.domain.event.EventId
 import link.socket.ampere.agents.domain.event.EventType
+import link.socket.ampere.agents.domain.event.MemoryEvent
+import link.socket.ampere.agents.domain.event.ProviderCallCompletedEvent
+import link.socket.ampere.agents.domain.event.ProviderCallStartedEvent
+import link.socket.ampere.agents.domain.event.ToolEvent
 import link.socket.ampere.agents.events.utils.EventSerializationException
 import link.socket.ampere.data.Repository
 import link.socket.ampere.db.Database
@@ -41,12 +45,13 @@ class EventRepository(
             runCatching {
                 val eventPayload: String = encode(event)
 
-                queries.insertEvent(
+                queries.insertEventWithRunId(
                     event_id = event.eventId,
                     event_type = event.eventType,
                     source_id = event.eventSource.getIdentifier(),
                     timestamp = event.timestamp.toEpochMilliseconds(),
                     payload = eventPayload,
+                    run_id = event.runIdOrNull(),
                 )
             }.map { }
         }
@@ -238,4 +243,14 @@ class EventRepository(
             cause = throwable,
         )
     }
+}
+
+private fun Event.runIdOrNull(): String? = when (this) {
+    is ProviderCallStartedEvent -> workflowId
+    is ProviderCallCompletedEvent -> workflowId
+    is ToolEvent.ToolExecutionStarted -> runId
+    is ToolEvent.ToolExecutionCompleted -> runId
+    is MemoryEvent.KnowledgeStored -> runId
+    is MemoryEvent.KnowledgeRecalled -> runId
+    else -> null
 }

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/trace/ArcRunTrace.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/trace/ArcRunTrace.kt
@@ -1,0 +1,106 @@
+package link.socket.ampere.trace
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.Serializable
+
+typealias ArcRunId = String
+typealias ArcId = String
+
+@Serializable
+data class ArcRunTrace(
+    val runId: ArcRunId,
+    val arcId: ArcId,
+    val startedAt: Instant,
+    val endedAt: Instant? = null,
+    val phases: List<PropelPhase> = emptyList(),
+)
+
+@Serializable
+data class PropelPhase(
+    val name: String,
+    val startedAt: Instant,
+    val endedAt: Instant? = null,
+    val events: List<TraceEvent> = emptyList(),
+    val modelInvocations: List<ModelInvocationTrace> = emptyList(),
+    val memoryWrites: List<MemoryWriteTrace> = emptyList(),
+    val toolCalls: List<ToolCallTrace> = emptyList(),
+    val wattCost: WattCost = WattCost(),
+)
+
+@Serializable
+data class TraceEvent(
+    val eventId: String,
+    val eventType: String,
+    val timestamp: Instant,
+    val sourceId: String,
+    val summary: String,
+    val payload: String? = null,
+)
+
+@Serializable
+data class ModelInvocationTrace(
+    val eventId: String,
+    val agentId: String,
+    val phaseName: String,
+    val providerId: String,
+    val modelId: String,
+    val startedAt: Instant,
+    val endedAt: Instant? = null,
+    val routingReason: String? = null,
+    val inputTokens: Int? = null,
+    val outputTokens: Int? = null,
+    val estimatedUsd: Double? = null,
+    val latencyMs: Long? = null,
+    val success: Boolean? = null,
+    val errorType: String? = null,
+    val wattCost: WattCost = WattCost(),
+)
+
+@Serializable
+data class MemoryWriteTrace(
+    val id: String,
+    val phaseName: String,
+    val timestamp: Instant,
+    val memoryType: String,
+    val sourceId: String? = null,
+    val taskType: String? = null,
+    val tags: List<String> = emptyList(),
+    val approach: String? = null,
+    val learnings: String? = null,
+)
+
+@Serializable
+data class ToolCallTrace(
+    val invocationId: String,
+    val phaseName: String,
+    val toolId: String,
+    val toolName: String,
+    val startedAt: Instant,
+    val endedAt: Instant? = null,
+    val durationMs: Long? = null,
+    val success: Boolean? = null,
+    val errorMessage: String? = null,
+)
+
+@Serializable
+data class WattCost(
+    val inputTokens: Int = 0,
+    val outputTokens: Int = 0,
+    val estimatedUsd: Double? = null,
+    val watts: Double = 0.0,
+) {
+    fun plus(other: WattCost): WattCost {
+        return WattCost(
+            inputTokens = inputTokens + other.inputTokens,
+            outputTokens = outputTokens + other.outputTokens,
+            estimatedUsd = estimatedUsd.plusNullable(other.estimatedUsd),
+            watts = watts + other.watts,
+        )
+    }
+}
+
+private fun Double?.plusNullable(other: Double?): Double? = when {
+    this == null -> other
+    other == null -> this
+    else -> this + other
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/trace/ArcTraceProjection.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/trace/ArcTraceProjection.kt
@@ -1,0 +1,362 @@
+package link.socket.ampere.trace
+
+import kotlinx.coroutines.withContext
+import kotlinx.datetime.Instant
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import link.socket.ampere.agents.domain.event.Event
+import link.socket.ampere.agents.domain.event.MemoryEvent
+import link.socket.ampere.agents.domain.event.ProviderCallCompletedEvent
+import link.socket.ampere.agents.domain.event.ProviderCallStartedEvent
+import link.socket.ampere.agents.domain.event.RoutingEvent
+import link.socket.ampere.agents.domain.event.SparkAppliedEvent
+import link.socket.ampere.agents.domain.event.SparkRemovedEvent
+import link.socket.ampere.agents.domain.event.ToolEvent
+import link.socket.ampere.data.DEFAULT_JSON
+import link.socket.ampere.db.Database
+import link.socket.ampere.db.events.EventStore
+import link.socket.ampere.db.memory.KnowledgeStore
+import link.socket.ampere.db.memory.OutcomeMemoryStore
+import link.socket.ampere.util.ioDispatcher
+
+class ArcTraceProjection(
+    private val database: Database,
+    private val json: Json = DEFAULT_JSON,
+    private val wattCostAggregator: WattCostAggregator = WattCostAggregator(),
+) {
+    suspend fun project(runId: ArcRunId): Result<ArcRunTrace> =
+        project(runId = runId, arcId = runId)
+
+    suspend fun project(
+        runId: ArcRunId,
+        arcId: ArcId,
+    ): Result<ArcRunTrace> = withContext(ioDispatcher) {
+        runCatching {
+            val eventRows = database.eventStoreQueries
+                .getEventsByRunIdOrPayload(run_id = runId)
+                .executeAsList()
+            val events = eventRows.mapNotNull { row -> row.decodeOrNull() }
+
+            val knowledgeRows = database.knowledgeStoreQueries
+                .findKnowledgeByRunId(runId)
+                .executeAsList()
+            val outcomeRows = database.outcomeMemoryStoreQueries
+                .getOutcomesByRunId(runId)
+                .executeAsList()
+
+            if (events.isEmpty() && knowledgeRows.isEmpty() && outcomeRows.isEmpty()) {
+                error("No trace data found for runId=$runId")
+            }
+
+            val modelInvocations = buildModelInvocations(events)
+            val toolCalls = buildToolCalls(events)
+            val memoryWrites = buildMemoryWrites(events, knowledgeRows, outcomeRows)
+            val phases = buildPhases(events, modelInvocations, memoryWrites, toolCalls)
+
+            val startedAt = phases.minOfOrNull { it.startedAt }
+                ?: events.minOfOrNull { it.event.timestamp }
+                ?: knowledgeRows.minOfOrNull { Instant.fromEpochMilliseconds(it.timestamp) }
+                ?: outcomeRows.minOfOrNull { Instant.fromEpochMilliseconds(it.timestamp) }
+                ?: error("No trace timestamps found for runId=$runId")
+            val endedAt = phases.mapNotNull { it.endedAt }.maxOrNull()
+
+            ArcRunTrace(
+                runId = runId,
+                arcId = arcId,
+                startedAt = startedAt,
+                endedAt = endedAt,
+                phases = phases,
+            )
+        }
+    }
+
+    private fun EventStore.decodeOrNull(): DecodedEvent? {
+        return try {
+            DecodedEvent(
+                event = json.decodeFromString(Event.serializer(), payload),
+                payload = payload,
+            )
+        } catch (_: SerializationException) {
+            null
+        } catch (_: IllegalArgumentException) {
+            null
+        }
+    }
+
+    private fun buildModelInvocations(events: List<DecodedEvent>): List<ModelInvocationTrace> {
+        val starts = events
+            .map { it.event }
+            .filterIsInstance<ProviderCallStartedEvent>()
+            .toMutableList()
+
+        return events
+            .map { it.event }
+            .filterIsInstance<ProviderCallCompletedEvent>()
+            .map { completed ->
+                val start = starts.firstOrNull { candidate ->
+                    candidate.timestamp <= completed.timestamp &&
+                        candidate.workflowId == completed.workflowId &&
+                        candidate.agentId == completed.agentId &&
+                        candidate.providerId == completed.providerId &&
+                        candidate.modelId == completed.modelId &&
+                        candidate.cognitivePhase == completed.cognitivePhase
+                }
+                if (start != null) {
+                    starts.remove(start)
+                }
+
+                val invocation = ModelInvocationTrace(
+                    eventId = completed.eventId,
+                    agentId = completed.agentId,
+                    phaseName = completed.cognitivePhase?.name ?: UNKNOWN_PHASE,
+                    providerId = completed.providerId,
+                    modelId = completed.modelId,
+                    startedAt = start?.timestamp
+                        ?: Instant.fromEpochMilliseconds(
+                            completed.timestamp.toEpochMilliseconds() - completed.latencyMs,
+                        ),
+                    endedAt = completed.timestamp,
+                    routingReason = start?.routingReason,
+                    inputTokens = completed.usage.inputTokens,
+                    outputTokens = completed.usage.outputTokens,
+                    estimatedUsd = completed.usage.estimatedCost,
+                    latencyMs = completed.latencyMs,
+                    success = completed.success,
+                    errorType = completed.errorType,
+                )
+
+                invocation.copy(wattCost = wattCostAggregator.costFor(invocation))
+            }
+    }
+
+    private fun buildToolCalls(events: List<DecodedEvent>): List<ToolCallTrace> {
+        val startsByInvocation = events
+            .map { it.event }
+            .filterIsInstance<ToolEvent.ToolExecutionStarted>()
+            .associateBy { it.invocationId }
+
+        val completedInvocationIds = mutableSetOf<String>()
+        val completedCalls = events
+            .map { it.event }
+            .filterIsInstance<ToolEvent.ToolExecutionCompleted>()
+            .map { completed ->
+                completedInvocationIds += completed.invocationId
+                val start = startsByInvocation[completed.invocationId]
+                ToolCallTrace(
+                    invocationId = completed.invocationId,
+                    phaseName = phaseNameFor(start ?: completed, default = EXECUTE_PHASE) ?: EXECUTE_PHASE,
+                    toolId = completed.toolId,
+                    toolName = completed.toolName,
+                    startedAt = start?.timestamp
+                        ?: Instant.fromEpochMilliseconds(
+                            completed.timestamp.toEpochMilliseconds() - completed.durationMs,
+                        ),
+                    endedAt = completed.timestamp,
+                    durationMs = completed.durationMs,
+                    success = completed.success,
+                    errorMessage = completed.errorMessage,
+                )
+            }
+
+        val pendingCalls = startsByInvocation.values
+            .filterNot { it.invocationId in completedInvocationIds }
+            .map { started ->
+                ToolCallTrace(
+                    invocationId = started.invocationId,
+                    phaseName = phaseNameFor(started, default = EXECUTE_PHASE) ?: EXECUTE_PHASE,
+                    toolId = started.toolId,
+                    toolName = started.toolName,
+                    startedAt = started.timestamp,
+                )
+            }
+
+        return (completedCalls + pendingCalls).sortedBy { it.startedAt }
+    }
+
+    private fun buildMemoryWrites(
+        events: List<DecodedEvent>,
+        knowledgeRows: List<KnowledgeStore>,
+        outcomeRows: List<OutcomeMemoryStore>,
+    ): List<MemoryWriteTrace> {
+        val writesById = linkedMapOf<String, MemoryWriteTrace>()
+
+        for (row in knowledgeRows) {
+            writesById[row.id] = row.toMemoryWriteTrace()
+        }
+
+        events
+            .map { it.event }
+            .filterIsInstance<MemoryEvent.KnowledgeStored>()
+            .forEach { event ->
+                val stored = database.knowledgeStoreQueries
+                    .getKnowledgeById(event.knowledgeId)
+                    .executeAsOneOrNull()
+
+                writesById[event.knowledgeId] = stored?.toMemoryWriteTrace(
+                    phaseName = LEARN_PHASE,
+                    fallbackTags = event.tags,
+                ) ?: MemoryWriteTrace(
+                    id = event.knowledgeId,
+                    phaseName = LEARN_PHASE,
+                    timestamp = event.timestamp,
+                    memoryType = event.knowledgeType.name,
+                    sourceId = event.sourceId,
+                    taskType = event.taskType,
+                    tags = event.tags,
+                    approach = event.approach,
+                    learnings = event.learnings,
+                )
+            }
+
+        for (row in outcomeRows) {
+            writesById[row.id] = MemoryWriteTrace(
+                id = row.id,
+                phaseName = EXECUTE_PHASE,
+                timestamp = Instant.fromEpochMilliseconds(row.timestamp),
+                memoryType = OUTCOME_MEMORY_TYPE,
+                sourceId = row.ticket_id,
+                approach = row.approach,
+                learnings = row.error_message,
+            )
+        }
+
+        return writesById.values.sortedBy { it.timestamp }
+    }
+
+    private fun KnowledgeStore.toMemoryWriteTrace(
+        phaseName: String = LEARN_PHASE,
+        fallbackTags: List<String> = emptyList(),
+    ): MemoryWriteTrace {
+        val tags = database.knowledgeStoreQueries
+            .getTagsForKnowledge(id)
+            .executeAsList()
+            .ifEmpty { fallbackTags }
+
+        return MemoryWriteTrace(
+            id = id,
+            phaseName = phaseName,
+            timestamp = Instant.fromEpochMilliseconds(timestamp),
+            memoryType = knowledge_type,
+            sourceId = outcome_id ?: idea_id ?: perception_id ?: plan_id ?: task_id,
+            taskType = task_type,
+            tags = tags,
+            approach = approach,
+            learnings = learnings,
+        )
+    }
+
+    private fun buildPhases(
+        events: List<DecodedEvent>,
+        modelInvocations: List<ModelInvocationTrace>,
+        memoryWrites: List<MemoryWriteTrace>,
+        toolCalls: List<ToolCallTrace>,
+    ): List<PropelPhase> {
+        val eventsByPhase = linkedMapOf<String, MutableList<TraceEvent>>()
+        var activePhase: String? = null
+
+        for (decoded in events) {
+            val event = decoded.event
+            val explicitPhase = phaseNameFor(event, default = activePhase)
+            val phaseName = explicitPhase ?: activePhase ?: RUN_PHASE
+            eventsByPhase.getOrPut(phaseName) { mutableListOf() }
+                .add(decoded.toTraceEvent())
+
+            activePhase = when (event) {
+                is SparkAppliedEvent -> event.phaseSparkName() ?: activePhase
+                is SparkRemovedEvent -> null
+                else -> explicitPhase ?: activePhase
+            }
+        }
+
+        val phaseNames = (
+            eventsByPhase.keys +
+                modelInvocations.map { it.phaseName } +
+                memoryWrites.map { it.phaseName } +
+                toolCalls.map { it.phaseName }
+            )
+            .filter { it.isNotBlank() }
+            .distinct()
+
+        return phaseNames.mapNotNull { phaseName ->
+            val phaseEvents = eventsByPhase[phaseName].orEmpty().sortedBy { it.timestamp }
+            val phaseModels = modelInvocations.filter { it.phaseName == phaseName }
+            val phaseMemoryWrites = memoryWrites.filter { it.phaseName == phaseName }
+            val phaseToolCalls = toolCalls.filter { it.phaseName == phaseName }
+
+            val timestamps = buildList {
+                addAll(phaseEvents.map { it.timestamp })
+                addAll(phaseModels.map { it.startedAt })
+                addAll(phaseModels.mapNotNull { it.endedAt })
+                addAll(phaseMemoryWrites.map { it.timestamp })
+                addAll(phaseToolCalls.map { it.startedAt })
+                addAll(phaseToolCalls.mapNotNull { it.endedAt })
+            }
+
+            val startedAt = timestamps.minOrNull() ?: return@mapNotNull null
+            val endedAt = timestamps.maxOrNull()
+
+            PropelPhase(
+                name = phaseName,
+                startedAt = startedAt,
+                endedAt = endedAt,
+                events = phaseEvents,
+                modelInvocations = phaseModels,
+                memoryWrites = phaseMemoryWrites,
+                toolCalls = phaseToolCalls,
+                wattCost = wattCostAggregator.aggregate(phaseModels),
+            )
+        }.sortedBy { it.startedAt }
+    }
+
+    private fun DecodedEvent.toTraceEvent(): TraceEvent {
+        return TraceEvent(
+            eventId = event.eventId,
+            eventType = event.eventType,
+            timestamp = event.timestamp,
+            sourceId = event.eventSource.getIdentifier(),
+            summary = event.getSummary(
+                formatUrgency = { urgency -> urgency.name },
+                formatSource = { source -> source.getIdentifier() },
+            ),
+            payload = payload,
+        )
+    }
+
+    private fun phaseNameFor(event: Event, default: String? = null): String? = when (event) {
+        is ProviderCallStartedEvent -> event.cognitivePhase?.name
+        is ProviderCallCompletedEvent -> event.cognitivePhase?.name
+        is RoutingEvent.RouteSelected -> event.phase?.name
+        is RoutingEvent.RouteFallback -> event.phase?.name
+        is MemoryEvent.KnowledgeRecalled -> RECALL_PHASE
+        is MemoryEvent.KnowledgeStored -> LEARN_PHASE
+        is ToolEvent.ToolExecutionStarted -> default ?: EXECUTE_PHASE
+        is ToolEvent.ToolExecutionCompleted -> default ?: EXECUTE_PHASE
+        is SparkAppliedEvent -> event.phaseSparkName() ?: default
+        is SparkRemovedEvent -> event.phaseSparkName() ?: default
+        else -> default
+    }
+
+    private fun SparkAppliedEvent.phaseSparkName(): String? =
+        sparkName.removePrefix("Phase:")
+            .takeIf { it != sparkName && it.isNotBlank() }
+            ?.uppercase()
+
+    private fun SparkRemovedEvent.phaseSparkName(): String? =
+        previousSparkName.removePrefix("Phase:")
+            .takeIf { it != previousSparkName && it.isNotBlank() }
+            ?.uppercase()
+
+    private data class DecodedEvent(
+        val event: Event,
+        val payload: String,
+    )
+
+    private companion object {
+        const val RUN_PHASE = "RUN"
+        const val UNKNOWN_PHASE = "UNKNOWN"
+        const val RECALL_PHASE = "RECALL"
+        const val EXECUTE_PHASE = "EXECUTE"
+        const val LEARN_PHASE = "LEARN"
+        const val OUTCOME_MEMORY_TYPE = "OUTCOME"
+    }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/trace/WattCostAggregator.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/trace/WattCostAggregator.kt
@@ -1,0 +1,54 @@
+package link.socket.ampere.trace
+
+import link.socket.ampere.api.model.TokenUsage
+import link.socket.ampere.domain.ai.UsageTier
+
+/**
+ * Converts telemetry token accounting into Ampere's normalized Watt units.
+ *
+ * The aggregator consumes the existing TokenUsage emitted by provider telemetry;
+ * it does not estimate tokens independently.
+ */
+class WattCostAggregator(
+    private val usageTier: UsageTier = UsageTier.TIER_1,
+) {
+    fun costFor(usage: TokenUsage): WattCost {
+        val inputTokens = usage.inputTokens ?: 0
+        val outputTokens = usage.outputTokens ?: 0
+        val totalTokens = inputTokens + outputTokens
+
+        return WattCost(
+            inputTokens = inputTokens,
+            outputTokens = outputTokens,
+            estimatedUsd = usage.estimatedCost,
+            watts = totalTokens.toDouble() / TOKENS_PER_WATT * multiplierFor(usageTier),
+        )
+    }
+
+    fun costFor(invocation: ModelInvocationTrace): WattCost =
+        costFor(
+            TokenUsage(
+                inputTokens = invocation.inputTokens,
+                outputTokens = invocation.outputTokens,
+                estimatedCost = invocation.estimatedUsd,
+            ),
+        )
+
+    fun aggregate(invocations: List<ModelInvocationTrace>): WattCost =
+        invocations.fold(WattCost()) { total, invocation ->
+            total.plus(invocation.wattCost.takeUnless { it == WattCost() } ?: costFor(invocation))
+        }
+
+    companion object {
+        const val TOKENS_PER_WATT: Double = 1_000.0
+
+        fun multiplierFor(usageTier: UsageTier): Double = when (usageTier) {
+            UsageTier.FREE -> 0.5
+            UsageTier.TIER_1 -> 1.0
+            UsageTier.TIER_2 -> 1.5
+            UsageTier.TIER_3 -> 2.0
+            UsageTier.TIER_4 -> 2.5
+            UsageTier.TIER_5 -> 3.0
+        }
+    }
+}

--- a/ampere-core/src/commonMain/sqldelight/link/socket/ampere/db/1.sqm
+++ b/ampere-core/src/commonMain/sqldelight/link/socket/ampere/db/1.sqm
@@ -1,0 +1,11 @@
+ALTER TABLE EventStore ADD COLUMN run_id TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_event_run_id ON EventStore(run_id);
+
+ALTER TABLE KnowledgeStore ADD COLUMN run_id TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_knowledge_run_id ON KnowledgeStore(run_id);
+
+ALTER TABLE OutcomeMemoryStore ADD COLUMN run_id TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_outcome_run_id ON OutcomeMemoryStore(run_id);

--- a/ampere-core/src/commonMain/sqldelight/link/socket/ampere/db/events/EventStore.sq
+++ b/ampere-core/src/commonMain/sqldelight/link/socket/ampere/db/events/EventStore.sq
@@ -3,11 +3,13 @@ CREATE TABLE EventStore (
   event_type TEXT NOT NULL,
   source_id TEXT NOT NULL,
   timestamp INTEGER NOT NULL,
-  payload TEXT NOT NULL
+  payload TEXT NOT NULL,
+  run_id TEXT
 );
 
 CREATE INDEX idx_event_type ON EventStore(event_type);
 CREATE INDEX idx_timestamp ON EventStore(timestamp);
+CREATE INDEX idx_event_run_id ON EventStore(run_id);
 
 -- Queries
 
@@ -15,38 +17,55 @@ insertEvent:
 INSERT INTO EventStore(event_id, event_type, source_id, timestamp, payload)
 VALUES (?, ?, ?, ?, ?);
 
+insertEventWithRunId:
+INSERT INTO EventStore(event_id, event_type, source_id, timestamp, payload, run_id)
+VALUES (?, ?, ?, ?, ?, ?);
+
 getAllEvents:
-SELECT event_id, event_type, source_id, timestamp, payload
+SELECT event_id, event_type, source_id, timestamp, payload, run_id
 FROM EventStore
 ORDER BY timestamp DESC;
 
 getEventsByType:
-SELECT event_id, event_type, source_id, timestamp, payload
+SELECT event_id, event_type, source_id, timestamp, payload, run_id
 FROM EventStore
 WHERE event_type = ?
 ORDER BY timestamp DESC;
 
 getEventsSince:
-SELECT event_id, event_type, source_id, timestamp, payload
+SELECT event_id, event_type, source_id, timestamp, payload, run_id
 FROM EventStore
 WHERE timestamp >= ?
 ORDER BY timestamp ASC;
 
 getEventById:
-SELECT event_id, event_type, source_id, timestamp, payload
+SELECT event_id, event_type, source_id, timestamp, payload, run_id
 FROM EventStore
 WHERE event_id = ?
 LIMIT 1;
 
 getEventsBetween:
-SELECT event_id, event_type, source_id, timestamp, payload
+SELECT event_id, event_type, source_id, timestamp, payload, run_id
 FROM EventStore
 WHERE timestamp >= ? AND timestamp <= ?
 ORDER BY timestamp ASC;
 
+getEventsByRunId:
+SELECT event_id, event_type, source_id, timestamp, payload, run_id
+FROM EventStore
+WHERE run_id = ?
+ORDER BY timestamp ASC;
+
+getEventsByRunIdOrPayload:
+SELECT event_id, event_type, source_id, timestamp, payload, run_id
+FROM EventStore
+WHERE run_id = :run_id
+   OR payload LIKE '%' || :run_id || '%'
+ORDER BY timestamp ASC;
+
 -- Query events with event type filter
 getEventsBetweenWithEventTypes:
-SELECT event_id, event_type, source_id, timestamp, payload
+SELECT event_id, event_type, source_id, timestamp, payload, run_id
 FROM EventStore
 WHERE timestamp >= :fromTime
   AND timestamp <= :toTime
@@ -55,7 +74,7 @@ ORDER BY timestamp ASC;
 
 -- Query events with source ID filter
 getEventsBetweenWithSourceIds:
-SELECT event_id, event_type, source_id, timestamp, payload
+SELECT event_id, event_type, source_id, timestamp, payload, run_id
 FROM EventStore
 WHERE timestamp >= :fromTime
   AND timestamp <= :toTime
@@ -64,7 +83,7 @@ ORDER BY timestamp ASC;
 
 -- Query events with both event type and source ID filters
 getEventsBetweenWithBothFilters:
-SELECT event_id, event_type, source_id, timestamp, payload
+SELECT event_id, event_type, source_id, timestamp, payload, run_id
 FROM EventStore
 WHERE timestamp >= :fromTime
   AND timestamp <= :toTime

--- a/ampere-core/src/commonMain/sqldelight/link/socket/ampere/db/memory/KnowledgeStore.sq
+++ b/ampere-core/src/commonMain/sqldelight/link/socket/ampere/db/memory/KnowledgeStore.sq
@@ -13,6 +13,7 @@ CREATE TABLE IF NOT EXISTS KnowledgeStore (
     approach TEXT NOT NULL,
     learnings TEXT NOT NULL,
     timestamp INTEGER NOT NULL, -- Unix epoch milliseconds
+    run_id TEXT,
 
     -- Type-specific foreign key IDs (only one will be non-null based on knowledge_type)
     idea_id TEXT,
@@ -29,6 +30,7 @@ CREATE TABLE IF NOT EXISTS KnowledgeStore (
 -- Indexes for common query patterns
 CREATE INDEX IF NOT EXISTS idx_knowledge_type ON KnowledgeStore(knowledge_type);
 CREATE INDEX IF NOT EXISTS idx_knowledge_timestamp ON KnowledgeStore(timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_knowledge_run_id ON KnowledgeStore(run_id);
 CREATE INDEX IF NOT EXISTS idx_knowledge_task_type ON KnowledgeStore(task_type);
 CREATE INDEX IF NOT EXISTS idx_knowledge_complexity ON KnowledgeStore(complexity_level);
 
@@ -81,6 +83,14 @@ INSERT INTO KnowledgeStore (
     task_type, complexity_level
 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
+-- Insert a knowledge entry with an Arc run correlation ID
+insertKnowledgeWithRunId:
+INSERT INTO KnowledgeStore (
+    id, knowledge_type, approach, learnings, timestamp, run_id,
+    idea_id, outcome_id, perception_id, plan_id, task_id,
+    task_type, complexity_level
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+
 -- Insert tag association
 insertKnowledgeTag:
 INSERT OR IGNORE INTO KnowledgeTag (knowledge_id, tag) VALUES (?, ?);
@@ -105,6 +115,12 @@ findKnowledgeByTimeRange:
 SELECT * FROM KnowledgeStore
 WHERE timestamp BETWEEN ? AND ?
 ORDER BY timestamp DESC;
+
+-- Find knowledge written during a specific Arc run
+findKnowledgeByRunId:
+SELECT * FROM KnowledgeStore
+WHERE run_id = ?
+ORDER BY timestamp ASC;
 
 -- Find knowledge by task type
 findKnowledgeByTaskType:

--- a/ampere-core/src/commonMain/sqldelight/link/socket/ampere/db/memory/OutcomeMemoryStore.sq
+++ b/ampere-core/src/commonMain/sqldelight/link/socket/ampere/db/memory/OutcomeMemoryStore.sq
@@ -9,7 +9,8 @@ CREATE TABLE OutcomeMemoryStore (
     execution_duration_ms INTEGER NOT NULL,
     files_changed INTEGER NOT NULL,
     error_message TEXT,
-    timestamp INTEGER NOT NULL
+    timestamp INTEGER NOT NULL,
+    run_id TEXT
 );
 
 -- Indexes for common queries
@@ -17,6 +18,7 @@ CREATE INDEX idx_outcome_ticket_id ON OutcomeMemoryStore(ticket_id);
 CREATE INDEX idx_outcome_executor_id ON OutcomeMemoryStore(executor_id);
 CREATE INDEX idx_outcome_timestamp ON OutcomeMemoryStore(timestamp DESC);
 CREATE INDEX idx_outcome_success ON OutcomeMemoryStore(success);
+CREATE INDEX idx_outcome_run_id ON OutcomeMemoryStore(run_id);
 
 -- Full-text search index for similarity matching on approach
 -- This enables fuzzy matching for "find similar outcomes"
@@ -54,6 +56,13 @@ INSERT INTO OutcomeMemoryStore(
 )
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
 
+insertOutcomeWithRunId:
+INSERT INTO OutcomeMemoryStore(
+    id, ticket_id, executor_id, approach, success,
+    execution_duration_ms, files_changed, error_message, timestamp, run_id
+)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+
 getOutcomeById:
 SELECT * FROM OutcomeMemoryStore WHERE id = ?;
 
@@ -61,6 +70,11 @@ getOutcomesByTicket:
 SELECT * FROM OutcomeMemoryStore
 WHERE ticket_id = ?
 ORDER BY timestamp DESC;
+
+getOutcomesByRunId:
+SELECT * FROM OutcomeMemoryStore
+WHERE run_id = ?
+ORDER BY timestamp ASC;
 
 getOutcomesByExecutor:
 SELECT * FROM OutcomeMemoryStore

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/trace/ArcRunTraceTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/trace/ArcRunTraceTest.kt
@@ -1,0 +1,64 @@
+package link.socket.ampere.trace
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.datetime.Instant
+import kotlinx.serialization.encodeToString
+import link.socket.ampere.data.DEFAULT_JSON
+
+class ArcRunTraceTest {
+
+    @Test
+    fun `ArcRunTrace round trips through JSON`() {
+        val trace = ArcRunTrace(
+            runId = "run-123",
+            arcId = "startup-saas",
+            startedAt = Instant.fromEpochMilliseconds(1_000),
+            endedAt = Instant.fromEpochMilliseconds(2_000),
+            phases = listOf(
+                PropelPhase(
+                    name = "PLAN",
+                    startedAt = Instant.fromEpochMilliseconds(1_000),
+                    endedAt = Instant.fromEpochMilliseconds(2_000),
+                    events = listOf(
+                        TraceEvent(
+                            eventId = "event-1",
+                            eventType = "ProviderCallCompleted",
+                            timestamp = Instant.fromEpochMilliseconds(2_000),
+                            sourceId = "agent-1",
+                            summary = "LLM call completed",
+                            payload = """{"eventId":"event-1"}""",
+                        ),
+                    ),
+                    modelInvocations = listOf(
+                        ModelInvocationTrace(
+                            eventId = "model-1",
+                            agentId = "agent-1",
+                            phaseName = "PLAN",
+                            providerId = "openai",
+                            modelId = "gpt-4.1",
+                            startedAt = Instant.fromEpochMilliseconds(1_000),
+                            endedAt = Instant.fromEpochMilliseconds(2_000),
+                            inputTokens = 1_000,
+                            outputTokens = 500,
+                            estimatedUsd = 0.006,
+                            latencyMs = 1_000,
+                            success = true,
+                            wattCost = WattCost(
+                                inputTokens = 1_000,
+                                outputTokens = 500,
+                                estimatedUsd = 0.006,
+                                watts = 1.5,
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val encoded = DEFAULT_JSON.encodeToString(trace)
+        val decoded = DEFAULT_JSON.decodeFromString(ArcRunTrace.serializer(), encoded)
+
+        assertEquals(trace, decoded)
+    }
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/trace/WattCostAggregatorTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/trace/WattCostAggregatorTest.kt
@@ -1,0 +1,28 @@
+package link.socket.ampere.trace
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import link.socket.ampere.api.model.TokenUsage
+import link.socket.ampere.domain.ai.UsageTier
+
+class WattCostAggregatorTest {
+
+    @Test
+    fun `known token counts produce expected Watt values for usage tier`() {
+        val aggregator = WattCostAggregator(UsageTier.TIER_2)
+
+        val cost = aggregator.costFor(
+            TokenUsage(
+                inputTokens = 1_000,
+                outputTokens = 500,
+                estimatedCost = 0.006,
+            ),
+        )
+
+        assertEquals(1_000, cost.inputTokens)
+        assertEquals(500, cost.outputTokens)
+        assertEquals(0.006, assertNotNull(cost.estimatedUsd), absoluteTolerance = 0.0000001)
+        assertEquals(2.25, cost.watts, absoluteTolerance = 0.0000001)
+    }
+}

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/trace/ArcTraceProjectionTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/trace/ArcTraceProjectionTest.kt
@@ -1,0 +1,248 @@
+package link.socket.ampere.trace
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.time.TimeSource
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import link.socket.ampere.agents.domain.Urgency
+import link.socket.ampere.agents.domain.cognition.sparks.CognitivePhase
+import link.socket.ampere.agents.domain.event.EventSource
+import link.socket.ampere.agents.domain.event.MemoryEvent
+import link.socket.ampere.agents.domain.event.ProviderCallCompletedEvent
+import link.socket.ampere.agents.domain.event.ProviderCallStartedEvent
+import link.socket.ampere.agents.domain.event.ToolEvent
+import link.socket.ampere.agents.domain.knowledge.KnowledgeType
+import link.socket.ampere.agents.events.EventRepository
+import link.socket.ampere.api.model.TokenUsage
+import link.socket.ampere.data.DEFAULT_JSON
+import link.socket.ampere.db.Database
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ArcTraceProjectionTest {
+
+    private val scope = TestScope(UnconfinedTestDispatcher())
+
+    private lateinit var driver: JdbcSqliteDriver
+    private lateinit var database: Database
+    private lateinit var eventRepository: EventRepository
+    private lateinit var projection: ArcTraceProjection
+
+    @BeforeTest
+    fun setUp() {
+        driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        Database.Schema.create(driver)
+        database = Database(driver)
+        eventRepository = EventRepository(DEFAULT_JSON, scope, database)
+        projection = ArcTraceProjection(database)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        driver.close()
+    }
+
+    @Test
+    fun `projects run events and memory rows into phase trace`() = runTest {
+        val runId = "run-trace-1"
+        val arcId = "startup-saas"
+
+        seedTrace(runId)
+
+        val trace = projection.project(runId = runId, arcId = arcId).getOrThrow()
+
+        assertEquals(runId, trace.runId)
+        assertEquals(arcId, trace.arcId)
+        assertEquals(Instant.fromEpochMilliseconds(1_000), trace.startedAt)
+
+        val plan = assertNotNull(trace.phases.firstOrNull { it.name == "PLAN" })
+        assertEquals(1, plan.modelInvocations.size)
+        assertEquals(1_000, plan.modelInvocations.single().inputTokens)
+        assertEquals(1.5, plan.wattCost.watts, absoluteTolerance = 0.0000001)
+
+        val execute = assertNotNull(trace.phases.firstOrNull { it.name == "EXECUTE" })
+        assertEquals(1, execute.toolCalls.size)
+        assertEquals("write-code", execute.toolCalls.single().toolId)
+        assertEquals(1, execute.modelInvocations.size)
+
+        val learn = assertNotNull(trace.phases.firstOrNull { it.name == "LEARN" })
+        assertEquals(1, learn.memoryWrites.size)
+        assertEquals("knowledge-1", learn.memoryWrites.single().id)
+        assertEquals("Use trace projections", learn.memoryWrites.single().approach)
+    }
+
+    @Test
+    fun `projects one hundred event run within target budget`() = runTest {
+        val runId = "run-trace-benchmark"
+        repeat(100) { index ->
+            eventRepository.saveEvent(
+                ProviderCallCompletedEvent(
+                    eventId = "complete-$index",
+                    timestamp = Instant.fromEpochMilliseconds(1_000L + index),
+                    eventSource = EventSource.Agent("agent-benchmark"),
+                    workflowId = runId,
+                    agentId = "agent-benchmark",
+                    cognitivePhase = CognitivePhase.PLAN,
+                    providerId = "openai",
+                    modelId = "gpt-4.1",
+                    usage = TokenUsage(
+                        inputTokens = 10,
+                        outputTokens = 5,
+                    ),
+                    latencyMs = 10,
+                    success = true,
+                ),
+            ).getOrThrow()
+        }
+
+        projection.project(runId).getOrThrow()
+
+        val mark = TimeSource.Monotonic.markNow()
+        projection.project(runId).getOrThrow()
+        val elapsed = mark.elapsedNow()
+
+        assertTrue(
+            elapsed.inWholeMilliseconds < 50,
+            "Projection took ${elapsed.inWholeMilliseconds}ms",
+        )
+    }
+
+    private suspend fun seedTrace(runId: String) {
+        eventRepository.saveEvent(
+            ProviderCallStartedEvent(
+                eventId = "plan-start",
+                timestamp = Instant.fromEpochMilliseconds(1_000),
+                eventSource = EventSource.Agent("planner-agent"),
+                workflowId = runId,
+                agentId = "planner-agent",
+                cognitivePhase = CognitivePhase.PLAN,
+                providerId = "openai",
+                modelId = "gpt-4.1",
+                routingReason = "agent_configuration",
+            ),
+        ).getOrThrow()
+
+        eventRepository.saveEvent(
+            ProviderCallCompletedEvent(
+                eventId = "plan-complete",
+                timestamp = Instant.fromEpochMilliseconds(1_250),
+                eventSource = EventSource.Agent("planner-agent"),
+                workflowId = runId,
+                agentId = "planner-agent",
+                cognitivePhase = CognitivePhase.PLAN,
+                providerId = "openai",
+                modelId = "gpt-4.1",
+                usage = TokenUsage(
+                    inputTokens = 1_000,
+                    outputTokens = 500,
+                    estimatedCost = 0.006,
+                ),
+                latencyMs = 250,
+                success = true,
+            ),
+        ).getOrThrow()
+
+        eventRepository.saveEvent(
+            ProviderCallStartedEvent(
+                eventId = "execute-start",
+                timestamp = Instant.fromEpochMilliseconds(1_500),
+                eventSource = EventSource.Agent("code-agent"),
+                workflowId = runId,
+                agentId = "code-agent",
+                cognitivePhase = CognitivePhase.EXECUTE,
+                providerId = "openai",
+                modelId = "gpt-4.1",
+                routingReason = "agent_configuration",
+            ),
+        ).getOrThrow()
+
+        eventRepository.saveEvent(
+            ToolEvent.ToolExecutionStarted(
+                eventId = "tool-start",
+                timestamp = Instant.fromEpochMilliseconds(1_600),
+                eventSource = EventSource.Agent("code-agent"),
+                urgency = Urgency.LOW,
+                invocationId = "tool-call-1",
+                toolId = "write-code",
+                toolName = "Write Code",
+                runId = runId,
+            ),
+        ).getOrThrow()
+
+        eventRepository.saveEvent(
+            ToolEvent.ToolExecutionCompleted(
+                eventId = "tool-complete",
+                timestamp = Instant.fromEpochMilliseconds(1_700),
+                eventSource = EventSource.Agent("code-agent"),
+                urgency = Urgency.LOW,
+                invocationId = "tool-call-1",
+                toolId = "write-code",
+                toolName = "Write Code",
+                success = true,
+                durationMs = 100,
+                runId = runId,
+            ),
+        ).getOrThrow()
+
+        eventRepository.saveEvent(
+            ProviderCallCompletedEvent(
+                eventId = "execute-complete",
+                timestamp = Instant.fromEpochMilliseconds(1_800),
+                eventSource = EventSource.Agent("code-agent"),
+                workflowId = runId,
+                agentId = "code-agent",
+                cognitivePhase = CognitivePhase.EXECUTE,
+                providerId = "openai",
+                modelId = "gpt-4.1",
+                usage = TokenUsage(
+                    inputTokens = 600,
+                    outputTokens = 400,
+                    estimatedCost = 0.004,
+                ),
+                latencyMs = 300,
+                success = true,
+            ),
+        ).getOrThrow()
+
+        database.knowledgeStoreQueries.insertKnowledgeWithRunId(
+            id = "knowledge-1",
+            knowledge_type = KnowledgeType.FROM_OUTCOME.name,
+            approach = "Use trace projections",
+            learnings = "Group events by cognitive phase",
+            timestamp = 1_900L,
+            run_id = runId,
+            idea_id = null,
+            outcome_id = "outcome-1",
+            perception_id = null,
+            plan_id = null,
+            task_id = null,
+            task_type = "trace",
+            complexity_level = "MODERATE",
+        )
+        database.knowledgeStoreQueries.insertKnowledgeTag("knowledge-1", "trace")
+
+        eventRepository.saveEvent(
+            MemoryEvent.KnowledgeStored(
+                eventId = "knowledge-stored",
+                timestamp = Instant.fromEpochMilliseconds(1_900),
+                eventSource = EventSource.Agent("code-agent"),
+                knowledgeId = "knowledge-1",
+                knowledgeType = KnowledgeType.FROM_OUTCOME,
+                taskType = "trace",
+                tags = listOf("trace"),
+                approach = "Use trace projections",
+                learnings = "Group events by cognitive phase",
+                sourceId = "outcome-1",
+                runId = runId,
+            ),
+        ).getOrThrow()
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `ArcRunTrace`, `ArcTraceProjection`, and `WattCostAggregator` under `ampere-core/.../trace/` to reconstruct per-Arc-run traces (phases, model invocations, tool calls, memory writes, Watt totals) from EventSerializerBus and memory tables as a read-only projection.
- Adds nullable `run_id` columns plus indexes on `EventStore`, `KnowledgeStore`, and `OutcomeMemoryStore` with a SQLDelight migration (`1.sqm`), and wires `run_id` through telemetry/tool/memory event persistence.
- Adds round-trip serialization, Watt aggregation, phase reconstruction, and 100-event projection budget tests.

I (Claude) wrote this commit. Closes #461.

## Test plan
- [x] `./gradlew ktlintFormat`
- [x] `./gradlew jvmTest`