### PR TITLE
AMPR-151 #460: add AgentPause primitive type system

### DIFF
--- a/ampere-core/src/androidMain/kotlin/link/socket/ampere/pause/ChannelAvailability.android.kt
+++ b/ampere-core/src/androidMain/kotlin/link/socket/ampere/pause/ChannelAvailability.android.kt
@@ -1,0 +1,13 @@
+package link.socket.ampere.pause
+
+import kotlin.reflect.KClass
+
+/**
+ * Android stub. Real implementation in W1.5 will query NotificationManager
+ * channel state, RecognizerIntent voice support, and the Ampere shell's
+ * lifecycle state.
+ */
+actual class ChannelAvailability actual constructor() {
+
+    actual fun available(): List<KClass<out EscalationChannel>> = emptyList()
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/pause/AgentPause.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/pause/AgentPause.kt
@@ -1,0 +1,68 @@
+package link.socket.ampere.pause
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Correlation identifier used to pair a [AgentPause] request with its
+ * matching [AgentPauseResponse]. Plugins generate one per pause they emit.
+ */
+typealias PauseCorrelationId = String
+
+/**
+ * A typed, serializable description of an agent that has paused execution and
+ * is awaiting human input.
+ *
+ * `AgentPause` is the OS-native escalation primitive. Where [link.socket.ampere
+ * .agents.events.surface.AgentSurface] models a Plugin asking the platform to
+ * render UI, `AgentPause` models the higher-level *intent* of "I am stuck and
+ * need a person." Channel selection (push notification → voice prompt →
+ * in-app card → public link) is handled by the W1.5 channel-selector against
+ * [suggestedChannels]; this type fixes the contract so renderers and per-Arc
+ * override UI can build against it now.
+ *
+ * The contract intentionally lives in commonMain and carries no platform
+ * references so it can be expressed across every Ampere target.
+ */
+@Serializable
+data class AgentPause(
+    /** Stable identifier used to pair this pause with its response. */
+    val correlationId: PauseCorrelationId,
+    /** Human-readable explanation of why the agent paused. */
+    val reason: String,
+    /** How time-sensitive the pause is; drives default channel selection. */
+    val urgency: PauseUrgency,
+    /**
+     * Ordered list of channels to attempt, highest priority first. The
+     * channel selector walks this list and falls through to the next channel
+     * on unavailability or non-response.
+     */
+    val suggestedChannels: List<EscalationChannel>,
+    /** How long to wait before considering the pause [AgentPauseResponse.TimedOut]. */
+    val timeoutMillis: Long,
+    /**
+     * Public URL the user can visit to respond, used as the lowest-priority
+     * fallback when no native channel is available. Optional — pauses that
+     * must not leak to a public surface should leave this null.
+     */
+    val fallbackUrl: String? = null,
+)
+
+/**
+ * Urgency level of an [AgentPause].
+ *
+ * This is intentionally distinct from [link.socket.ampere.agents.domain.Urgency]
+ * (which classifies bus events). Pause urgency drives channel-selection
+ * defaults: [Routine] prefers in-app card, [Important] prefers push
+ * notification, [Critical] prefers voice prompt.
+ */
+@Serializable
+enum class PauseUrgency {
+    /** Non-blocking; in-app card is the default channel. */
+    Routine,
+
+    /** Time-sensitive; push notification is the default channel. */
+    Important,
+
+    /** Blocking; voice prompt is the default channel. */
+    Critical,
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/pause/AgentPauseResponse.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/pause/AgentPauseResponse.kt
@@ -1,0 +1,45 @@
+package link.socket.ampere.pause
+
+import kotlinx.serialization.Serializable
+
+/**
+ * The reply to an [AgentPause].
+ *
+ * Every variant carries the same [correlationId] as the originating
+ * [AgentPause], which is what lets the awaiter pair the response with the
+ * request that emitted it.
+ */
+@Serializable
+sealed interface AgentPauseResponse {
+
+    /** Echo of the originating [AgentPause.correlationId]. */
+    val correlationId: PauseCorrelationId
+
+    /**
+     * The user approved the paused operation. [payload] carries any
+     * additional structured data the responder supplied (e.g., a confirmation
+     * note, a chosen option). It is opaque to the pause primitive — Plugin
+     * code parses it.
+     */
+    @Serializable
+    data class Approved(
+        override val correlationId: PauseCorrelationId,
+        val payload: String? = null,
+    ) : AgentPauseResponse
+
+    /** The user rejected the paused operation. */
+    @Serializable
+    data class Rejected(
+        override val correlationId: PauseCorrelationId,
+        val reason: String? = null,
+    ) : AgentPauseResponse
+
+    /**
+     * No channel produced a response within [AgentPause.timeoutMillis]. The
+     * agent should treat the pause as unanswered.
+     */
+    @Serializable
+    data class TimedOut(
+        override val correlationId: PauseCorrelationId,
+    ) : AgentPauseResponse
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/pause/ChannelAvailability.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/pause/ChannelAvailability.kt
@@ -1,0 +1,28 @@
+package link.socket.ampere.pause
+
+import kotlin.reflect.KClass
+
+/**
+ * Platform query for which [EscalationChannel] variants are currently
+ * available on this device.
+ *
+ * The W1.5 channel-selector consults [available] before walking
+ * [AgentPause.suggestedChannels] and skips channels whose variant is not in
+ * the returned set. Per-platform implementations inspect runtime state
+ * (notification permissions, voice-input availability, foreground/background)
+ * to populate the result.
+ *
+ * This file ships intentionally empty stubs in W0.3 — the actual platform
+ * logic lands in W1.5. The contract exists now so W1.5 and W2.2 can build
+ * against a stable API.
+ */
+expect class ChannelAvailability() {
+
+    /**
+     * Returns the [EscalationChannel] subclasses that are currently usable.
+     * An empty result means no native channel is available — callers should
+     * fall through to [EscalationChannel.PublicLink] if the originating
+     * [AgentPause.fallbackUrl] is set, or treat the pause as unrouteable.
+     */
+    fun available(): List<KClass<out EscalationChannel>>
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/pause/EscalationChannel.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/pause/EscalationChannel.kt
@@ -1,0 +1,73 @@
+package link.socket.ampere.pause
+
+import kotlinx.serialization.Serializable
+
+/**
+ * A channel through which an [AgentPause] can solicit a human response.
+ *
+ * Each variant declares the minimal renderer parameters needed for a platform
+ * implementation to dispatch the channel without reaching back into Ampere.
+ * The channel-selector (W1.5) walks [AgentPause.suggestedChannels] in order;
+ * the per-Arc override UI (W2.2) reorders or filters the list.
+ */
+@Serializable
+sealed interface EscalationChannel {
+
+    /**
+     * Native push notification. The renderer maps [notificationCategory] onto
+     * the platform-specific category/channel id (Android notification channel,
+     * iOS `UNNotificationCategory`).
+     */
+    @Serializable
+    data class Push(
+        val notificationCategory: String,
+        val title: String,
+        val body: String,
+        val deeplink: String? = null,
+    ) : EscalationChannel
+
+    /**
+     * Voice prompt — typically a synthesized read-out followed by a
+     * speech-to-text response window. Used for [PauseUrgency.Critical] pauses
+     * by default.
+     */
+    @Serializable
+    data class Voice(
+        val prompt: String,
+        val expectedResponseSeconds: Int = 15,
+        val voiceProfile: String? = null,
+    ) : EscalationChannel
+
+    /**
+     * In-app card displayed inside the Ampere shell. The renderer resolves
+     * [cardKind] to an in-app surface (e.g., a banner, a modal, an Arc-pinned
+     * card).
+     */
+    @Serializable
+    data class InAppCard(
+        val cardKind: CardKind,
+        val title: String,
+        val body: String,
+        val primaryActionLabel: String = "Approve",
+        val secondaryActionLabel: String = "Reject",
+    ) : EscalationChannel {
+
+        @Serializable
+        enum class CardKind {
+            Banner,
+            Modal,
+            ArcPinned,
+        }
+    }
+
+    /**
+     * Lowest-priority fallback: a public URL the user opens in a browser.
+     * Used when no native channel is available, or when the agent
+     * intentionally wants to reach a non-Ampere recipient.
+     */
+    @Serializable
+    data class PublicLink(
+        val url: String,
+        val displayLabel: String = "Open in browser",
+    ) : EscalationChannel
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/pause/AgentPauseSerializationTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/pause/AgentPauseSerializationTest.kt
@@ -1,0 +1,220 @@
+package link.socket.ampere.pause
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+
+class AgentPauseSerializationTest {
+
+    private val json = Json {
+        prettyPrint = false
+        encodeDefaults = true
+    }
+
+    @Test
+    fun `AgentPause round-trips through JSON with all fields populated`() {
+        val original = AgentPause(
+            correlationId = "pause-1",
+            reason = "Confirm production deploy",
+            urgency = PauseUrgency.Critical,
+            suggestedChannels = listOf(
+                EscalationChannel.Voice(
+                    prompt = "Approve the production deploy?",
+                    expectedResponseSeconds = 20,
+                    voiceProfile = "default",
+                ),
+                EscalationChannel.Push(
+                    notificationCategory = "deploy",
+                    title = "Approve production deploy",
+                    body = "Hold on the v0.5.0 ship while we wait.",
+                    deeplink = "ampere://pause/pause-1",
+                ),
+                EscalationChannel.InAppCard(
+                    cardKind = EscalationChannel.InAppCard.CardKind.Modal,
+                    title = "Production deploy",
+                    body = "Approve to ship.",
+                ),
+                EscalationChannel.PublicLink(
+                    url = "https://ampere.example/pause/pause-1",
+                    displayLabel = "Open approval",
+                ),
+            ),
+            timeoutMillis = 60_000,
+            fallbackUrl = "https://ampere.example/pause/pause-1",
+        )
+
+        val encoded = json.encodeToString(AgentPause.serializer(), original)
+        val decoded = json.decodeFromString(AgentPause.serializer(), encoded)
+
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun `AgentPause round-trips with null fallbackUrl`() {
+        val original = AgentPause(
+            correlationId = "pause-no-link",
+            reason = "Internal-only escalation",
+            urgency = PauseUrgency.Routine,
+            suggestedChannels = listOf(
+                EscalationChannel.InAppCard(
+                    cardKind = EscalationChannel.InAppCard.CardKind.Banner,
+                    title = "Heads up",
+                    body = "Want to keep going?",
+                ),
+            ),
+            timeoutMillis = 5_000,
+            fallbackUrl = null,
+        )
+
+        val encoded = json.encodeToString(AgentPause.serializer(), original)
+        val decoded = json.decodeFromString(AgentPause.serializer(), encoded)
+
+        assertEquals(original, decoded)
+        assertNull(decoded.fallbackUrl)
+    }
+
+    @Test
+    fun `every EscalationChannel variant round-trips`() {
+        val channels: List<EscalationChannel> = listOf(
+            EscalationChannel.Push(
+                notificationCategory = "auth",
+                title = "Approve sign-in",
+                body = "From 192.0.2.1",
+            ),
+            EscalationChannel.Voice(prompt = "Approve the sign-in?"),
+            EscalationChannel.InAppCard(
+                cardKind = EscalationChannel.InAppCard.CardKind.ArcPinned,
+                title = "Continue?",
+                body = "Long-running search waiting on you.",
+            ),
+            EscalationChannel.PublicLink(url = "https://example.com/p/x"),
+        )
+
+        for (channel in channels) {
+            val encoded = json.encodeToString(EscalationChannel.serializer(), channel)
+            val decoded = json.decodeFromString(EscalationChannel.serializer(), encoded)
+            assertEquals(channel, decoded, "Channel $channel did not round-trip cleanly")
+        }
+    }
+
+    @Test
+    fun `every AgentPauseResponse variant round-trips`() {
+        val responses: List<AgentPauseResponse> = listOf(
+            AgentPauseResponse.Approved(correlationId = "p-1", payload = "lgtm"),
+            AgentPauseResponse.Approved(correlationId = "p-2"),
+            AgentPauseResponse.Rejected(correlationId = "p-3", reason = "wrong env"),
+            AgentPauseResponse.Rejected(correlationId = "p-4"),
+            AgentPauseResponse.TimedOut(correlationId = "p-5"),
+        )
+
+        for (response in responses) {
+            val encoded = json.encodeToString(AgentPauseResponse.serializer(), response)
+            val decoded = json.decodeFromString(AgentPauseResponse.serializer(), encoded)
+            assertEquals(response, decoded)
+        }
+    }
+
+    @Test
+    fun `every PauseUrgency value round-trips`() {
+        for (urgency in PauseUrgency.entries) {
+            val encoded = json.encodeToString(PauseUrgency.serializer(), urgency)
+            val decoded = json.decodeFromString(PauseUrgency.serializer(), encoded)
+            assertEquals(urgency, decoded)
+        }
+    }
+
+    @Test
+    fun `AgentPauseResponse correlationId is exhaustive across variants`() {
+        val responses: List<AgentPauseResponse> = listOf(
+            AgentPauseResponse.Approved(correlationId = "a"),
+            AgentPauseResponse.Rejected(correlationId = "b"),
+            AgentPauseResponse.TimedOut(correlationId = "c"),
+        )
+        for (response in responses) {
+            // Exhaustive when ensures every variant is covered at compile time.
+            val id: PauseCorrelationId = when (response) {
+                is AgentPauseResponse.Approved -> response.correlationId
+                is AgentPauseResponse.Rejected -> response.correlationId
+                is AgentPauseResponse.TimedOut -> response.correlationId
+            }
+            assertTrue(id.isNotEmpty())
+        }
+    }
+
+    @Test
+    fun `EscalationChannel sealed hierarchy is exhaustive at compile time`() {
+        val channels: List<EscalationChannel> = listOf(
+            EscalationChannel.Push("c", "t", "b"),
+            EscalationChannel.Voice(prompt = "p"),
+            EscalationChannel.InAppCard(
+                cardKind = EscalationChannel.InAppCard.CardKind.Modal,
+                title = "t",
+                body = "b",
+            ),
+            EscalationChannel.PublicLink(url = "https://example.com"),
+        )
+        for (channel in channels) {
+            val description: String = when (channel) {
+                is EscalationChannel.Push -> "push:${channel.notificationCategory}"
+                is EscalationChannel.Voice -> "voice:${channel.prompt}"
+                is EscalationChannel.InAppCard -> "card:${channel.cardKind}"
+                is EscalationChannel.PublicLink -> "link:${channel.url}"
+            }
+            assertTrue(description.isNotEmpty())
+        }
+    }
+
+    @Test
+    fun `AgentPause preserves channel ordering through serialization`() {
+        val original = AgentPause(
+            correlationId = "pause-order",
+            reason = "verify ordering",
+            urgency = PauseUrgency.Important,
+            suggestedChannels = listOf(
+                EscalationChannel.Push("c1", "t1", "b1"),
+                EscalationChannel.InAppCard(
+                    cardKind = EscalationChannel.InAppCard.CardKind.Banner,
+                    title = "t",
+                    body = "b",
+                ),
+                EscalationChannel.PublicLink(url = "https://example.com"),
+            ),
+            timeoutMillis = 30_000,
+        )
+
+        val encoded = json.encodeToString(AgentPause.serializer(), original)
+        val decoded = json.decodeFromString(AgentPause.serializer(), encoded)
+
+        assertEquals(original.suggestedChannels, decoded.suggestedChannels)
+        assertIs<EscalationChannel.Push>(decoded.suggestedChannels[0])
+        assertIs<EscalationChannel.InAppCard>(decoded.suggestedChannels[1])
+        assertIs<EscalationChannel.PublicLink>(decoded.suggestedChannels[2])
+    }
+
+    @Test
+    fun `Approved payload is optional and round-trips when absent`() {
+        val original: AgentPauseResponse = AgentPauseResponse.Approved(correlationId = "p-x")
+        val encoded = json.encodeToString(AgentPauseResponse.serializer(), original)
+        val decoded = json.decodeFromString(AgentPauseResponse.serializer(), encoded)
+        assertEquals(original, decoded)
+        val approved = decoded as AgentPauseResponse.Approved
+        assertNull(approved.payload)
+    }
+
+    @Test
+    fun `Approved payload is preserved when supplied`() {
+        val original: AgentPauseResponse = AgentPauseResponse.Approved(
+            correlationId = "p-y",
+            payload = "ship-it-v0.5.0",
+        )
+        val encoded = json.encodeToString(AgentPauseResponse.serializer(), original)
+        val decoded = json.decodeFromString(AgentPauseResponse.serializer(), encoded)
+        val approved = decoded as AgentPauseResponse.Approved
+        assertNotNull(approved.payload)
+        assertEquals("ship-it-v0.5.0", approved.payload)
+    }
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/pause/ChannelAvailabilityTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/pause/ChannelAvailabilityTest.kt
@@ -1,0 +1,15 @@
+package link.socket.ampere.pause
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ChannelAvailabilityTest {
+
+    @Test
+    fun `stub returns empty channel list on every platform`() {
+        val availability = ChannelAvailability()
+        assertEquals(emptyList(), availability.available())
+        assertTrue(availability.available().isEmpty())
+    }
+}

--- a/ampere-core/src/iosMain/kotlin/link/socket/ampere/pause/ChannelAvailability.ios.kt
+++ b/ampere-core/src/iosMain/kotlin/link/socket/ampere/pause/ChannelAvailability.ios.kt
@@ -1,0 +1,13 @@
+package link.socket.ampere.pause
+
+import kotlin.reflect.KClass
+
+/**
+ * iOS stub. Real implementation in W1.5 will query
+ * `UNUserNotificationCenter`, AVAudioSession voice availability, and the
+ * Ampere shell's foreground state.
+ */
+actual class ChannelAvailability actual constructor() {
+
+    actual fun available(): List<KClass<out EscalationChannel>> = emptyList()
+}

--- a/ampere-core/src/jsMain/kotlin/link/socket/ampere/pause/ChannelAvailability.js.kt
+++ b/ampere-core/src/jsMain/kotlin/link/socket/ampere/pause/ChannelAvailability.js.kt
@@ -1,0 +1,12 @@
+package link.socket.ampere.pause
+
+import kotlin.reflect.KClass
+
+/**
+ * JS/browser stub. Real implementation in W1.5 may bridge the Notifications
+ * API and the in-app card; voice and native push are typically unavailable.
+ */
+actual class ChannelAvailability actual constructor() {
+
+    actual fun available(): List<KClass<out EscalationChannel>> = emptyList()
+}

--- a/ampere-core/src/jvmMain/kotlin/link/socket/ampere/pause/ChannelAvailability.jvm.kt
+++ b/ampere-core/src/jvmMain/kotlin/link/socket/ampere/pause/ChannelAvailability.jvm.kt
@@ -1,0 +1,13 @@
+package link.socket.ampere.pause
+
+import kotlin.reflect.KClass
+
+/**
+ * JVM/desktop stub. Real implementation in W1.5 may surface system tray
+ * notifications and a desktop in-app card; voice and push are typically
+ * unavailable.
+ */
+actual class ChannelAvailability actual constructor() {
+
+    actual fun available(): List<KClass<out EscalationChannel>> = emptyList()
+}

--- a/ampere-core/src/wasmJsMain/kotlin/link/socket/ampere/pause/ChannelAvailability.wasmJs.kt
+++ b/ampere-core/src/wasmJsMain/kotlin/link/socket/ampere/pause/ChannelAvailability.wasmJs.kt
@@ -1,0 +1,12 @@
+package link.socket.ampere.pause
+
+import kotlin.reflect.KClass
+
+/**
+ * Wasm/JS stub. Real implementation in W1.5 may bridge the Notifications API
+ * and the in-app card; voice and native push are typically unavailable.
+ */
+actual class ChannelAvailability actual constructor() {
+
+    actual fun available(): List<KClass<out EscalationChannel>> = emptyList()
+}

--- a/docs/ampere/agent-pause.md
+++ b/docs/ampere/agent-pause.md
@@ -1,0 +1,114 @@
+# AgentPause
+
+`AgentPause` is Ampere's primitive for **paused-and-awaiting-human-input state**. It is the OS-native escalation contract that Plugin code (commonMain), the channel-selector (W1.5), and per-Arc override UI (W2.2) all build against.
+
+Where [`AgentSurface`](agent-surface.md) models a Plugin asking the platform to render a specific UI, `AgentPause` models the higher-level intent: *"this agent is stuck and needs a person."* The pause primitive carries channel preferences; the channel-selector consumes the preferences plus runtime availability and decides how to actually reach the user.
+
+## Design goals
+
+- **Typed and serializable.** Every variant is `@Serializable`; pauses can be persisted, replayed, and shipped over a wire.
+- **commonMain-only.** No iOS, Android, or Compose imports leak into the type definitions. Platform code lives behind `expect`/`actual`.
+- **Stable correlation.** Every pause and every response carries a `PauseCorrelationId` so awaiters can pair requests with responses.
+- **Public-link fallback supported.** Even though `EscalationChannel.PublicLink` is the lowest-priority channel, the type definitions support it as a first-class variant so a pause that escapes Ampere can still be expressed.
+
+## Type hierarchy
+
+| Type | Location | Purpose |
+| --- | --- | --- |
+| `AgentPause` | `link.socket.ampere.pause` | Data class describing a paused agent and its escalation preferences. |
+| `PauseUrgency` | `link.socket.ampere.pause` | Enum: `Routine`, `Important`, `Critical`. |
+| `EscalationChannel` | `link.socket.ampere.pause` | Sealed hierarchy: `Push`, `Voice`, `InAppCard`, `PublicLink`. |
+| `AgentPauseResponse` | `link.socket.ampere.pause` | Sealed reply: `Approved`, `Rejected`, `TimedOut`. |
+| `ChannelAvailability` | `link.socket.ampere.pause` | `expect class` querying which channels are available on this device. |
+| `PauseCorrelationId` | `link.socket.ampere.pause` | `typealias PauseCorrelationId = String`. |
+
+## Channel-fallback ordering
+
+`AgentPause.suggestedChannels` is an **ordered** list. The channel-selector (W1.5) walks it from first to last and uses the first channel that satisfies all of:
+
+1. The variant appears in `ChannelAvailability.available()` for the current device.
+2. The user's per-Arc override (W2.2) does not exclude it.
+3. Any platform-level permission gate (e.g., notification permission) is satisfied.
+
+If no channel in `suggestedChannels` is reachable, the selector falls through to `EscalationChannel.PublicLink(url = AgentPause.fallbackUrl)` if `fallbackUrl` is non-null. If `fallbackUrl` is null, the pause is treated as unrouteable and resolves as `AgentPauseResponse.TimedOut` once `timeoutMillis` elapses.
+
+The fallback ordering is deliberately *channel-priority-first, not urgency-first*. A `Routine` pause that lists `Voice` first will still attempt voice before the in-app card — urgency only sets defaults; the Plugin author always has the final say on ordering.
+
+## Urgency-to-default-channel mapping
+
+When a Plugin author does not provide explicit `suggestedChannels`, the channel-selector synthesises a default list from `urgency`. These defaults are intended for the channel-selector implementation in W1.5; the type system does not enforce them.
+
+| `PauseUrgency` | Default channel order |
+| --- | --- |
+| `Routine` | `InAppCard` → `Push` → `PublicLink` |
+| `Important` | `Push` → `InAppCard` → `PublicLink` |
+| `Critical` | `Voice` → `Push` → `InAppCard` → `PublicLink` |
+
+`PublicLink` always tail-anchors the default list when `AgentPause.fallbackUrl` is set. A pause without a `fallbackUrl` simply omits it.
+
+## Lifecycle
+
+```
+Plugin                       Channel selector (W1.5)               Renderer
+  |                                    |                                |
+  | emitPause(AgentPause)              |                                |
+  |----------------------------------->|                                |
+  |                                    | walk suggestedChannels         |
+  |                                    | check ChannelAvailability      |
+  |                                    | dispatch to platform renderer  |
+  |                                    |------------------------------->|
+  |                                    |                                | render channel
+  |                                    |                                | gather response
+  | awaitPauseResponse(correlationId)  |                                |
+  |==suspended=========================|                                |
+  |                                    | publish AgentPauseResponse     |
+  |                                    |<-------------------------------|
+  |<================ AgentPauseResponse                                 |
+```
+
+W0.3 ships only the type contract on the left and right of the diagram. The channel-selector logic in the middle, plus the bus-level events that connect the two, are tracked in W1.5 and W2.2.
+
+## Relationship to ConsentRepository
+
+`AgentPause` builds on the existing `ConsentRepository` and `ConsentAwarePromptService` rather than replacing them.
+
+- `ConsentRepository` continues to store *whether* a user has granted standing consent for a class of operation. The pause primitive does not duplicate this storage.
+- `ConsentAwarePromptService` continues to gate prompts against consent state. When that gate trips and a fresh decision is needed, the service should now emit an `AgentPause` instead of inlining its own escalation logic.
+- An `AgentPauseResponse.Approved` may be persisted as a one-shot consent grant; an `AgentPauseResponse.Rejected` may be persisted as a one-shot denial. The `payload` field on `Approved` is opaque to the pause primitive — Plugin code converts it into the consent record that `ConsentRepository` needs.
+
+This split keeps consent storage and escalation routing as separate concerns: the consent layer answers *"does the user already say yes?"*, the pause primitive answers *"how do we ask?"*.
+
+## Plugin example
+
+```kotlin
+val pause = AgentPause(
+    correlationId = "deploy-prod-${Clock.System.now().toEpochMilliseconds()}",
+    reason = "Approve production deploy of v0.5.0",
+    urgency = PauseUrgency.Critical,
+    suggestedChannels = listOf(
+        EscalationChannel.Voice(
+            prompt = "Approve the v0.5.0 production deploy?",
+            expectedResponseSeconds = 20,
+        ),
+        EscalationChannel.Push(
+            notificationCategory = "deploy",
+            title = "Approve production deploy",
+            body = "v0.5.0 is ready to ship.",
+            deeplink = "ampere://pause/deploy-prod",
+        ),
+        EscalationChannel.InAppCard(
+            cardKind = EscalationChannel.InAppCard.CardKind.Modal,
+            title = "Production deploy",
+            body = "Approve to ship v0.5.0.",
+        ),
+    ),
+    timeoutMillis = 5 * 60 * 1000L,
+    fallbackUrl = "https://ampere.example/pause/deploy-prod",
+)
+```
+
+## Versioning
+
+`AgentPause`, `EscalationChannel`, `AgentPauseResponse`, `PauseUrgency`, and `ChannelAvailability` are part of the public Ampere SDK. Adding a new `EscalationChannel` variant is a breaking change for renderers (their `when` becomes non-exhaustive at compile time), which is the intended forcing function: every renderer must explicitly opt in to a new channel before it ships.
+
+Adding optional fields with defaults to existing variants is source-compatible. Removing fields, or changing field types, is a breaking change.


### PR DESCRIPTION
## Summary

I added the `AgentPause` primitive type system in `commonMain` (W0.3 foundation): `AgentPause` data class with `PauseUrgency` (Routine/Important/Critical), the `EscalationChannel` sealed hierarchy (`Push`, `Voice`, `InAppCard`, `PublicLink`), `AgentPauseResponse` (`Approved`/`Rejected`/`TimedOut`), and an `expect class ChannelAvailability` with empty stub `actual`s on iOS, Android, JVM, JS, and Wasm. I covered the contract with round-trip serialization, ordering, and exhaustiveness tests, and documented the channel-fallback ordering, urgency-to-default-channel mapping, and the relationship to `ConsentRepository` in `docs/ampere/agent-pause.md`. This unblocks W1.5 (channel-selector) and W2.2 (per-Arc override UI) by giving them a stable API to import against.

Closes #460

## Test plan

- [x] `./gradlew :ampere-core:ktlintFormat`
- [x] `./gradlew :ampere-core:jvmTest` (11 new tests pass; no regressions)
- [x] iOS arm64/x64/simulatorArm64 compile cleanly
- [x] JS and wasmJs compile cleanly
- [x] Common metadata compile validates `expect`/`actual` matches across all targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)