### PR TITLE
AMPR-150 #459: add AgentSurface primitive type system

### DIFF
--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/watch/presentation/EventCategorizer.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/watch/presentation/EventCategorizer.kt
@@ -1,5 +1,6 @@
 package link.socket.ampere.cli.watch.presentation
 
+import link.socket.ampere.agents.domain.event.AgentSurfaceEvent
 import link.socket.ampere.agents.domain.event.Event
 import link.socket.ampere.agents.domain.event.FileSystemEvent
 import link.socket.ampere.agents.domain.event.GitEvent
@@ -89,7 +90,9 @@ object EventCategorizer {
         is TicketEvent.TicketStatusChanged,
         is TicketEvent.TicketAssigned,
         is TicketEvent.TicketCompleted,
-        is TicketEvent.TicketMeetingScheduled -> EventSignificance.SIGNIFICANT
+        is TicketEvent.TicketMeetingScheduled,
+        is AgentSurfaceEvent.Requested,
+        is AgentSurfaceEvent.Responded -> EventSignificance.SIGNIFICANT
 
         // Routine cognitive operations - maintenance work
         is GitEvent.BranchCreated,

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/renderer/EventRenderer.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/renderer/EventRenderer.kt
@@ -12,6 +12,7 @@ import com.github.ajalt.mordant.terminal.Terminal
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import link.socket.ampere.agents.domain.Urgency
+import link.socket.ampere.agents.domain.event.AgentSurfaceEvent
 import link.socket.ampere.agents.domain.event.Event
 import link.socket.ampere.agents.domain.event.EventSource
 import link.socket.ampere.agents.domain.event.FileSystemEvent
@@ -156,6 +157,9 @@ class EventRenderer(
             is SparkRemovedEvent -> SparkColors.SparkIcons.REMOVED to gray
             is CognitiveStateSnapshot -> SparkColors.SparkIcons.SNAPSHOT to magenta
             is SparkEvent -> SparkColors.SparkIcons.APPLIED to magenta // fallback
+            // AgentSurface events: native UI surface request/response
+            is AgentSurfaceEvent.Requested -> "🪟" to magenta
+            is AgentSurfaceEvent.Responded -> "🪟" to blue
         }
     }
 

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/AgentSurfaceEvent.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/AgentSurfaceEvent.kt
@@ -1,0 +1,90 @@
+package link.socket.ampere.agents.domain.event
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.Serializable
+import link.socket.ampere.agents.domain.Urgency
+import link.socket.ampere.agents.events.surface.AgentSurface
+import link.socket.ampere.agents.events.surface.AgentSurfaceResponse
+import link.socket.ampere.agents.events.surface.CorrelationId
+
+/**
+ * Bus-level events that carry [AgentSurface] traffic.
+ *
+ * Plugin code emits a [Requested] when it needs to render UI; the platform
+ * renderer replies with a [Responded] carrying the same correlation id. The
+ * matching [link.socket.ampere.agents.events.surface.awaitSurfaceResponse]
+ * helper consumes [Responded] and resumes the Plugin coroutine.
+ */
+@Serializable
+sealed interface AgentSurfaceEvent : Event {
+
+    /** Echo of [AgentSurface.correlationId] for routing replies. */
+    val correlationId: CorrelationId
+
+    /** A Plugin is asking the platform to render an [AgentSurface]. */
+    @Serializable
+    data class Requested(
+        override val eventId: EventId,
+        override val timestamp: Instant,
+        override val eventSource: EventSource,
+        override val urgency: Urgency = Urgency.MEDIUM,
+        val surface: AgentSurface,
+    ) : AgentSurfaceEvent {
+
+        override val correlationId: CorrelationId = surface.correlationId
+
+        override val eventType: EventType = EVENT_TYPE
+
+        override fun getSummary(
+            formatUrgency: (Urgency) -> String,
+            formatSource: (EventSource) -> String,
+        ): String {
+            val kind = when (surface) {
+                is AgentSurface.Form -> "Form '${surface.title}'"
+                is AgentSurface.Choice -> "Choice '${surface.title}'"
+                is AgentSurface.Confirmation -> "Confirmation"
+                is AgentSurface.Card -> "Card '${surface.title}'"
+            }
+            return "Surface request: $kind (corr=$correlationId) ${formatUrgency(urgency)} from ${formatSource(
+                eventSource,
+            )}"
+        }
+
+        companion object {
+            const val EVENT_TYPE: EventType = "AgentSurfaceRequested"
+        }
+    }
+
+    /** The platform renderer replying to a previous [Requested]. */
+    @Serializable
+    data class Responded(
+        override val eventId: EventId,
+        override val timestamp: Instant,
+        override val eventSource: EventSource,
+        override val urgency: Urgency = Urgency.LOW,
+        val response: AgentSurfaceResponse,
+    ) : AgentSurfaceEvent {
+
+        override val correlationId: CorrelationId = response.correlationId
+
+        override val eventType: EventType = EVENT_TYPE
+
+        override fun getSummary(
+            formatUrgency: (Urgency) -> String,
+            formatSource: (EventSource) -> String,
+        ): String {
+            val outcome = when (response) {
+                is AgentSurfaceResponse.Submitted -> "submitted"
+                is AgentSurfaceResponse.Cancelled -> "cancelled"
+                is AgentSurfaceResponse.TimedOut -> "timed out"
+            }
+            return "Surface response: $outcome (corr=$correlationId) ${formatUrgency(urgency)} from ${formatSource(
+                eventSource,
+            )}"
+        }
+
+        companion object {
+            const val EVENT_TYPE: EventType = "AgentSurfaceResponded"
+        }
+    }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/EventRegistry.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/EventRegistry.kt
@@ -98,6 +98,10 @@ object EventRegistry {
 
         // PermissionEvent types
         PermissionDeniedEvent.EVENT_TYPE,
+
+        // AgentSurfaceEvent types
+        AgentSurfaceEvent.Requested.EVENT_TYPE,
+        AgentSurfaceEvent.Responded.EVENT_TYPE,
     )
 
     /**

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/surface/AgentSurface.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/surface/AgentSurface.kt
@@ -1,0 +1,130 @@
+package link.socket.ampere.agents.events.surface
+
+import kotlinx.serialization.Serializable
+
+/**
+ * A correlation identifier used to pair a surface request with its response.
+ *
+ * Plugins generate one of these per [AgentSurface] they emit and pass it to
+ * [link.socket.ampere.agents.events.surface.awaitSurfaceResponse] to receive
+ * the [AgentSurfaceResponse] produced by the platform renderer.
+ */
+typealias CorrelationId = String
+
+/**
+ * A typed, serializable description of a UI render request emitted by a Plugin.
+ *
+ * Platform renderers (iOS, Android Compose Multiplatform, Desktop) translate each
+ * variant into native UI. This contract lives in commonMain and intentionally
+ * carries no platform or framework references so it can be expressed across
+ * every Ampere target.
+ *
+ * Every variant carries a [correlationId] so the emitting Plugin can wait for
+ * the matching [AgentSurfaceResponse] without coupling to bus internals.
+ */
+@Serializable
+sealed interface AgentSurface {
+
+    /** Stable identifier used to pair this surface with its response. */
+    val correlationId: CorrelationId
+
+    /**
+     * A multi-field form. Renderers display the [fields] in order and submit a
+     * map of field id to typed value when the user confirms.
+     */
+    @Serializable
+    data class Form(
+        override val correlationId: CorrelationId,
+        val title: String,
+        val description: String? = null,
+        val fields: List<AgentSurfaceField>,
+        val submitLabel: String = "Submit",
+        val cancelLabel: String = "Cancel",
+    ) : AgentSurface
+
+    /**
+     * A single- or multi-select picker. Renderers display the [options] in
+     * order and submit the chosen option ids.
+     */
+    @Serializable
+    data class Choice(
+        override val correlationId: CorrelationId,
+        val title: String,
+        val description: String? = null,
+        val options: List<Option>,
+        val multiSelect: Boolean = false,
+        val minSelections: Int = if (multiSelect) 0 else 1,
+        val maxSelections: Int = if (multiSelect) options.size else 1,
+    ) : AgentSurface {
+
+        @Serializable
+        data class Option(
+            val id: String,
+            val label: String,
+            val description: String? = null,
+            val enabled: Boolean = true,
+        )
+    }
+
+    /**
+     * A confirmation prompt. Renderers display [prompt] with an affordance for
+     * accept/reject. Use [severity] to influence destructive vs. neutral
+     * styling without leaking renderer types.
+     */
+    @Serializable
+    data class Confirmation(
+        override val correlationId: CorrelationId,
+        val prompt: String,
+        val severity: Severity = Severity.Info,
+        val confirmLabel: String = "Confirm",
+        val cancelLabel: String = "Cancel",
+    ) : AgentSurface {
+
+        @Serializable
+        enum class Severity {
+            Info,
+            Warning,
+            Destructive,
+        }
+    }
+
+    /**
+     * A rich, slot-based card. Each [Slot] is a typed content fragment that the
+     * renderer composes; new slot kinds can be added without breaking existing
+     * renderers because slots are sealed.
+     */
+    @Serializable
+    data class Card(
+        override val correlationId: CorrelationId,
+        val title: String,
+        val slots: List<Slot>,
+        val actions: List<Action> = emptyList(),
+    ) : AgentSurface {
+
+        @Serializable
+        sealed interface Slot {
+
+            @Serializable
+            data class Heading(val text: String, val level: Int = 2) : Slot
+
+            @Serializable
+            data class Body(val text: String) : Slot
+
+            @Serializable
+            data class KeyValue(val key: String, val value: String) : Slot
+
+            @Serializable
+            data class Image(val url: String, val altText: String? = null) : Slot
+
+            @Serializable
+            data class Code(val source: String, val language: String? = null) : Slot
+        }
+
+        @Serializable
+        data class Action(
+            val id: String,
+            val label: String,
+            val severity: Confirmation.Severity = Confirmation.Severity.Info,
+        )
+    }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/surface/AgentSurfaceBusExt.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/surface/AgentSurfaceBusExt.kt
@@ -1,0 +1,79 @@
+package link.socket.ampere.agents.events.surface
+
+import kotlin.time.Duration
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.withTimeout
+import kotlinx.datetime.Clock
+import link.socket.ampere.agents.definition.AgentId
+import link.socket.ampere.agents.domain.Urgency
+import link.socket.ampere.agents.domain.event.AgentSurfaceEvent
+import link.socket.ampere.agents.domain.event.EventSource
+import link.socket.ampere.agents.events.bus.EventSerialBus
+import link.socket.ampere.agents.events.bus.subscribe
+import link.socket.ampere.agents.events.subscription.EventSubscription
+import link.socket.ampere.agents.events.utils.generateUUID
+
+/**
+ * Emit an [AgentSurfaceEvent.Requested] for [surface] over [this] bus.
+ */
+suspend fun EventSerialBus.emitSurfaceRequest(
+    surface: AgentSurface,
+    eventSource: EventSource,
+    urgency: Urgency = Urgency.MEDIUM,
+) {
+    publish(
+        AgentSurfaceEvent.Requested(
+            eventId = generateUUID(surface.correlationId),
+            timestamp = Clock.System.now(),
+            eventSource = eventSource,
+            urgency = urgency,
+            surface = surface,
+        ),
+    )
+}
+
+/**
+ * Subscribe to [AgentSurfaceEvent.Responded] events and suspend until one is
+ * delivered with the matching [correlationId].
+ *
+ * If [timeout] is supplied and elapses first, an
+ * [AgentSurfaceResponse.TimedOut] is returned instead of throwing. Callers
+ * that prefer cancellation-style timeouts can pass [timeout] = null and wrap
+ * with [withTimeout] themselves.
+ *
+ * Note: due to the current bus contract, multiple concurrent awaits for the
+ * same event type share a registration; this helper completes only on the
+ * first match for [correlationId] and ignores other events. Callers should
+ * not assume the underlying handler is unregistered when this function
+ * returns.
+ */
+suspend fun EventSerialBus.awaitSurfaceResponse(
+    awaiterAgentId: AgentId,
+    correlationId: CorrelationId,
+    timeout: Duration? = null,
+): AgentSurfaceResponse {
+    val deferred = CompletableDeferred<AgentSurfaceResponse>()
+
+    subscribe<AgentSurfaceEvent.Responded, EventSubscription.ByEventClassType>(
+        agentId = awaiterAgentId,
+        eventType = AgentSurfaceEvent.Responded.EVENT_TYPE,
+    ) { event, _ ->
+        if (event.correlationId == correlationId && !deferred.isCompleted) {
+            deferred.complete(event.response)
+        }
+    }
+
+    return if (timeout == null) {
+        deferred.await()
+    } else {
+        try {
+            withTimeout(timeout) { deferred.await() }
+        } catch (_: TimeoutCancellationException) {
+            AgentSurfaceResponse.TimedOut(
+                correlationId = correlationId,
+                timeoutMillis = timeout.inWholeMilliseconds,
+            )
+        }
+    }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/surface/AgentSurfaceField.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/surface/AgentSurfaceField.kt
@@ -1,0 +1,236 @@
+package link.socket.ampere.agents.events.surface
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.Serializable
+
+/**
+ * A typed input field that can appear inside an [AgentSurface.Form].
+ *
+ * Validation predicates are expressed in pure Kotlin so they run identically on
+ * every target. Renderers may surface failures inline, but the canonical check
+ * is [validate]; the platform must not accept a [AgentSurfaceFieldValue] that
+ * fails validation.
+ */
+@Serializable
+sealed interface AgentSurfaceField {
+
+    /** Stable id used as the key in [AgentSurfaceResponse.Submitted.values]. */
+    val id: String
+
+    /** Human-readable label shown next to the field. */
+    val label: String
+
+    /** Optional helper text displayed beneath the field. */
+    val helpText: String?
+
+    /** Whether a value is required for submission. */
+    val required: Boolean
+
+    /**
+     * Validate a field value of the matching variant. Returns
+     * [FieldValidationResult.Valid] on success, otherwise a list of human-
+     * readable error messages.
+     */
+    fun validate(value: AgentSurfaceFieldValue?): FieldValidationResult
+
+    /** Free-form single-line or multi-line text. */
+    @Serializable
+    data class Text(
+        override val id: String,
+        override val label: String,
+        override val helpText: String? = null,
+        override val required: Boolean = false,
+        val placeholder: String? = null,
+        val multiline: Boolean = false,
+        val minLength: Int = 0,
+        val maxLength: Int? = null,
+        val pattern: String? = null,
+    ) : AgentSurfaceField {
+
+        override fun validate(value: AgentSurfaceFieldValue?): FieldValidationResult {
+            val errors = mutableListOf<String>()
+            val text = (value as? AgentSurfaceFieldValue.TextValue)?.value
+            if (text.isNullOrEmpty()) {
+                if (required) errors += "$label is required"
+                return FieldValidationResult.from(errors)
+            }
+            if (text.length < minLength) errors += "$label must be at least $minLength characters"
+            maxLength?.let { if (text.length > it) errors += "$label must be at most $it characters" }
+            pattern?.let {
+                if (!Regex(it).matches(text)) errors += "$label is not in the expected format"
+            }
+            return FieldValidationResult.from(errors)
+        }
+    }
+
+    /** A numeric input. Renderers may show a stepper, slider, or text field. */
+    @Serializable
+    data class Number(
+        override val id: String,
+        override val label: String,
+        override val helpText: String? = null,
+        override val required: Boolean = false,
+        val min: Double? = null,
+        val max: Double? = null,
+        val integerOnly: Boolean = false,
+    ) : AgentSurfaceField {
+
+        override fun validate(value: AgentSurfaceFieldValue?): FieldValidationResult {
+            val errors = mutableListOf<String>()
+            val number = (value as? AgentSurfaceFieldValue.NumberValue)?.value
+            if (number == null) {
+                if (required) errors += "$label is required"
+                return FieldValidationResult.from(errors)
+            }
+            if (integerOnly && number != number.toLong().toDouble()) {
+                errors += "$label must be a whole number"
+            }
+            min?.let { if (number < it) errors += "$label must be at least $it" }
+            max?.let { if (number > it) errors += "$label must be at most $it" }
+            return FieldValidationResult.from(errors)
+        }
+    }
+
+    /** Boolean toggle (checkbox or switch). */
+    @Serializable
+    data class Toggle(
+        override val id: String,
+        override val label: String,
+        override val helpText: String? = null,
+        override val required: Boolean = false,
+        val default: Boolean = false,
+    ) : AgentSurfaceField {
+
+        override fun validate(value: AgentSurfaceFieldValue?): FieldValidationResult {
+            val toggled = (value as? AgentSurfaceFieldValue.ToggleValue)?.value
+            if (required && toggled != true) {
+                return FieldValidationResult.Invalid(listOf("$label must be enabled"))
+            }
+            return FieldValidationResult.Valid
+        }
+    }
+
+    /** A date and/or time picker, expressed as an [Instant]. */
+    @Serializable
+    data class DateTime(
+        override val id: String,
+        override val label: String,
+        override val helpText: String? = null,
+        override val required: Boolean = false,
+        val notBefore: Instant? = null,
+        val notAfter: Instant? = null,
+        val includeTime: Boolean = true,
+    ) : AgentSurfaceField {
+
+        override fun validate(value: AgentSurfaceFieldValue?): FieldValidationResult {
+            val errors = mutableListOf<String>()
+            val instant = (value as? AgentSurfaceFieldValue.DateTimeValue)?.value
+            if (instant == null) {
+                if (required) errors += "$label is required"
+                return FieldValidationResult.from(errors)
+            }
+            notBefore?.let { if (instant < it) errors += "$label must not be before $it" }
+            notAfter?.let { if (instant > it) errors += "$label must not be after $it" }
+            return FieldValidationResult.from(errors)
+        }
+    }
+
+    /** Single- or multi-pick from a fixed set of options inline within a form. */
+    @Serializable
+    data class Selection(
+        override val id: String,
+        override val label: String,
+        override val helpText: String? = null,
+        override val required: Boolean = false,
+        val options: List<AgentSurface.Choice.Option>,
+        val multiSelect: Boolean = false,
+        val minSelections: Int = if (multiSelect) 0 else 1,
+        val maxSelections: Int = if (multiSelect) options.size else 1,
+    ) : AgentSurfaceField {
+
+        override fun validate(value: AgentSurfaceFieldValue?): FieldValidationResult {
+            val errors = mutableListOf<String>()
+            val selections = (value as? AgentSurfaceFieldValue.SelectionValue)?.selectedIds.orEmpty()
+            if (selections.isEmpty()) {
+                if (required) errors += "$label is required"
+                return FieldValidationResult.from(errors)
+            }
+            if (selections.size < minSelections) errors += "$label requires at least $minSelections selection(s)"
+            if (selections.size > maxSelections) errors += "$label allows at most $maxSelections selection(s)"
+            val validIds = options.map { it.id }.toSet()
+            val unknown = selections.filterNot { it in validIds }
+            if (unknown.isNotEmpty()) errors += "$label has unknown options: ${unknown.joinToString()}"
+            return FieldValidationResult.from(errors)
+        }
+    }
+
+    /**
+     * A masked/secret input. Carries the same validation primitives as [Text]
+     * but renderers must avoid logging or persisting the value beyond the
+     * scope of the originating Plugin.
+     */
+    @Serializable
+    data class Secret(
+        override val id: String,
+        override val label: String,
+        override val helpText: String? = null,
+        override val required: Boolean = false,
+        val minLength: Int = 0,
+        val maxLength: Int? = null,
+    ) : AgentSurfaceField {
+
+        override fun validate(value: AgentSurfaceFieldValue?): FieldValidationResult {
+            val errors = mutableListOf<String>()
+            val text = (value as? AgentSurfaceFieldValue.SecretValue)?.value
+            if (text.isNullOrEmpty()) {
+                if (required) errors += "$label is required"
+                return FieldValidationResult.from(errors)
+            }
+            if (text.length < minLength) errors += "$label must be at least $minLength characters"
+            maxLength?.let { if (text.length > it) errors += "$label must be at most $it characters" }
+            return FieldValidationResult.from(errors)
+        }
+    }
+}
+
+/**
+ * Typed value returned from the renderer for a single field. The variant must
+ * line up with the corresponding [AgentSurfaceField] variant.
+ */
+@Serializable
+sealed interface AgentSurfaceFieldValue {
+
+    @Serializable
+    data class TextValue(val value: String) : AgentSurfaceFieldValue
+
+    @Serializable
+    data class NumberValue(val value: Double) : AgentSurfaceFieldValue
+
+    @Serializable
+    data class ToggleValue(val value: Boolean) : AgentSurfaceFieldValue
+
+    @Serializable
+    data class DateTimeValue(val value: Instant) : AgentSurfaceFieldValue
+
+    @Serializable
+    data class SelectionValue(val selectedIds: List<String>) : AgentSurfaceFieldValue
+
+    @Serializable
+    data class SecretValue(val value: String) : AgentSurfaceFieldValue
+}
+
+/** Outcome of running [AgentSurfaceField.validate] on a single value. */
+@Serializable
+sealed interface FieldValidationResult {
+
+    @Serializable
+    data object Valid : FieldValidationResult
+
+    @Serializable
+    data class Invalid(val errors: List<String>) : FieldValidationResult
+
+    companion object {
+        fun from(errors: List<String>): FieldValidationResult =
+            if (errors.isEmpty()) Valid else Invalid(errors)
+    }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/surface/AgentSurfaceResponse.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/surface/AgentSurfaceResponse.kt
@@ -1,0 +1,52 @@
+package link.socket.ampere.agents.events.surface
+
+import kotlinx.serialization.Serializable
+
+/**
+ * The renderer's reply to an [AgentSurface] request.
+ *
+ * Every variant carries the same [correlationId] as the originating
+ * [AgentSurface], which is what allows
+ * [link.socket.ampere.agents.events.surface.awaitSurfaceResponse]
+ * to resume the awaiting coroutine.
+ */
+@Serializable
+sealed interface AgentSurfaceResponse {
+
+    /** Echo of the originating [AgentSurface.correlationId]. */
+    val correlationId: CorrelationId
+
+    /**
+     * The user submitted the surface. For [AgentSurface.Form] variants the
+     * [values] map is keyed by [AgentSurfaceField.id]. For
+     * [AgentSurface.Choice] variants the response is encoded as a single
+     * [AgentSurfaceFieldValue.SelectionValue] under the well-known key
+     * [SELECTION_KEY]. For [AgentSurface.Confirmation] and [AgentSurface.Card]
+     * the [chosenAction] carries the action id and [values] is empty.
+     */
+    @Serializable
+    data class Submitted(
+        override val correlationId: CorrelationId,
+        val values: Map<String, AgentSurfaceFieldValue> = emptyMap(),
+        val chosenAction: String? = null,
+    ) : AgentSurfaceResponse
+
+    /** The user explicitly dismissed the surface. */
+    @Serializable
+    data class Cancelled(
+        override val correlationId: CorrelationId,
+        val reason: String? = null,
+    ) : AgentSurfaceResponse
+
+    /** The renderer did not produce a response within the allotted window. */
+    @Serializable
+    data class TimedOut(
+        override val correlationId: CorrelationId,
+        val timeoutMillis: Long,
+    ) : AgentSurfaceResponse
+
+    companion object {
+        /** Key used for [AgentSurface.Choice] selections inside [Submitted.values]. */
+        const val SELECTION_KEY: String = "selection"
+    }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/utils/SignificanceAwareEventLogger.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/utils/SignificanceAwareEventLogger.kt
@@ -2,6 +2,7 @@ package link.socket.ampere.agents.events.utils
 
 import co.touchlab.kermit.Logger
 import link.socket.ampere.agents.domain.Urgency
+import link.socket.ampere.agents.domain.event.AgentSurfaceEvent
 import link.socket.ampere.agents.domain.event.Event
 import link.socket.ampere.agents.domain.event.EventSource
 import link.socket.ampere.agents.domain.event.EventType
@@ -159,6 +160,10 @@ class SignificanceAwareEventLogger(
         // Routing events - routine for selection, significant for fallbacks
         is RoutingEvent.RouteSelected -> EventSignificance.ROUTINE
         is RoutingEvent.RouteFallback -> EventSignificance.SIGNIFICANT
+
+        // AgentSurface events - significant; users see them directly via the renderer
+        is AgentSurfaceEvent.Requested -> EventSignificance.SIGNIFICANT
+        is AgentSurfaceEvent.Responded -> EventSignificance.SIGNIFICANT
     }
 
     private fun formatUrgency(urgency: Urgency): String = when (urgency) {

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/events/surface/AgentSurfaceEventTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/events/surface/AgentSurfaceEventTest.kt
@@ -1,0 +1,148 @@
+package link.socket.ampere.agents.events.surface
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import link.socket.ampere.agents.domain.Urgency
+import link.socket.ampere.agents.domain.event.AgentSurfaceEvent
+import link.socket.ampere.agents.domain.event.EventRegistry
+import link.socket.ampere.agents.domain.event.EventSource
+import link.socket.ampere.agents.events.bus.EventSerialBus
+import link.socket.ampere.agents.events.bus.subscribe
+import link.socket.ampere.agents.events.subscription.EventSubscription
+import link.socket.ampere.agents.events.utils.generateUUID
+
+class AgentSurfaceEventTest {
+
+    @Test
+    fun `Requested event has expected type and summary`() {
+        val event = AgentSurfaceEvent.Requested(
+            eventId = "evt-1",
+            timestamp = Clock.System.now(),
+            eventSource = EventSource.Agent("plugin-x"),
+            urgency = Urgency.MEDIUM,
+            surface = AgentSurface.Confirmation(
+                correlationId = "c-1",
+                prompt = "Continue?",
+            ),
+        )
+
+        assertEquals("AgentSurfaceRequested", event.eventType)
+        assertEquals("c-1", event.correlationId)
+        val summary = event.getSummary(
+            formatUrgency = { "[${it.name}]" },
+            formatSource = { (it as? EventSource.Agent)?.agentId ?: "?" },
+        )
+        assertTrue(summary.contains("Confirmation"))
+        assertTrue(summary.contains("c-1"))
+    }
+
+    @Test
+    fun `Responded event surfaces outcome in summary`() {
+        val event = AgentSurfaceEvent.Responded(
+            eventId = "evt-2",
+            timestamp = Clock.System.now(),
+            eventSource = EventSource.Human,
+            response = AgentSurfaceResponse.Cancelled(correlationId = "c-1"),
+        )
+
+        assertEquals("AgentSurfaceResponded", event.eventType)
+        val summary = event.getSummary(
+            formatUrgency = { "[${it.name}]" },
+            formatSource = { "human" },
+        )
+        assertTrue(summary.contains("cancelled"))
+    }
+
+    @Test
+    fun `EventRegistry includes both AgentSurface event types`() {
+        assertTrue(AgentSurfaceEvent.Requested.EVENT_TYPE in EventRegistry.allEventTypes)
+        assertTrue(AgentSurfaceEvent.Responded.EVENT_TYPE in EventRegistry.allEventTypes)
+    }
+
+    @Test
+    fun `plugin can emit a surface request and receive a stub response via the bus`() = runTest {
+        coroutineScope {
+            val bus = EventSerialBus(scope = this)
+            val pluginAgent = "plugin-agent"
+            val rendererAgent = "renderer-stub"
+            val correlationId = "corr-flow-1"
+            val seenRequest = CompletableDeferred<AgentSurface>()
+
+            bus.subscribe<AgentSurfaceEvent.Requested, EventSubscription.ByEventClassType>(
+                agentId = rendererAgent,
+                eventType = AgentSurfaceEvent.Requested.EVENT_TYPE,
+            ) { event, _ ->
+                if (event.correlationId == correlationId && !seenRequest.isCompleted) {
+                    seenRequest.complete(event.surface)
+                    bus.publish(
+                        AgentSurfaceEvent.Responded(
+                            eventId = generateUUID(correlationId, rendererAgent),
+                            timestamp = Clock.System.now(),
+                            eventSource = EventSource.Agent(rendererAgent),
+                            response = AgentSurfaceResponse.Submitted(
+                                correlationId = correlationId,
+                                values = mapOf(
+                                    "branchName" to AgentSurfaceFieldValue.TextValue("feature/test"),
+                                ),
+                                chosenAction = "submit",
+                            ),
+                        ),
+                    )
+                }
+            }
+
+            val awaiter = async {
+                bus.awaitSurfaceResponse(
+                    awaiterAgentId = pluginAgent,
+                    correlationId = correlationId,
+                    timeout = 5.seconds,
+                )
+            }
+
+            bus.emitSurfaceRequest(
+                surface = AgentSurface.Form(
+                    correlationId = correlationId,
+                    title = "Branch",
+                    fields = listOf(
+                        AgentSurfaceField.Text(id = "branchName", label = "Branch name", required = true),
+                    ),
+                ),
+                eventSource = EventSource.Agent(pluginAgent),
+            )
+
+            val rendered = seenRequest.await()
+            assertIs<AgentSurface.Form>(rendered)
+            assertEquals("Branch", rendered.title)
+
+            val response = awaiter.await()
+            val submitted = assertIs<AgentSurfaceResponse.Submitted>(response)
+            assertEquals(correlationId, submitted.correlationId)
+            val text = assertIs<AgentSurfaceFieldValue.TextValue>(submitted.values["branchName"])
+            assertEquals("feature/test", text.value)
+        }
+    }
+
+    @Test
+    fun `awaitSurfaceResponse returns TimedOut when the renderer never replies`() = runTest {
+        coroutineScope {
+            val bus = EventSerialBus(scope = this)
+            val response = bus.awaitSurfaceResponse(
+                awaiterAgentId = "plugin-agent",
+                correlationId = "missing",
+                timeout = 50.milliseconds,
+            )
+            val timedOut = assertIs<AgentSurfaceResponse.TimedOut>(response)
+            assertEquals("missing", timedOut.correlationId)
+            assertEquals(50, timedOut.timeoutMillis)
+        }
+    }
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/events/surface/AgentSurfaceFieldValidationTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/events/surface/AgentSurfaceFieldValidationTest.kt
@@ -1,0 +1,155 @@
+package link.socket.ampere.agents.events.surface
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlinx.datetime.Instant
+
+class AgentSurfaceFieldValidationTest {
+
+    @Test
+    fun `Text field flags missing required value`() {
+        val field = AgentSurfaceField.Text(id = "name", label = "Name", required = true)
+        val result = field.validate(null)
+        assertIs<FieldValidationResult.Invalid>(result)
+        assertTrue(result.errors.any { it.contains("required", ignoreCase = true) })
+    }
+
+    @Test
+    fun `Text field enforces minLength and pattern`() {
+        val field = AgentSurfaceField.Text(
+            id = "branch",
+            label = "Branch",
+            required = true,
+            minLength = 3,
+            maxLength = 10,
+            pattern = "^[a-z-]+$",
+        )
+
+        val tooShort = field.validate(AgentSurfaceFieldValue.TextValue("ab"))
+        assertIs<FieldValidationResult.Invalid>(tooShort)
+        assertTrue(tooShort.errors.any { it.contains("at least 3") })
+
+        val tooLong = field.validate(AgentSurfaceFieldValue.TextValue("abcdefghijklmnop"))
+        assertIs<FieldValidationResult.Invalid>(tooLong)
+        assertTrue(tooLong.errors.any { it.contains("at most 10") })
+
+        val badPattern = field.validate(AgentSurfaceFieldValue.TextValue("Abc"))
+        assertIs<FieldValidationResult.Invalid>(badPattern)
+        assertTrue(badPattern.errors.any { it.contains("expected format") })
+
+        val ok = field.validate(AgentSurfaceFieldValue.TextValue("feature"))
+        assertEquals(FieldValidationResult.Valid, ok)
+    }
+
+    @Test
+    fun `Number field enforces bounds and integer-only`() {
+        val field = AgentSurfaceField.Number(
+            id = "count",
+            label = "Count",
+            required = true,
+            min = 1.0,
+            max = 10.0,
+            integerOnly = true,
+        )
+
+        assertIs<FieldValidationResult.Invalid>(field.validate(null))
+        assertIs<FieldValidationResult.Invalid>(field.validate(AgentSurfaceFieldValue.NumberValue(0.0)))
+        assertIs<FieldValidationResult.Invalid>(field.validate(AgentSurfaceFieldValue.NumberValue(11.0)))
+        assertIs<FieldValidationResult.Invalid>(field.validate(AgentSurfaceFieldValue.NumberValue(2.5)))
+        assertEquals(FieldValidationResult.Valid, field.validate(AgentSurfaceFieldValue.NumberValue(3.0)))
+    }
+
+    @Test
+    fun `Toggle field flags missing acceptance when required`() {
+        val field = AgentSurfaceField.Toggle(id = "tos", label = "Accept ToS", required = true)
+        assertIs<FieldValidationResult.Invalid>(field.validate(AgentSurfaceFieldValue.ToggleValue(false)))
+        assertEquals(
+            FieldValidationResult.Valid,
+            field.validate(AgentSurfaceFieldValue.ToggleValue(true)),
+        )
+    }
+
+    @Test
+    fun `DateTime field enforces notBefore and notAfter`() {
+        val low = Instant.fromEpochMilliseconds(1_000)
+        val high = Instant.fromEpochMilliseconds(10_000)
+        val field = AgentSurfaceField.DateTime(
+            id = "when",
+            label = "When",
+            required = true,
+            notBefore = low,
+            notAfter = high,
+        )
+
+        assertIs<FieldValidationResult.Invalid>(
+            field.validate(AgentSurfaceFieldValue.DateTimeValue(Instant.fromEpochMilliseconds(0))),
+        )
+        assertIs<FieldValidationResult.Invalid>(
+            field.validate(AgentSurfaceFieldValue.DateTimeValue(Instant.fromEpochMilliseconds(20_000))),
+        )
+        assertEquals(
+            FieldValidationResult.Valid,
+            field.validate(AgentSurfaceFieldValue.DateTimeValue(Instant.fromEpochMilliseconds(5_000))),
+        )
+    }
+
+    @Test
+    fun `Selection field enforces option ids and selection counts`() {
+        val field = AgentSurfaceField.Selection(
+            id = "branches",
+            label = "Branches",
+            required = true,
+            options = listOf(
+                AgentSurface.Choice.Option(id = "main", label = "main"),
+                AgentSurface.Choice.Option(id = "develop", label = "develop"),
+            ),
+            multiSelect = true,
+            minSelections = 1,
+            maxSelections = 1,
+        )
+
+        assertIs<FieldValidationResult.Invalid>(
+            field.validate(AgentSurfaceFieldValue.SelectionValue(emptyList())),
+        )
+        val tooMany = field.validate(AgentSurfaceFieldValue.SelectionValue(listOf("main", "develop")))
+        assertIs<FieldValidationResult.Invalid>(tooMany)
+        assertTrue(tooMany.errors.any { it.contains("at most 1") })
+
+        val unknown = field.validate(AgentSurfaceFieldValue.SelectionValue(listOf("trunk")))
+        assertIs<FieldValidationResult.Invalid>(unknown)
+        assertTrue(unknown.errors.any { it.contains("unknown options") })
+
+        assertEquals(
+            FieldValidationResult.Valid,
+            field.validate(AgentSurfaceFieldValue.SelectionValue(listOf("main"))),
+        )
+    }
+
+    @Test
+    fun `Secret field reuses Text-style length checks`() {
+        val field = AgentSurfaceField.Secret(
+            id = "token",
+            label = "Token",
+            required = true,
+            minLength = 8,
+            maxLength = 32,
+        )
+
+        assertIs<FieldValidationResult.Invalid>(field.validate(null))
+        assertIs<FieldValidationResult.Invalid>(field.validate(AgentSurfaceFieldValue.SecretValue("short")))
+        assertEquals(
+            FieldValidationResult.Valid,
+            field.validate(AgentSurfaceFieldValue.SecretValue("a-real-token")),
+        )
+    }
+
+    @Test
+    fun `mismatched value variant is treated as missing`() {
+        val field = AgentSurfaceField.Text(id = "x", label = "X", required = true)
+        val result = field.validate(AgentSurfaceFieldValue.NumberValue(1.0))
+        assertIs<FieldValidationResult.Invalid>(result)
+        assertTrue(result.errors.any { it.contains("required", ignoreCase = true) })
+    }
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/events/surface/AgentSurfaceSerializationTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/events/surface/AgentSurfaceSerializationTest.kt
@@ -1,0 +1,196 @@
+package link.socket.ampere.agents.events.surface
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlinx.datetime.Instant
+import kotlinx.serialization.json.Json
+
+class AgentSurfaceSerializationTest {
+
+    private val json = Json {
+        prettyPrint = false
+        encodeDefaults = true
+    }
+
+    @Test
+    fun `Form surface round-trips through JSON`() {
+        val original: AgentSurface = AgentSurface.Form(
+            correlationId = "corr-form-1",
+            title = "Create branch",
+            description = "Provide a branch name and base.",
+            fields = listOf(
+                AgentSurfaceField.Text(
+                    id = "branchName",
+                    label = "Branch name",
+                    required = true,
+                    minLength = 1,
+                    maxLength = 64,
+                    pattern = "^[a-z0-9/_-]+$",
+                ),
+                AgentSurfaceField.Toggle(
+                    id = "draft",
+                    label = "Open as draft",
+                    default = true,
+                ),
+            ),
+        )
+
+        val encoded = json.encodeToString(AgentSurface.serializer(), original)
+        val decoded = json.decodeFromString(AgentSurface.serializer(), encoded)
+
+        assertEquals(original, decoded)
+        assertIs<AgentSurface.Form>(decoded)
+    }
+
+    @Test
+    fun `Choice surface round-trips through JSON`() {
+        val original: AgentSurface = AgentSurface.Choice(
+            correlationId = "corr-choice-1",
+            title = "Pick a base branch",
+            options = listOf(
+                AgentSurface.Choice.Option(id = "main", label = "main"),
+                AgentSurface.Choice.Option(id = "develop", label = "develop", description = "integration"),
+            ),
+        )
+
+        val encoded = json.encodeToString(AgentSurface.serializer(), original)
+        val decoded = json.decodeFromString(AgentSurface.serializer(), encoded)
+
+        assertEquals(original, decoded)
+        assertIs<AgentSurface.Choice>(decoded)
+    }
+
+    @Test
+    fun `Confirmation surface round-trips through JSON`() {
+        val original: AgentSurface = AgentSurface.Confirmation(
+            correlationId = "corr-conf-1",
+            prompt = "Force-push to main?",
+            severity = AgentSurface.Confirmation.Severity.Destructive,
+            confirmLabel = "Force push",
+        )
+
+        val encoded = json.encodeToString(AgentSurface.serializer(), original)
+        val decoded = json.decodeFromString(AgentSurface.serializer(), encoded)
+
+        assertEquals(original, decoded)
+        assertIs<AgentSurface.Confirmation>(decoded)
+    }
+
+    @Test
+    fun `Card surface round-trips through JSON with all slot kinds`() {
+        val original: AgentSurface = AgentSurface.Card(
+            correlationId = "corr-card-1",
+            title = "Pull request",
+            slots = listOf(
+                AgentSurface.Card.Slot.Heading("Summary", level = 1),
+                AgentSurface.Card.Slot.Body("Adds AgentSurface primitive."),
+                AgentSurface.Card.Slot.KeyValue("Files", "12"),
+                AgentSurface.Card.Slot.Image("https://example.com/diff.png", altText = "Diff"),
+                AgentSurface.Card.Slot.Code("println(\"hi\")", language = "kotlin"),
+            ),
+            actions = listOf(
+                AgentSurface.Card.Action(id = "approve", label = "Approve"),
+                AgentSurface.Card.Action(
+                    id = "reject",
+                    label = "Reject",
+                    severity = AgentSurface.Confirmation.Severity.Destructive,
+                ),
+            ),
+        )
+
+        val encoded = json.encodeToString(AgentSurface.serializer(), original)
+        val decoded = json.decodeFromString(AgentSurface.serializer(), encoded)
+
+        assertEquals(original, decoded)
+        assertIs<AgentSurface.Card>(decoded)
+    }
+
+    @Test
+    fun `every AgentSurfaceField variant round-trips`() {
+        val fields: List<AgentSurfaceField> = listOf(
+            AgentSurfaceField.Text(id = "t", label = "T"),
+            AgentSurfaceField.Number(id = "n", label = "N", min = 0.0, max = 100.0, integerOnly = true),
+            AgentSurfaceField.Toggle(id = "g", label = "G"),
+            AgentSurfaceField.DateTime(
+                id = "d",
+                label = "D",
+                notBefore = Instant.fromEpochMilliseconds(0),
+                notAfter = Instant.fromEpochMilliseconds(1_000_000),
+            ),
+            AgentSurfaceField.Selection(
+                id = "s",
+                label = "S",
+                options = listOf(AgentSurface.Choice.Option(id = "a", label = "A")),
+            ),
+            AgentSurfaceField.Secret(id = "k", label = "K", minLength = 8),
+        )
+
+        for (field in fields) {
+            val encoded = json.encodeToString(AgentSurfaceField.serializer(), field)
+            val decoded = json.decodeFromString(AgentSurfaceField.serializer(), encoded)
+            assertEquals(field, decoded, "Field $field did not round-trip cleanly")
+        }
+    }
+
+    @Test
+    fun `every AgentSurfaceFieldValue variant round-trips`() {
+        val values: List<AgentSurfaceFieldValue> = listOf(
+            AgentSurfaceFieldValue.TextValue("hello"),
+            AgentSurfaceFieldValue.NumberValue(42.5),
+            AgentSurfaceFieldValue.ToggleValue(true),
+            AgentSurfaceFieldValue.DateTimeValue(Instant.fromEpochMilliseconds(1_700_000_000_000L)),
+            AgentSurfaceFieldValue.SelectionValue(listOf("a", "b")),
+            AgentSurfaceFieldValue.SecretValue("hunter2"),
+        )
+
+        for (value in values) {
+            val encoded = json.encodeToString(AgentSurfaceFieldValue.serializer(), value)
+            val decoded = json.decodeFromString(AgentSurfaceFieldValue.serializer(), encoded)
+            assertEquals(value, decoded, "Value $value did not round-trip cleanly")
+        }
+    }
+
+    @Test
+    fun `every AgentSurfaceResponse variant round-trips`() {
+        val responses: List<AgentSurfaceResponse> = listOf(
+            AgentSurfaceResponse.Submitted(
+                correlationId = "corr-1",
+                values = mapOf(
+                    "name" to AgentSurfaceFieldValue.TextValue("Ampere"),
+                    "draft" to AgentSurfaceFieldValue.ToggleValue(false),
+                ),
+                chosenAction = "submit",
+            ),
+            AgentSurfaceResponse.Cancelled(correlationId = "corr-2", reason = "user dismissed"),
+            AgentSurfaceResponse.TimedOut(correlationId = "corr-3", timeoutMillis = 30_000),
+        )
+
+        for (response in responses) {
+            val encoded = json.encodeToString(AgentSurfaceResponse.serializer(), response)
+            val decoded = json.decodeFromString(AgentSurfaceResponse.serializer(), encoded)
+            assertEquals(response, decoded)
+        }
+    }
+
+    @Test
+    fun `every AgentSurface variant carries a correlationId`() {
+        val surfaces: List<AgentSurface> = listOf(
+            AgentSurface.Form(correlationId = "f", title = "t", fields = emptyList()),
+            AgentSurface.Choice(correlationId = "c", title = "t", options = emptyList()),
+            AgentSurface.Confirmation(correlationId = "cf", prompt = "?"),
+            AgentSurface.Card(correlationId = "cd", title = "t", slots = emptyList()),
+        )
+        // Exhaustive when ensures every variant is covered at compile time.
+        for (surface in surfaces) {
+            val id: CorrelationId = when (surface) {
+                is AgentSurface.Form -> surface.correlationId
+                is AgentSurface.Choice -> surface.correlationId
+                is AgentSurface.Confirmation -> surface.correlationId
+                is AgentSurface.Card -> surface.correlationId
+            }
+            assertTrue(id.isNotEmpty())
+        }
+    }
+}

--- a/docs/ampere/agent-surface.md
+++ b/docs/ampere/agent-surface.md
@@ -1,0 +1,111 @@
+# AgentSurface
+
+`AgentSurface` is Ampere's primitive for **Plugin-emitted UI render requests**. It is the common contract that Plugin code (commonMain) and platform renderers (iOS, Android Compose Multiplatform, Desktop) build against. This document is the source of truth for the W1.3 / W1.4 platform renderers and the W2.1 reference Plugins.
+
+## Design goals
+
+- **Typed and serializable.** Every variant is `@Serializable`; surface requests can be persisted, replayed, and shipped over a wire.
+- **commonMain-only.** No iOS, Android, or Compose imports leak into the type definitions. Renderers translate the contract into native UI.
+- **No reactive framework dependencies.** `kotlinx.coroutines.flow` is acceptable; Compose, SwiftUI, and React are not.
+- **Stable correlation.** Every surface and every response carries a `correlationId` so a Plugin can `awaitSurfaceResponse` without coupling to bus internals.
+
+## Type hierarchy
+
+| Type | Location | Purpose |
+| --- | --- | --- |
+| `AgentSurface` | `link.socket.ampere.agents.events.surface` | Sealed render request (`Form`, `Choice`, `Confirmation`, `Card`). |
+| `AgentSurfaceField` | `link.socket.ampere.agents.events.surface` | Sealed input field for `Form` (`Text`, `Number`, `Toggle`, `DateTime`, `Selection`, `Secret`). |
+| `AgentSurfaceFieldValue` | `link.socket.ampere.agents.events.surface` | Typed value returned per field. |
+| `AgentSurfaceResponse` | `link.socket.ampere.agents.events.surface` | Sealed reply (`Submitted`, `Cancelled`, `TimedOut`). |
+| `FieldValidationResult` | `link.socket.ampere.agents.events.surface` | `Valid` / `Invalid(errors)` from `AgentSurfaceField.validate`. |
+| `AgentSurfaceEvent` | `link.socket.ampere.agents.domain.event` | `Requested` / `Responded` events flowing through `EventSerialBus`. |
+| `CorrelationId` | `link.socket.ampere.agents.events.surface` | `typealias CorrelationId = String`. |
+
+## Lifecycle
+
+```
+Plugin                          EventSerialBus                       Renderer
+  |                                    |                                |
+  | bus.emitSurfaceRequest(surface)    |                                |
+  |----------------------------------->|                                |
+  |                                    | publish(Requested)             |
+  |                                    |------------------------------->|
+  |                                    |                                | render UI
+  | awaitSurfaceResponse(correlationId)|                                | gather response
+  |==suspended=========================|                                |
+  |                                    | publish(Responded)             |
+  |                                    |<-------------------------------|
+  |                                    |                                |
+  |<================ AgentSurfaceResponse                               |
+```
+
+1. **Emit.** The Plugin calls `bus.emitSurfaceRequest(surface, eventSource)` (or constructs `AgentSurfaceEvent.Requested` directly and publishes it).
+2. **Render.** A platform-specific subscriber to `AgentSurfaceEvent.Requested` translates the surface into native UI.
+3. **Respond.** When the user submits, cancels, or the renderer's own timeout elapses, the renderer publishes `AgentSurfaceEvent.Responded` with the same `correlationId`.
+4. **Resume.** `awaitSurfaceResponse(awaiterAgentId, correlationId, timeout)` returns the `AgentSurfaceResponse`. If `timeout` elapses first, the helper returns an `AgentSurfaceResponse.TimedOut` rather than throwing.
+
+## Validation
+
+Field validation is the canonical responsibility of `AgentSurfaceField.validate(value)`. It runs in pure Kotlin so renderers, Plugin code, and integration tests share the exact same predicates.
+
+| Field | Rules |
+| --- | --- |
+| `Text` | `required`, `minLength`, `maxLength`, optional `pattern` (Kotlin `Regex`). |
+| `Number` | `required`, `min`, `max`, `integerOnly`. |
+| `Toggle` | `required` means the toggle must be `true` to pass. |
+| `DateTime` | `required`, `notBefore`, `notAfter`. |
+| `Selection` | `required`, `minSelections`, `maxSelections`, unknown ids rejected. |
+| `Secret` | `required`, `minLength`, `maxLength`. Renderers must avoid logging the value beyond the originating Plugin. |
+
+`validate` returns `FieldValidationResult.Valid` or `FieldValidationResult.Invalid(errors)` with human-readable messages. Renderers may surface failures inline, but they must not submit a response that fails validation.
+
+## Renderer requirements
+
+Every platform renderer (iOS native pass-through, Android Compose Multiplatform, Desktop Compose, Web) **must**:
+
+1. Subscribe to `AgentSurfaceEvent.Requested.EVENT_TYPE` on the bus.
+2. Dispatch on `event.surface` exhaustively over the four `AgentSurface` variants — adding a variant in `commonMain` is a breaking change that fails the renderer's `when` at compile time.
+3. Render fields in the order they appear in `AgentSurface.Form.fields`.
+4. Run `AgentSurfaceField.validate` before publishing `Submitted`. Submission with invalid values is a contract violation.
+5. Publish exactly one `AgentSurfaceEvent.Responded` per `Requested`, carrying the originating `correlationId`.
+6. Treat `AgentSurfaceField.Secret` values as ephemeral: never persist, log, or echo them outside the renderer.
+7. Map `AgentSurface.Confirmation.Severity.Destructive` to the platform's destructive affordance (red action button on Android, system-red on iOS, etc.) — this is the only intended way severity is allowed to leak into renderer styling.
+
+Renderers **must not**:
+
+- Mutate or extend the surface payload before forwarding it elsewhere.
+- Reference Compose, SwiftUI, or other UI types from the `commonMain` contract.
+- Drop a `Requested` silently — if no renderer is registered, the bus simply has no subscribers and the awaiter will time out, which is the intended degradation.
+
+## Plugin example
+
+```kotlin
+suspend fun choosePullRequestBranch(
+    bus: EventSerialBus,
+    agentId: AgentId,
+): AgentSurfaceResponse {
+    val correlationId = generateUUID(agentId, "pr-branch")
+    bus.emitSurfaceRequest(
+        surface = AgentSurface.Choice(
+            correlationId = correlationId,
+            title = "Pick a base branch",
+            options = listOf(
+                AgentSurface.Choice.Option(id = "main", label = "main"),
+                AgentSurface.Choice.Option(id = "develop", label = "develop"),
+            ),
+        ),
+        eventSource = EventSource.Agent(agentId),
+    )
+    return bus.awaitSurfaceResponse(
+        awaiterAgentId = agentId,
+        correlationId = correlationId,
+        timeout = 30.seconds,
+    )
+}
+```
+
+## Versioning
+
+`AgentSurface`, `AgentSurfaceField`, `AgentSurfaceFieldValue`, and `AgentSurfaceResponse` are part of the public Ampere SDK. Adding a new variant is a breaking change for renderers (their `when` becomes non-exhaustive at compile time), which is the intended forcing function: every renderer must explicitly opt in to a new surface type before it ships.
+
+Adding optional fields with defaults to existing variants is source-compatible. Removing fields, or changing field types, is a breaking change.


### PR DESCRIPTION
## Summary

Codifies `AgentSurface` as a typed, serializable DSL for Plugin-emitted UI render requests in commonMain so platform renderers (W1.3, W1.4) and reference Plugins (W2.1) build against a stable contract. I added sealed `AgentSurface` (`Form`/`Choice`/`Confirmation`/`Card`), `AgentSurfaceField` (`Text`/`Number`/`Toggle`/`DateTime`/`Selection`/`Secret`) with pure-Kotlin validation, `AgentSurfaceResponse`, `AgentSurfaceEvent.Requested`/`Responded` wired into `EventSerialBus`, and an `awaitSurfaceResponse(correlationId, timeout)` helper. Coverage includes round-trip serialization, field validation, and a bus-driven request → stub-renderer → response integration test, plus contract/lifecycle/renderer docs at `docs/ampere/agent-surface.md`. Existing `Event`-exhaustive `when` sites in `SignificanceAwareEventLogger`, CLI `EventCategorizer`, and `EventRenderer` were extended for the new variants.

Closes #459

## Test plan

- [x] `./gradlew :ampere-core:jvmTest --tests "link.socket.ampere.agents.events.surface.*"` (21/21 pass)
- [x] `./gradlew jvmTest` (full sweep across modules passes)
- [x] `./gradlew :ampere-core:ktlintCheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)