### PR TITLE
AMPR-153 #462: add on-device knowledge embeddings schema

### DIFF
--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/knowledge/EmbeddingVector.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/knowledge/EmbeddingVector.kt
@@ -1,0 +1,120 @@
+package link.socket.ampere.knowledge
+
+import kotlin.math.sqrt
+
+/**
+ * A dense vector representation of a document chunk produced by an embedding model.
+ *
+ * Provides similarity primitives ([cosineSimilarity], [dotProduct]) used by the
+ * on-device knowledge retrieval pipeline, plus a stable byte serialization
+ * ([toBlob] / [fromBlob]) for SQLDelight BLOB persistence.
+ *
+ * Values use structural equality based on the underlying [FloatArray] contents.
+ */
+class EmbeddingVector(
+    val values: FloatArray,
+) {
+    init {
+        require(values.isNotEmpty()) { "EmbeddingVector must have at least one dimension" }
+    }
+
+    /** Number of dimensions in the vector. */
+    val dimension: Int get() = values.size
+
+    /**
+     * Sum of element-wise products with [other].
+     *
+     * @throws IllegalArgumentException if [dimension] does not match.
+     */
+    fun dotProduct(other: EmbeddingVector): Float {
+        require(dimension == other.dimension) {
+            "Dimension mismatch: $dimension vs ${other.dimension}"
+        }
+        var sum = 0f
+        val a = values
+        val b = other.values
+        for (i in a.indices) {
+            sum += a[i] * b[i]
+        }
+        return sum
+    }
+
+    /**
+     * Cosine similarity in `[-1, 1]`. Returns `0` when either vector has zero magnitude.
+     *
+     * @throws IllegalArgumentException if [dimension] does not match.
+     */
+    fun cosineSimilarity(other: EmbeddingVector): Float {
+        require(dimension == other.dimension) {
+            "Dimension mismatch: $dimension vs ${other.dimension}"
+        }
+        var dot = 0f
+        var magA = 0f
+        var magB = 0f
+        val a = values
+        val b = other.values
+        for (i in a.indices) {
+            val x = a[i]
+            val y = b[i]
+            dot += x * y
+            magA += x * x
+            magB += y * y
+        }
+        val denominator = sqrt(magA) * sqrt(magB)
+        return if (denominator == 0f) 0f else dot / denominator
+    }
+
+    /**
+     * Serialize to a fixed-size big-endian byte array (`dimension * 4` bytes) for BLOB storage.
+     *
+     * Format: each [Float] is encoded via [Float.toRawBits] in big-endian order so the
+     * payload is portable across all Kotlin Multiplatform targets.
+     */
+    fun toBlob(): ByteArray {
+        val bytes = ByteArray(values.size * BYTES_PER_FLOAT)
+        for (i in values.indices) {
+            val bits = values[i].toRawBits()
+            val offset = i * BYTES_PER_FLOAT
+            bytes[offset] = (bits ushr 24).toByte()
+            bytes[offset + 1] = (bits ushr 16).toByte()
+            bytes[offset + 2] = (bits ushr 8).toByte()
+            bytes[offset + 3] = bits.toByte()
+        }
+        return bytes
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is EmbeddingVector) return false
+        return values.contentEquals(other.values)
+    }
+
+    override fun hashCode(): Int = values.contentHashCode()
+
+    override fun toString(): String = "EmbeddingVector(dimension=$dimension)"
+
+    companion object {
+        private const val BYTES_PER_FLOAT = 4
+
+        /**
+         * Decode a vector previously written by [toBlob].
+         *
+         * @throws IllegalArgumentException if [bytes] length is not a positive multiple of 4.
+         */
+        fun fromBlob(bytes: ByteArray): EmbeddingVector {
+            require(bytes.isNotEmpty() && bytes.size % BYTES_PER_FLOAT == 0) {
+                "Embedding blob must be a positive multiple of $BYTES_PER_FLOAT bytes, got ${bytes.size}"
+            }
+            val floats = FloatArray(bytes.size / BYTES_PER_FLOAT)
+            for (i in floats.indices) {
+                val offset = i * BYTES_PER_FLOAT
+                val bits = (bytes[offset].toInt() and 0xff shl 24) or
+                    (bytes[offset + 1].toInt() and 0xff shl 16) or
+                    (bytes[offset + 2].toInt() and 0xff shl 8) or
+                    (bytes[offset + 3].toInt() and 0xff)
+                floats[i] = Float.fromBits(bits)
+            }
+            return EmbeddingVector(floats)
+        }
+    }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/knowledge/KnowledgeStore.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/knowledge/KnowledgeStore.kt
@@ -1,0 +1,113 @@
+package link.socket.ampere.knowledge
+
+import kotlinx.datetime.Instant
+
+/**
+ * On-device knowledge primitive: stores documents, chunks them, embeds the chunks,
+ * and answers retrieval queries over the local index.
+ *
+ * Implementations are platform-specific (W1.8 iOS, W1.9 Android) — this commonMain
+ * surface is the contract those pipelines target.
+ *
+ * All work runs on-device. No cloud embedding APIs are invoked from this layer.
+ */
+interface KnowledgeStore {
+
+    /**
+     * Persist a new document or update an existing one keyed by content hash.
+     *
+     * Implementations should be idempotent: importing a document whose
+     * [KnowledgeDocument.contentHash] already exists must not create duplicate
+     * chunks or embeddings.
+     */
+    suspend fun addDocument(document: KnowledgeDocument): Result<KnowledgeDocument>
+
+    /**
+     * Split [documentId]'s content into chunks and produce embeddings for each chunk
+     * using the on-device embedding model identified by [modelId].
+     *
+     * @param documentId Document previously persisted via [addDocument].
+     * @param modelId Identifier of the embedding model (e.g. `"all-MiniLM-L6-v2"`).
+     * @return The chunks that were embedded, in order.
+     */
+    suspend fun chunkAndEmbed(
+        documentId: String,
+        modelId: String,
+    ): Result<List<KnowledgeChunk>>
+
+    /**
+     * Retrieve chunks relevant to [text] using the supplied [mode].
+     *
+     * @param text Free-form query.
+     * @param limit Maximum number of results to return.
+     * @param mode Retrieval strategy. Defaults to [QueryMode.HYBRID].
+     */
+    suspend fun query(
+        text: String,
+        limit: Int = DEFAULT_QUERY_LIMIT,
+        mode: QueryMode = QueryMode.HYBRID,
+    ): Result<List<KnowledgeQueryResult>>
+
+    companion object {
+        const val DEFAULT_QUERY_LIMIT: Int = 10
+    }
+}
+
+/**
+ * Strategy for resolving a [KnowledgeStore.query] call.
+ */
+enum class QueryMode {
+    /** Cosine-similarity search over [EmbeddingVector]s. */
+    SEMANTIC,
+
+    /** FTS5 keyword search over chunk text. */
+    KEYWORD,
+
+    /** Combine [SEMANTIC] and [KEYWORD] results, blending scores. */
+    HYBRID,
+}
+
+/**
+ * A document imported into the on-device knowledge store.
+ *
+ * @param id Stable identifier.
+ * @param title Human-readable title.
+ * @param sourceUri Optional pointer to the original source (file path, URL, etc.).
+ * @param importedAt When the document was imported.
+ * @param contentHash Hash of the source content; used for idempotent re-import.
+ * @param content Raw textual content. May be empty if the implementation lazily
+ *        loads content from [sourceUri].
+ */
+data class KnowledgeDocument(
+    val id: String,
+    val title: String,
+    val sourceUri: String?,
+    val importedAt: Instant,
+    val contentHash: String,
+    val content: String = "",
+)
+
+/**
+ * A chunk of a [KnowledgeDocument]'s text — the unit at which embeddings are produced
+ * and retrieval results are returned.
+ */
+data class KnowledgeChunk(
+    val id: String,
+    val documentId: String,
+    val chunkIndex: Int,
+    val text: String,
+    val charStart: Int,
+    val charEnd: Int,
+)
+
+/**
+ * A single retrieval hit returned by [KnowledgeStore.query].
+ *
+ * @param chunk The matching chunk.
+ * @param score Mode-dependent score (cosine similarity, FTS rank, or hybrid blend).
+ *        Higher scores indicate better matches.
+ */
+data class KnowledgeQueryResult(
+    val chunk: KnowledgeChunk,
+    val score: Float,
+)

--- a/ampere-core/src/commonMain/sqldelight/link/socket/ampere/db/Knowledge.sq
+++ b/ampere-core/src/commonMain/sqldelight/link/socket/ampere/db/Knowledge.sq
@@ -1,0 +1,145 @@
+-- On-device knowledge schema: documents, chunks, and embedding vectors.
+-- Vectors are stored as raw BLOBs serialized via EmbeddingVector.toBlob().
+-- Platform retrieval pipelines (W1.8 iOS, W1.9 Android) target this surface.
+
+CREATE TABLE IF NOT EXISTS knowledge_documents (
+    id TEXT PRIMARY KEY NOT NULL,
+    title TEXT NOT NULL,
+    source_uri TEXT,
+    imported_at INTEGER NOT NULL,
+    content_hash TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_knowledge_documents_imported_at
+    ON knowledge_documents(imported_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_knowledge_documents_content_hash
+    ON knowledge_documents(content_hash);
+
+CREATE TABLE IF NOT EXISTS knowledge_chunks (
+    id TEXT PRIMARY KEY NOT NULL,
+    document_id TEXT NOT NULL,
+    chunk_index INTEGER NOT NULL,
+    text TEXT NOT NULL,
+    char_start INTEGER NOT NULL,
+    char_end INTEGER NOT NULL,
+    FOREIGN KEY (document_id) REFERENCES knowledge_documents(id) ON DELETE CASCADE,
+    UNIQUE (document_id, chunk_index)
+);
+
+CREATE INDEX IF NOT EXISTS idx_knowledge_chunks_document_id
+    ON knowledge_chunks(document_id);
+
+CREATE TABLE IF NOT EXISTS knowledge_embeddings (
+    chunk_id TEXT NOT NULL,
+    model_id TEXT NOT NULL,
+    vector_blob BLOB NOT NULL,
+    created_at INTEGER NOT NULL,
+    PRIMARY KEY (chunk_id, model_id),
+    FOREIGN KEY (chunk_id) REFERENCES knowledge_chunks(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_knowledge_embeddings_model_id
+    ON knowledge_embeddings(model_id);
+
+-- =============================================================================
+-- DOCUMENT QUERIES
+-- =============================================================================
+
+insertDocument:
+INSERT INTO knowledge_documents(id, title, source_uri, imported_at, content_hash)
+VALUES (?, ?, ?, ?, ?);
+
+upsertDocument:
+INSERT OR REPLACE INTO knowledge_documents(id, title, source_uri, imported_at, content_hash)
+VALUES (?, ?, ?, ?, ?);
+
+getDocumentById:
+SELECT * FROM knowledge_documents WHERE id = ?;
+
+getDocumentByContentHash:
+SELECT * FROM knowledge_documents WHERE content_hash = ? LIMIT 1;
+
+listDocuments:
+SELECT * FROM knowledge_documents
+ORDER BY imported_at DESC
+LIMIT :limit;
+
+deleteDocument:
+DELETE FROM knowledge_documents WHERE id = ?;
+
+countDocuments:
+SELECT COUNT(*) FROM knowledge_documents;
+
+-- =============================================================================
+-- CHUNK QUERIES
+-- =============================================================================
+
+insertChunk:
+INSERT INTO knowledge_chunks(id, document_id, chunk_index, text, char_start, char_end)
+VALUES (?, ?, ?, ?, ?, ?);
+
+updateChunkText:
+UPDATE knowledge_chunks
+SET text = ?, char_start = ?, char_end = ?
+WHERE id = ?;
+
+getChunkById:
+SELECT * FROM knowledge_chunks WHERE id = ?;
+
+getChunksByDocument:
+SELECT * FROM knowledge_chunks
+WHERE document_id = ?
+ORDER BY chunk_index ASC;
+
+deleteChunksForDocument:
+DELETE FROM knowledge_chunks WHERE document_id = ?;
+
+countChunks:
+SELECT COUNT(*) FROM knowledge_chunks;
+
+-- =============================================================================
+-- EMBEDDING QUERIES
+-- =============================================================================
+
+insertEmbedding:
+INSERT INTO knowledge_embeddings(chunk_id, model_id, vector_blob, created_at)
+VALUES (?, ?, ?, ?);
+
+upsertEmbedding:
+INSERT OR REPLACE INTO knowledge_embeddings(chunk_id, model_id, vector_blob, created_at)
+VALUES (?, ?, ?, ?);
+
+getEmbedding:
+SELECT * FROM knowledge_embeddings
+WHERE chunk_id = ? AND model_id = ?;
+
+getEmbeddingsForModel:
+SELECT * FROM knowledge_embeddings
+WHERE model_id = ?;
+
+-- Joined view: every chunk with its embedding for a specific model.
+-- Platform similarity scoring iterates this set in memory.
+getChunkEmbeddingsForModel:
+SELECT
+    c.id AS chunk_id,
+    c.document_id AS document_id,
+    c.chunk_index AS chunk_index,
+    c.text AS text,
+    c.char_start AS char_start,
+    c.char_end AS char_end,
+    e.model_id AS model_id,
+    e.vector_blob AS vector_blob,
+    e.created_at AS created_at
+FROM knowledge_chunks c
+INNER JOIN knowledge_embeddings e ON c.id = e.chunk_id
+WHERE e.model_id = ?;
+
+deleteEmbeddingsForChunk:
+DELETE FROM knowledge_embeddings WHERE chunk_id = ?;
+
+deleteEmbeddingsForModel:
+DELETE FROM knowledge_embeddings WHERE model_id = ?;
+
+countEmbeddings:
+SELECT COUNT(*) FROM knowledge_embeddings;

--- a/ampere-core/src/commonMain/sqldelight/link/socket/ampere/db/KnowledgeFTS.sq
+++ b/ampere-core/src/commonMain/sqldelight/link/socket/ampere/db/KnowledgeFTS.sq
@@ -1,0 +1,55 @@
+-- FTS5 virtual table over knowledge_chunks.text for keyword fallback retrieval.
+-- Triggers keep the index in sync with knowledge_chunks insert/update/delete.
+
+-- FTS5 column names must match the content table (knowledge_chunks).
+-- The `id` column is UNINDEXED so it isn't tokenized, only stored.
+CREATE VIRTUAL TABLE IF NOT EXISTS knowledge_chunks_fts USING fts5(
+    id UNINDEXED,
+    text,
+    content=knowledge_chunks,
+    content_rowid=rowid
+);
+
+-- For external-content FTS5 tables, deletes use the 'delete' command form
+-- (https://sqlite.org/fts5.html#the_delete_command). A plain DELETE FROM fts
+-- WHERE rowid = old.rowid would re-read the content table and remove the wrong
+-- tokens for AFTER UPDATE triggers because the content row has already changed.
+CREATE TRIGGER IF NOT EXISTS knowledge_chunks_fts_insert
+AFTER INSERT ON knowledge_chunks BEGIN
+    INSERT INTO knowledge_chunks_fts(rowid, id, text)
+    VALUES (new.rowid, new.id, new.text);
+END;
+
+CREATE TRIGGER IF NOT EXISTS knowledge_chunks_fts_delete
+AFTER DELETE ON knowledge_chunks BEGIN
+    INSERT INTO knowledge_chunks_fts(knowledge_chunks_fts, rowid, id, text)
+    VALUES ('delete', old.rowid, old.id, old.text);
+END;
+
+CREATE TRIGGER IF NOT EXISTS knowledge_chunks_fts_update
+AFTER UPDATE ON knowledge_chunks BEGIN
+    INSERT INTO knowledge_chunks_fts(knowledge_chunks_fts, rowid, id, text)
+    VALUES ('delete', old.rowid, old.id, old.text);
+    INSERT INTO knowledge_chunks_fts(rowid, id, text)
+    VALUES (new.rowid, new.id, new.text);
+END;
+
+-- =============================================================================
+-- FTS QUERIES
+-- =============================================================================
+
+-- FTS5 keyword match against chunk text. Returns chunks ranked by FTS relevance.
+searchChunksByText:
+SELECT c.*
+FROM knowledge_chunks c
+INNER JOIN knowledge_chunks_fts fts ON c.rowid = fts.rowid
+WHERE knowledge_chunks_fts MATCH :query
+ORDER BY fts.rank
+LIMIT :limit;
+
+-- LIKE-based fallback for environments where FTS5 querying is unavailable
+-- or for very short query strings that don't tokenize well.
+searchChunksByTextLike:
+SELECT * FROM knowledge_chunks
+WHERE text LIKE '%' || :substring || '%'
+LIMIT :limit;

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/knowledge/EmbeddingVectorTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/knowledge/EmbeddingVectorTest.kt
@@ -1,0 +1,147 @@
+package link.socket.ampere.knowledge
+
+import kotlin.math.abs
+import kotlin.math.sqrt
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class EmbeddingVectorTest {
+
+    @Test
+    fun `dimension reflects underlying float array size`() {
+        val vector = EmbeddingVector(floatArrayOf(0.1f, 0.2f, 0.3f, 0.4f))
+        assertEquals(4, vector.dimension)
+    }
+
+    @Test
+    fun `cosine similarity of identical unit vectors is 1`() {
+        val a = EmbeddingVector(floatArrayOf(1f, 0f, 0f))
+        val b = EmbeddingVector(floatArrayOf(1f, 0f, 0f))
+        assertApproximatelyEqual(1f, a.cosineSimilarity(b))
+    }
+
+    @Test
+    fun `cosine similarity of orthogonal vectors is 0`() {
+        val a = EmbeddingVector(floatArrayOf(1f, 0f))
+        val b = EmbeddingVector(floatArrayOf(0f, 1f))
+        assertApproximatelyEqual(0f, a.cosineSimilarity(b))
+    }
+
+    @Test
+    fun `cosine similarity of opposite vectors is -1`() {
+        val a = EmbeddingVector(floatArrayOf(1f, 2f, 3f))
+        val b = EmbeddingVector(floatArrayOf(-1f, -2f, -3f))
+        assertApproximatelyEqual(-1f, a.cosineSimilarity(b))
+    }
+
+    @Test
+    fun `cosine similarity matches reference value for known vectors`() {
+        // a · b = 1*4 + 2*5 + 3*6 = 32
+        // |a| = sqrt(14), |b| = sqrt(77)
+        // cos = 32 / (sqrt(14) * sqrt(77))
+        val a = EmbeddingVector(floatArrayOf(1f, 2f, 3f))
+        val b = EmbeddingVector(floatArrayOf(4f, 5f, 6f))
+        val expected = 32f / (sqrt(14f) * sqrt(77f))
+        assertApproximatelyEqual(expected, a.cosineSimilarity(b))
+    }
+
+    @Test
+    fun `cosine similarity returns 0 when either vector is all zeros`() {
+        val zero = EmbeddingVector(floatArrayOf(0f, 0f, 0f))
+        val nonZero = EmbeddingVector(floatArrayOf(1f, 2f, 3f))
+        assertEquals(0f, zero.cosineSimilarity(nonZero))
+        assertEquals(0f, nonZero.cosineSimilarity(zero))
+    }
+
+    @Test
+    fun `cosine similarity throws when dimensions differ`() {
+        val a = EmbeddingVector(floatArrayOf(1f, 2f))
+        val b = EmbeddingVector(floatArrayOf(1f, 2f, 3f))
+        assertFailsWith<IllegalArgumentException> { a.cosineSimilarity(b) }
+    }
+
+    @Test
+    fun `dot product matches reference value`() {
+        val a = EmbeddingVector(floatArrayOf(1f, 2f, 3f))
+        val b = EmbeddingVector(floatArrayOf(4f, -5f, 6f))
+        // 1*4 + 2*(-5) + 3*6 = 4 - 10 + 18 = 12
+        assertApproximatelyEqual(12f, a.dotProduct(b))
+    }
+
+    @Test
+    fun `dot product throws when dimensions differ`() {
+        val a = EmbeddingVector(floatArrayOf(1f, 2f))
+        val b = EmbeddingVector(floatArrayOf(1f, 2f, 3f))
+        assertFailsWith<IllegalArgumentException> { a.dotProduct(b) }
+    }
+
+    @Test
+    fun `empty vector is rejected`() {
+        assertFailsWith<IllegalArgumentException> { EmbeddingVector(floatArrayOf()) }
+    }
+
+    @Test
+    fun `toBlob round-trips via fromBlob`() {
+        val original = EmbeddingVector(
+            floatArrayOf(0f, -1.5f, 3.14159f, Float.MIN_VALUE, Float.MAX_VALUE, 42f),
+        )
+        val blob = original.toBlob()
+        val restored = EmbeddingVector.fromBlob(blob)
+        assertEquals(original, restored)
+        assertEquals(original.dimension * 4, blob.size)
+    }
+
+    @Test
+    fun `fromBlob rejects malformed input`() {
+        assertFailsWith<IllegalArgumentException> { EmbeddingVector.fromBlob(ByteArray(0)) }
+        assertFailsWith<IllegalArgumentException> { EmbeddingVector.fromBlob(ByteArray(3)) }
+        assertFailsWith<IllegalArgumentException> { EmbeddingVector.fromBlob(ByteArray(7)) }
+    }
+
+    @Test
+    fun `equality is structural and based on contents`() {
+        val a = EmbeddingVector(floatArrayOf(1f, 2f, 3f))
+        val b = EmbeddingVector(floatArrayOf(1f, 2f, 3f))
+        val c = EmbeddingVector(floatArrayOf(1f, 2f, 4f))
+        assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
+        assertNotEquals(a, c)
+    }
+
+    @Test
+    fun `cosine similarity on 1000-element vector completes quickly`() {
+        val a = EmbeddingVector(FloatArray(1000) { i -> (i + 1).toFloat() / 1000f })
+        val b = EmbeddingVector(FloatArray(1000) { i -> (1000 - i).toFloat() / 1000f })
+
+        // Warm up to allow the JIT (or Kotlin/Native loop optimizer) to settle.
+        repeat(WARMUP_ITERATIONS) { a.cosineSimilarity(b) }
+
+        val mark = kotlin.time.TimeSource.Monotonic.markNow()
+        repeat(MEASURED_ITERATIONS) { a.cosineSimilarity(b) }
+        val elapsed = mark.elapsedNow()
+        val perCallMicros = elapsed.inWholeMicroseconds.toDouble() / MEASURED_ITERATIONS
+
+        assertTrue(
+            perCallMicros < PER_CALL_BUDGET_MICROS,
+            "Cosine similarity took ${perCallMicros}us per call (budget ${PER_CALL_BUDGET_MICROS}us)",
+        )
+    }
+
+    private fun assertApproximatelyEqual(expected: Float, actual: Float, epsilon: Float = 1e-5f) {
+        assertTrue(
+            abs(expected - actual) < epsilon,
+            "Expected $expected, got $actual (epsilon=$epsilon)",
+        )
+    }
+
+    companion object {
+        private const val WARMUP_ITERATIONS = 1_000
+        private const val MEASURED_ITERATIONS = 1_000
+
+        // Ticket budget is 1ms (1000us) per call. Headroom for slow CI hosts.
+        private const val PER_CALL_BUDGET_MICROS = 1_000.0
+    }
+}

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/knowledge/KnowledgeFTSTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/knowledge/KnowledgeFTSTest.kt
@@ -1,0 +1,103 @@
+package link.socket.ampere.knowledge
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import link.socket.ampere.db.Database
+
+class KnowledgeFTSTest {
+
+    private lateinit var driver: JdbcSqliteDriver
+    private lateinit var database: Database
+
+    @BeforeTest
+    fun setUp() {
+        driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        Database.Schema.create(driver)
+        database = Database(driver)
+        database.knowledgeQueries.insertDocument(
+            id = "doc-1",
+            title = "Manual",
+            source_uri = null,
+            imported_at = 1_000L,
+            content_hash = "hash-1",
+        )
+    }
+
+    @AfterTest
+    fun tearDown() {
+        driver.close()
+    }
+
+    @Test
+    fun `FTS query returns chunks matching keyword after insert`() {
+        insertChunk("chunk-1", 0, "Lighthouses guide ships safely along the rocky coast.")
+        insertChunk("chunk-2", 1, "Modern beacons replaced manual lamp keepers.")
+
+        val matches = database.knowledgeFTSQueries
+            .searchChunksByText("lighthouses", limit = 5)
+            .executeAsList()
+
+        assertEquals(listOf("chunk-1"), matches.map { it.id })
+    }
+
+    @Test
+    fun `FTS index reflects updates to chunk text`() {
+        insertChunk("chunk-1", 0, "First version mentions docking.")
+
+        database.knowledgeQueries.updateChunkText(
+            text = "Second version mentions sailing.",
+            char_start = 0,
+            char_end = 32,
+            id = "chunk-1",
+        )
+
+        val sailing = database.knowledgeFTSQueries
+            .searchChunksByText("sailing", limit = 5)
+            .executeAsList()
+        assertEquals(listOf("chunk-1"), sailing.map { it.id })
+
+        val docking = database.knowledgeFTSQueries
+            .searchChunksByText("docking", limit = 5)
+            .executeAsList()
+        assertTrue(docking.isEmpty())
+    }
+
+    @Test
+    fun `FTS index removes entries when chunks are deleted`() {
+        insertChunk("chunk-1", 0, "Schooners crossed the harbor at dawn.")
+        insertChunk("chunk-2", 1, "Ferries kept the schedule despite fog.")
+
+        database.knowledgeQueries.deleteChunksForDocument("doc-1")
+
+        val matches = database.knowledgeFTSQueries
+            .searchChunksByText("schooners", limit = 5)
+            .executeAsList()
+        assertTrue(matches.isEmpty())
+    }
+
+    @Test
+    fun `LIKE fallback returns chunks containing substring`() {
+        insertChunk("chunk-1", 0, "Tide tables are critical for navigation.")
+        insertChunk("chunk-2", 1, "Currents shift seasonally.")
+
+        val matches = database.knowledgeFTSQueries
+            .searchChunksByTextLike("Tide", limit = 5)
+            .executeAsList()
+        assertEquals(listOf("chunk-1"), matches.map { it.id })
+    }
+
+    private fun insertChunk(id: String, index: Int, text: String) {
+        database.knowledgeQueries.insertChunk(
+            id = id,
+            document_id = "doc-1",
+            chunk_index = index.toLong(),
+            text = text,
+            char_start = 0,
+            char_end = text.length.toLong(),
+        )
+    }
+}

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/knowledge/KnowledgeSchemaTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/knowledge/KnowledgeSchemaTest.kt
@@ -1,0 +1,214 @@
+package link.socket.ampere.knowledge
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import link.socket.ampere.db.Database
+
+class KnowledgeSchemaTest {
+
+    private lateinit var driver: JdbcSqliteDriver
+    private lateinit var database: Database
+
+    @BeforeTest
+    fun setUp() {
+        driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        Database.Schema.create(driver)
+        database = Database(driver)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        driver.close()
+    }
+
+    @Test
+    fun `documents support insert lookup and listing`() {
+        database.knowledgeQueries.insertDocument(
+            id = "doc-1",
+            title = "Lighthouse manual",
+            source_uri = "file:///docs/lighthouse.txt",
+            imported_at = 1_000L,
+            content_hash = "hash-1",
+        )
+        database.knowledgeQueries.insertDocument(
+            id = "doc-2",
+            title = "Pier inventory",
+            source_uri = null,
+            imported_at = 2_000L,
+            content_hash = "hash-2",
+        )
+
+        val byId = database.knowledgeQueries.getDocumentById("doc-1").executeAsOne()
+        assertEquals("Lighthouse manual", byId.title)
+        assertEquals("file:///docs/lighthouse.txt", byId.source_uri)
+        assertEquals("hash-1", byId.content_hash)
+
+        val byHash = database.knowledgeQueries.getDocumentByContentHash("hash-2").executeAsOne()
+        assertEquals("doc-2", byHash.id)
+
+        val newest = database.knowledgeQueries.listDocuments(limit = 10).executeAsList()
+        assertEquals(listOf("doc-2", "doc-1"), newest.map { it.id })
+
+        assertEquals(2L, database.knowledgeQueries.countDocuments().executeAsOne())
+    }
+
+    @Test
+    fun `chunks list and bulk-delete by document`() {
+        seedDocument("doc-1")
+        database.knowledgeQueries.insertChunk(
+            id = "chunk-1",
+            document_id = "doc-1",
+            chunk_index = 0,
+            text = "Lighthouses warn ships of dangerous coastlines.",
+            char_start = 0,
+            char_end = 47,
+        )
+        database.knowledgeQueries.insertChunk(
+            id = "chunk-2",
+            document_id = "doc-1",
+            chunk_index = 1,
+            text = "Modern lighthouses are usually automated.",
+            char_start = 48,
+            char_end = 90,
+        )
+
+        val chunks = database.knowledgeQueries.getChunksByDocument("doc-1").executeAsList()
+        assertEquals(listOf(0L, 1L), chunks.map { it.chunk_index })
+
+        database.knowledgeQueries.deleteChunksForDocument("doc-1")
+
+        assertEquals(
+            0,
+            database.knowledgeQueries.getChunksByDocument("doc-1").executeAsList().size,
+        )
+    }
+
+    @Test
+    fun `embeddings round-trip blob payload preserving float values`() {
+        seedDocument("doc-1")
+        database.knowledgeQueries.insertChunk(
+            id = "chunk-1",
+            document_id = "doc-1",
+            chunk_index = 0,
+            text = "An ocean wave hides a sandbar.",
+            char_start = 0,
+            char_end = 30,
+        )
+
+        val original = EmbeddingVector(floatArrayOf(0.25f, -0.5f, 0.75f, 1.125f))
+        database.knowledgeQueries.insertEmbedding(
+            chunk_id = "chunk-1",
+            model_id = "all-MiniLM-L6-v2",
+            vector_blob = original.toBlob(),
+            created_at = 5_000L,
+        )
+
+        val row = database.knowledgeQueries
+            .getEmbedding("chunk-1", "all-MiniLM-L6-v2")
+            .executeAsOne()
+
+        val restored = EmbeddingVector.fromBlob(row.vector_blob)
+        assertEquals(original, restored)
+        assertContentEquals(original.values, restored.values)
+        assertEquals(5_000L, row.created_at)
+    }
+
+    @Test
+    fun `getChunkEmbeddingsForModel joins chunks with their vectors`() {
+        seedDocument("doc-1")
+        listOf(
+            Triple("chunk-1", 0, "First chunk"),
+            Triple("chunk-2", 1, "Second chunk"),
+        ).forEach { (id, index, text) ->
+            database.knowledgeQueries.insertChunk(
+                id = id,
+                document_id = "doc-1",
+                chunk_index = index.toLong(),
+                text = text,
+                char_start = 0,
+                char_end = text.length.toLong(),
+            )
+            database.knowledgeQueries.insertEmbedding(
+                chunk_id = id,
+                model_id = "model-A",
+                vector_blob = EmbeddingVector(floatArrayOf(index.toFloat(), 0f)).toBlob(),
+                created_at = 1_000L + index,
+            )
+        }
+
+        val joined = database.knowledgeQueries
+            .getChunkEmbeddingsForModel("model-A")
+            .executeAsList()
+        assertEquals(2, joined.size)
+        assertEquals(setOf("chunk-1", "chunk-2"), joined.map { it.chunk_id }.toSet())
+        joined.forEach { row ->
+            val vector = EmbeddingVector.fromBlob(row.vector_blob)
+            assertEquals(2, vector.dimension)
+        }
+
+        val missing = database.knowledgeQueries
+            .getChunkEmbeddingsForModel("missing-model")
+            .executeAsList()
+        assertTrue(missing.isEmpty())
+    }
+
+    @Test
+    fun `upsertEmbedding replaces existing row`() {
+        seedDocument("doc-1")
+        database.knowledgeQueries.insertChunk(
+            id = "chunk-1",
+            document_id = "doc-1",
+            chunk_index = 0,
+            text = "Original text.",
+            char_start = 0,
+            char_end = 14,
+        )
+
+        val first = EmbeddingVector(floatArrayOf(1f, 0f))
+        database.knowledgeQueries.upsertEmbedding(
+            chunk_id = "chunk-1",
+            model_id = "model-A",
+            vector_blob = first.toBlob(),
+            created_at = 1_000L,
+        )
+
+        val second = EmbeddingVector(floatArrayOf(0f, 1f))
+        database.knowledgeQueries.upsertEmbedding(
+            chunk_id = "chunk-1",
+            model_id = "model-A",
+            vector_blob = second.toBlob(),
+            created_at = 2_000L,
+        )
+
+        val row = assertNotNull(
+            database.knowledgeQueries.getEmbedding("chunk-1", "model-A").executeAsOneOrNull(),
+        )
+        assertEquals(second, EmbeddingVector.fromBlob(row.vector_blob))
+        assertEquals(2_000L, row.created_at)
+        assertEquals(1L, database.knowledgeQueries.countEmbeddings().executeAsOne())
+    }
+
+    @Test
+    fun `deleting a document removes the row`() {
+        seedDocument("doc-1")
+        database.knowledgeQueries.deleteDocument("doc-1")
+        assertNull(database.knowledgeQueries.getDocumentById("doc-1").executeAsOneOrNull())
+    }
+
+    private fun seedDocument(id: String) {
+        database.knowledgeQueries.insertDocument(
+            id = id,
+            title = "Doc $id",
+            source_uri = null,
+            imported_at = 1_000L,
+            content_hash = "hash-$id",
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Lands the W0.5 on-device knowledge foundation: SQLDelight tables for `knowledge_documents`, `knowledge_chunks`, and `knowledge_embeddings` (vector stored as BLOB), plus a `knowledge_chunks_fts` FTS5 virtual table for keyword fallback with triggers using the FTS5 `'delete'` command for correct external-content sync on UPDATE.
- Adds the pure-Kotlin `EmbeddingVector` value type (cosine similarity, dot product, big-endian `toBlob`/`fromBlob`) and the `commonMain` `KnowledgeStore` interface that platform pipelines (W1.8 iOS, W1.9 Android) will implement.
- Tests cover `EmbeddingVector` correctness against reference values, a 1000-element cosine perf budget under 1ms, end-to-end CRUD over the new schema, and FTS insert/update/delete propagation.

Closes #462

## Test plan
- [x] `./gradlew :ampere-core:ktlintFormat`
- [x] `./gradlew :ampere-core:jvmTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)