### PR TITLE
AMPR-155 #464: add plugin MCP client manifest extension

### DIFF
--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/mcp/McpClient.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/mcp/McpClient.kt
@@ -1,0 +1,100 @@
+package link.socket.ampere.mcp
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.json.JsonElement
+import link.socket.ampere.agents.tools.mcp.McpProtocol
+import link.socket.ampere.agents.tools.mcp.McpServerConfiguration
+import link.socket.ampere.agents.tools.mcp.connection.HttpClientHandler
+import link.socket.ampere.agents.tools.mcp.connection.HttpMcpConnection
+import link.socket.ampere.agents.tools.mcp.connection.McpServerConnection
+import link.socket.ampere.agents.tools.mcp.protocol.McpToolDescriptor
+import link.socket.ampere.agents.tools.mcp.protocol.ToolCallResult
+import link.socket.ampere.plugin.McpServerDependency
+
+/**
+ * Plugin-facing facade over an MCP server connection.
+ *
+ * Wraps an [McpServerConnection] (default [HttpMcpConnection]) with the
+ * dependency declaration plus credential resolution, so plugin call sites
+ * stay free of transport details. JSON-RPC framing remains in
+ * [link.socket.ampere.agents.tools.mcp.protocol.McpClient]; this class
+ * doesn't reimplement it.
+ *
+ * The [connectionFactory] seam exists so tests can substitute mock
+ * connections without touching the production HTTP path.
+ *
+ * Lifecycle:
+ * 1. [connect] — resolve credential, build the connection, run handshake.
+ * 2. [listTools] — query tool descriptors from the server.
+ * 3. [callTool] — invoke a remote tool.
+ * 4. [close] — disconnect and release transport resources.
+ */
+class McpClient(
+    private val dependency: McpServerDependency,
+    private val credentialBinding: McpCredentialBinding,
+    private val linkId: LinkId,
+    private val connectionFactory: (McpServerDependency, McpCredential?) -> McpServerConnection =
+        ::defaultHttpConnection,
+) {
+    private val mutex = Mutex()
+    private var connection: McpServerConnection? = null
+
+    val isConnected: Boolean
+        get() = connection?.isConnected == true
+
+    suspend fun connect(): Result<Unit> = mutex.withLock {
+        val existing = connection
+        if (existing != null && existing.isConnected) {
+            return Result.success(Unit)
+        }
+
+        val credentialResult = credentialBinding.resolve(linkId, dependency.uri)
+        val credential = credentialResult.getOrElse { return Result.failure(it) }
+
+        val newConnection = connectionFactory(dependency, credential)
+        connection = newConnection
+
+        return newConnection.connect()
+            .mapCatching {
+                newConnection.initialize().getOrThrow()
+                Unit
+            }
+    }
+
+    suspend fun listTools(): Result<List<McpToolDescriptor>> {
+        val active = connection
+            ?: return Result.failure(IllegalStateException("McpClient must connect() before listTools()"))
+        return active.listTools()
+    }
+
+    suspend fun callTool(name: String, arguments: JsonElement?): Result<ToolCallResult> {
+        val active = connection
+            ?: return Result.failure(IllegalStateException("McpClient must connect() before callTool()"))
+        return active.invokeTool(name, arguments)
+    }
+
+    suspend fun close(): Result<Unit> = mutex.withLock {
+        val active = connection ?: return Result.success(Unit)
+        return active.disconnect().also { connection = null }
+    }
+}
+
+/**
+ * Default factory: builds an [HttpMcpConnection] from a dependency plus the
+ * resolved credential. Used unless the caller injects a different factory
+ * (typically for tests).
+ */
+fun defaultHttpConnection(
+    dependency: McpServerDependency,
+    credential: McpCredential?,
+): McpServerConnection {
+    val config = McpServerConfiguration(
+        id = dependency.name,
+        displayName = dependency.name,
+        protocol = McpProtocol.HTTP,
+        endpoint = dependency.uri,
+        authToken = credential?.authToken,
+    )
+    return HttpMcpConnection(config, HttpClientHandler())
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/mcp/McpCredentialBinding.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/mcp/McpCredentialBinding.kt
@@ -1,0 +1,79 @@
+package link.socket.ampere.mcp
+
+import kotlin.jvm.JvmInline
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.Serializable
+
+/**
+ * Identifier for a Link — the user-bound authorization scope under which
+ * an MCP credential is stored.
+ *
+ * The Link concept is upcoming work; modeling it as a value class lets the
+ * eventual store interface match without a churn cycle.
+ */
+@JvmInline
+@Serializable
+value class LinkId(val value: String)
+
+/**
+ * Credential material a plugin's [McpClient] surfaces into its connection
+ * layer when calling an MCP server.
+ *
+ * Today only [authToken] is captured; future fields (refresh token, OAuth
+ * metadata) can be added without breaking the binding contract.
+ */
+@Serializable
+data class McpCredential(
+    val authToken: String? = null,
+)
+
+/**
+ * Storage contract for credentials a plugin uses to talk to an MCP server.
+ *
+ * Implementations are scoped per Link so credentials revocations follow the
+ * Link lifecycle. The interface intentionally avoids leaking implementation
+ * concerns (transactionality, persistence, encryption) so the upcoming
+ * Link-backed store can drop in.
+ */
+interface McpCredentialBinding {
+    suspend fun bind(linkId: LinkId, mcpUri: String, credential: McpCredential): Result<Unit>
+
+    suspend fun resolve(linkId: LinkId, mcpUri: String): Result<McpCredential?>
+
+    suspend fun unbind(linkId: LinkId, mcpUri: String): Result<Unit>
+}
+
+/**
+ * In-memory [McpCredentialBinding] suitable for tests and single-process
+ * environments. The persistent Link-backed implementation lands separately.
+ */
+class InMemoryMcpCredentialBinding : McpCredentialBinding {
+
+    private val mutex = Mutex()
+    private val store = mutableMapOf<Pair<LinkId, String>, McpCredential>()
+
+    override suspend fun bind(
+        linkId: LinkId,
+        mcpUri: String,
+        credential: McpCredential,
+    ): Result<Unit> = mutex.withLock {
+        store[linkId to mcpUri] = credential
+        Result.success(Unit)
+    }
+
+    override suspend fun resolve(
+        linkId: LinkId,
+        mcpUri: String,
+    ): Result<McpCredential?> = mutex.withLock {
+        Result.success(store[linkId to mcpUri])
+    }
+
+    override suspend fun unbind(
+        linkId: LinkId,
+        mcpUri: String,
+    ): Result<Unit> = mutex.withLock {
+        store.remove(linkId to mcpUri)
+        Result.success(Unit)
+    }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/plugin/McpServerDependency.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/plugin/McpServerDependency.kt
@@ -1,0 +1,30 @@
+package link.socket.ampere.plugin
+
+import kotlinx.serialization.Serializable
+import link.socket.ampere.plugin.permission.PluginPermission
+
+/**
+ * Declares an MCP server that a plugin depends on at runtime.
+ *
+ * Each declared dependency must be matched by a corresponding
+ * [PluginPermission.MCPServer] entry in [PluginManifest.requiredPermissions]
+ * so the user grant flow can authorize the plugin's access to it.
+ *
+ * @property name Local handle used by the plugin to reference the server
+ *   (e.g., `"notion"`). Distinct from the connection [uri] so plugins can
+ *   reference servers symbolically.
+ * @property uri The MCP server endpoint (e.g., `"mcp://..."` or
+ *   `"https://..."`). Used both to dial the server and to match the
+ *   [PluginPermission.MCPServer] grant.
+ * @property requiredPermissions Permissions the plugin will exercise via
+ *   this server. Each must also appear in
+ *   [PluginManifest.requiredPermissions]; otherwise the manifest validator
+ *   surfaces a diagnostic so the plugin author can lift the permission to
+ *   the top-level grant scope.
+ */
+@Serializable
+data class McpServerDependency(
+    val name: String,
+    val uri: String,
+    val requiredPermissions: List<PluginPermission> = emptyList(),
+)

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/plugin/PluginContext.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/plugin/PluginContext.kt
@@ -1,0 +1,157 @@
+package link.socket.ampere.plugin
+
+import link.socket.ampere.agents.config.AgentActionAutonomy
+import link.socket.ampere.agents.execution.tools.McpTool
+import link.socket.ampere.agents.execution.tools.Tool
+import link.socket.ampere.agents.tools.mcp.connection.McpServerConnection
+import link.socket.ampere.mcp.LinkId
+import link.socket.ampere.mcp.McpClient
+import link.socket.ampere.mcp.McpCredential
+import link.socket.ampere.mcp.McpCredentialBinding
+import link.socket.ampere.mcp.defaultHttpConnection
+
+/**
+ * Runtime context for an active plugin instance.
+ *
+ * Bundles a validated [PluginManifest] together with the plugin's native
+ * tools and the [McpClient] instances opened for each declared
+ * [McpServerDependency]. The MCP tools discovered from each server are
+ * exposed through [availableTools] alongside any native tools, and each
+ * carries the originating manifest so [PluginPermissionGate][link.socket.ampere.plugin.permission.PluginPermissionGate]
+ * still gates dispatch.
+ *
+ * Construction goes through [create]. It validates the manifest, opens an
+ * [McpClient] per dependency, runs the handshake, lists tools, and wraps
+ * each descriptor as an [McpTool]. Server failures are surfaced per server
+ * (mirroring the existing [link.socket.ampere.agents.tools.mcp.McpServerManager]
+ * resilience pattern) so one bad server doesn't kill the plugin.
+ *
+ * Tools are dispatched through
+ * [link.socket.ampere.propel.ExecuteStep], which resolves the right
+ * [McpClient] via [mcpClientFor].
+ */
+class PluginContext private constructor(
+    val manifest: PluginManifest,
+    private val nativeTools: List<Tool<*>>,
+    private val mcpClientsByUri: Map<String, McpClient>,
+    private val mcpToolsByServerUri: Map<String, List<McpTool>>,
+    val serverFailures: List<PluginContextServerFailure>,
+) {
+
+    fun availableTools(): List<Tool<*>> =
+        nativeTools + mcpToolsByServerUri.values.flatten()
+
+    /**
+     * Looks up the [McpClient] responsible for a tool's originating server.
+     *
+     * Returns null for tools without a matching server (e.g., a stale
+     * [McpTool] referencing a server that failed to come up).
+     */
+    fun mcpClientFor(tool: McpTool): McpClient? =
+        mcpClientsByUri[tool.serverId]
+
+    suspend fun close(): Result<Unit> {
+        val errors = mutableListOf<Throwable>()
+        mcpClientsByUri.values.forEach { client ->
+            client.close().onFailure { errors += it }
+        }
+        return if (errors.isEmpty()) {
+            Result.success(Unit)
+        } else {
+            Result.failure(errors.first())
+        }
+    }
+
+    companion object {
+        suspend fun create(
+            manifest: PluginManifest,
+            credentialBinding: McpCredentialBinding,
+            linkId: LinkId,
+            nativeTools: List<Tool<*>> = emptyList(),
+            connectionFactory: (McpServerDependency, McpCredential?) -> McpServerConnection =
+                ::defaultHttpConnection,
+        ): Result<PluginContext> {
+            val validation = PluginManifestValidator.validate(manifest)
+            if (validation is ManifestValidationResult.Invalid) {
+                return Result.failure(
+                    PluginManifestValidationException(validation.reasons),
+                )
+            }
+
+            val clientsByUri = mutableMapOf<String, McpClient>()
+            val toolsByUri = mutableMapOf<String, List<McpTool>>()
+            val failures = mutableListOf<PluginContextServerFailure>()
+
+            manifest.mcpServers.forEach { dependency ->
+                val client = McpClient(
+                    dependency = dependency,
+                    credentialBinding = credentialBinding,
+                    linkId = linkId,
+                    connectionFactory = connectionFactory,
+                )
+
+                val connectResult = client.connect()
+                if (connectResult.isFailure) {
+                    failures += PluginContextServerFailure(
+                        dependency = dependency,
+                        cause = connectResult.exceptionOrNull(),
+                    )
+                    client.close()
+                    return@forEach
+                }
+
+                val toolsResult = client.listTools()
+                val descriptors = toolsResult.getOrElse { error ->
+                    failures += PluginContextServerFailure(
+                        dependency = dependency,
+                        cause = error,
+                    )
+                    client.close()
+                    return@forEach
+                }
+
+                clientsByUri[dependency.uri] = client
+                toolsByUri[dependency.uri] = descriptors.map { descriptor ->
+                    McpTool(
+                        id = "${dependency.name}:${descriptor.name}",
+                        name = descriptor.name,
+                        description = descriptor.description,
+                        requiredAgentAutonomy = AgentActionAutonomy.ACT_WITH_NOTIFICATION,
+                        pluginManifest = manifest,
+                        serverId = dependency.uri,
+                        remoteToolName = descriptor.name,
+                        inputSchema = descriptor.inputSchema,
+                    )
+                }
+            }
+
+            return Result.success(
+                PluginContext(
+                    manifest = manifest,
+                    nativeTools = nativeTools,
+                    mcpClientsByUri = clientsByUri,
+                    mcpToolsByServerUri = toolsByUri,
+                    serverFailures = failures,
+                ),
+            )
+        }
+    }
+}
+
+/**
+ * Captures a per-server failure encountered during [PluginContext.create].
+ *
+ * Surfaced rather than thrown so a single misbehaving MCP server doesn't
+ * fail the rest of the plugin's tools.
+ */
+data class PluginContextServerFailure(
+    val dependency: McpServerDependency,
+    val cause: Throwable?,
+)
+
+/**
+ * Thrown when a manifest fails validation during [PluginContext.create].
+ */
+class PluginManifestValidationException(
+    val reasons: List<ManifestValidationReason>,
+) : Exception("Plugin manifest validation failed: $reasons")

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/plugin/PluginManifest.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/plugin/PluginManifest.kt
@@ -6,8 +6,8 @@ import link.socket.ampere.plugin.permission.PluginPermission
 /**
  * Manifest metadata for a plugin and the permissions it requires at runtime.
  *
- * [requiredPermissions] defaults to empty so manifests created before the
- * permission schema continue to decode unchanged.
+ * [requiredPermissions] and [mcpServers] default to empty so manifests created
+ * before each schema addition continue to decode unchanged.
  */
 @Serializable
 data class PluginManifest(
@@ -17,4 +17,5 @@ data class PluginManifest(
     val description: String? = null,
     val entrypoint: String? = null,
     val requiredPermissions: List<PluginPermission> = emptyList(),
+    val mcpServers: List<McpServerDependency> = emptyList(),
 )

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/plugin/PluginManifestValidator.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/plugin/PluginManifestValidator.kt
@@ -1,0 +1,78 @@
+package link.socket.ampere.plugin
+
+import link.socket.ampere.plugin.permission.PluginPermission
+
+/**
+ * Pure-function validator for [PluginManifest].
+ *
+ * Today this enforces that every MCP server declared in
+ * [PluginManifest.mcpServers] is matched by a corresponding
+ * [PluginPermission.MCPServer] entry in [PluginManifest.requiredPermissions],
+ * and that any permissions a dependency claims it needs are also lifted to
+ * the manifest's top-level grant scope.
+ *
+ * Returning a sealed result keeps the validator usable both for early failure
+ * (during plugin install) and for surfacing diagnostics in tooling.
+ */
+object PluginManifestValidator {
+
+    fun validate(manifest: PluginManifest): ManifestValidationResult {
+        val reasons = mutableListOf<ManifestValidationReason>()
+
+        val grantedMcpUris = manifest.requiredPermissions
+            .filterIsInstance<PluginPermission.MCPServer>()
+            .map { it.uri }
+            .toSet()
+
+        manifest.mcpServers.forEach { dependency ->
+            if (dependency.uri !in grantedMcpUris) {
+                reasons += ManifestValidationReason.MissingMcpServerPermission(
+                    dependencyName = dependency.name,
+                    uri = dependency.uri,
+                )
+            }
+
+            dependency.requiredPermissions.forEach { permission ->
+                if (permission !in manifest.requiredPermissions) {
+                    reasons += ManifestValidationReason.DependencyPermissionNotLifted(
+                        dependencyName = dependency.name,
+                        permission = permission,
+                    )
+                }
+            }
+        }
+
+        return if (reasons.isEmpty()) {
+            ManifestValidationResult.Valid
+        } else {
+            ManifestValidationResult.Invalid(reasons)
+        }
+    }
+}
+
+sealed interface ManifestValidationResult {
+    data object Valid : ManifestValidationResult
+
+    data class Invalid(val reasons: List<ManifestValidationReason>) : ManifestValidationResult
+}
+
+sealed interface ManifestValidationReason {
+
+    /**
+     * A [McpServerDependency] was declared but no matching
+     * [PluginPermission.MCPServer] grant was present.
+     */
+    data class MissingMcpServerPermission(
+        val dependencyName: String,
+        val uri: String,
+    ) : ManifestValidationReason
+
+    /**
+     * A [McpServerDependency] declared a permission that wasn't lifted to the
+     * manifest's top-level [PluginManifest.requiredPermissions].
+     */
+    data class DependencyPermissionNotLifted(
+        val dependencyName: String,
+        val permission: PluginPermission,
+    ) : ManifestValidationReason
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/propel/ExecuteStep.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/propel/ExecuteStep.kt
@@ -1,0 +1,100 @@
+package link.socket.ampere.propel
+
+import kotlinx.serialization.json.JsonElement
+import link.socket.ampere.agents.execution.tools.FunctionTool
+import link.socket.ampere.agents.execution.tools.McpTool
+import link.socket.ampere.agents.execution.tools.ToolId
+import link.socket.ampere.agents.tools.mcp.protocol.ToolCallResult
+import link.socket.ampere.plugin.PluginContext
+import link.socket.ampere.plugin.PluginManifest
+import link.socket.ampere.plugin.permission.GateResult
+import link.socket.ampere.plugin.permission.PluginPermission
+import link.socket.ampere.plugin.permission.PluginPermissionGate
+import link.socket.ampere.plugin.permission.PluginToolCall
+import link.socket.ampere.plugin.permission.UserGrants
+
+/**
+ * Single entry point for plugin-sourced tool invocations during the PROPEL
+ * Execute phase.
+ *
+ * The step looks up the tool by ID against [PluginContext.availableTools],
+ * runs [PluginPermissionGate] using the manifest plus user grants supplied
+ * by [userGrantProvider], and then dispatches:
+ * - [McpTool]: routes through the [PluginContext]'s matching
+ *   [link.socket.ampere.mcp.McpClient].
+ * - [FunctionTool]: not routed here yet — native plugin tool execution
+ *   lands with the broader plugin runtime work, so the step returns a
+ *   typed [ExecuteResult.NativeToolNotSupported] rather than guessing at
+ *   an `ExecutionRequest` to construct.
+ *
+ * Because plugin-sourced MCP calls flow through this single step, the
+ * permission gate cannot be bypassed by callers that need MCP access.
+ */
+class ExecuteStep(
+    private val context: PluginContext,
+    private val userGrantProvider: suspend (PluginManifest) -> UserGrants,
+) {
+
+    suspend fun execute(toolId: ToolId, arguments: JsonElement?): ExecuteResult {
+        val tool = context.availableTools().firstOrNull { it.id == toolId }
+            ?: return ExecuteResult.UnknownTool(toolId)
+
+        val gateResult = PluginPermissionGate.check(
+            toolCall = PluginToolCall(
+                pluginId = context.manifest.id,
+                toolId = tool.id,
+            ),
+            manifest = context.manifest,
+            userGrants = userGrantProvider(context.manifest),
+        )
+
+        when (gateResult) {
+            is GateResult.Allow -> Unit
+            is GateResult.DenyMissing -> return ExecuteResult.PermissionDenied(
+                permission = gateResult.permission,
+                reason = PermissionDeniedReason.MISSING_GRANT,
+            )
+            is GateResult.DenyRevoked -> return ExecuteResult.PermissionDenied(
+                permission = gateResult.permission,
+                reason = PermissionDeniedReason.REVOKED_GRANT,
+            )
+        }
+
+        return when (tool) {
+            is McpTool -> dispatchMcp(tool, arguments)
+            is FunctionTool<*> -> ExecuteResult.NativeToolNotSupported(tool.id)
+        }
+    }
+
+    private suspend fun dispatchMcp(tool: McpTool, arguments: JsonElement?): ExecuteResult {
+        val client = context.mcpClientFor(tool)
+            ?: return ExecuteResult.Failure(
+                "No MCP client registered for tool '${tool.id}' (server '${tool.serverId}')",
+            )
+
+        return client.callTool(tool.remoteToolName, arguments).fold(
+            onSuccess = { ExecuteResult.Success(it) },
+            onFailure = { ExecuteResult.Failure(it.message ?: it::class.simpleName.orEmpty()) },
+        )
+    }
+}
+
+sealed interface ExecuteResult {
+    data class Success(val result: ToolCallResult) : ExecuteResult
+
+    data class UnknownTool(val toolId: ToolId) : ExecuteResult
+
+    data class PermissionDenied(
+        val permission: PluginPermission,
+        val reason: PermissionDeniedReason,
+    ) : ExecuteResult
+
+    data class NativeToolNotSupported(val toolId: ToolId) : ExecuteResult
+
+    data class Failure(val message: String) : ExecuteResult
+}
+
+enum class PermissionDeniedReason {
+    MISSING_GRANT,
+    REVOKED_GRANT,
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/mcp/McpCredentialBindingTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/mcp/McpCredentialBindingTest.kt
@@ -1,0 +1,59 @@
+package link.socket.ampere.mcp
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlinx.coroutines.test.runTest
+
+class McpCredentialBindingTest {
+
+    private val linkId = LinkId("link-1")
+    private val mcpUri = "mcp://github"
+
+    @Test
+    fun `bind then resolve returns the bound credential`() = runTest {
+        val binding = InMemoryMcpCredentialBinding()
+        val credential = McpCredential(authToken = "abc-123")
+
+        binding.bind(linkId, mcpUri, credential).getOrThrow()
+        val resolved = binding.resolve(linkId, mcpUri).getOrThrow()
+
+        assertEquals(credential, resolved)
+    }
+
+    @Test
+    fun `resolve for unknown linkId or uri returns null`() = runTest {
+        val binding = InMemoryMcpCredentialBinding()
+
+        val unknown = binding.resolve(linkId, mcpUri).getOrThrow()
+
+        assertNull(unknown)
+    }
+
+    @Test
+    fun `unbind removes the credential`() = runTest {
+        val binding = InMemoryMcpCredentialBinding()
+        val credential = McpCredential(authToken = "abc-123")
+        binding.bind(linkId, mcpUri, credential).getOrThrow()
+
+        binding.unbind(linkId, mcpUri).getOrThrow()
+        val resolved = binding.resolve(linkId, mcpUri).getOrThrow()
+
+        assertNull(resolved)
+    }
+
+    @Test
+    fun `credentials scoped per linkId and per uri`() = runTest {
+        val binding = InMemoryMcpCredentialBinding()
+        val a = McpCredential(authToken = "token-a")
+        val b = McpCredential(authToken = "token-b")
+        val otherLink = LinkId("link-2")
+
+        binding.bind(linkId, mcpUri, a).getOrThrow()
+        binding.bind(otherLink, mcpUri, b).getOrThrow()
+
+        assertEquals(a, binding.resolve(linkId, mcpUri).getOrThrow())
+        assertEquals(b, binding.resolve(otherLink, mcpUri).getOrThrow())
+        assertNull(binding.resolve(linkId, "mcp://other").getOrThrow())
+    }
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/plugin/PluginManifestValidationTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/plugin/PluginManifestValidationTest.kt
@@ -1,0 +1,123 @@
+package link.socket.ampere.plugin
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import link.socket.ampere.plugin.permission.PluginPermission
+
+class PluginManifestValidationTest {
+
+    @Test
+    fun `manifest with declared mcp server and matching permission validates`() {
+        val manifest = PluginManifest(
+            id = "github-plugin",
+            name = "GitHub Plugin",
+            version = "1.0.0",
+            requiredPermissions = listOf(
+                PluginPermission.MCPServer("mcp://github"),
+            ),
+            mcpServers = listOf(
+                McpServerDependency(
+                    name = "github",
+                    uri = "mcp://github",
+                ),
+            ),
+        )
+
+        val result = PluginManifestValidator.validate(manifest)
+
+        assertEquals(ManifestValidationResult.Valid, result)
+    }
+
+    @Test
+    fun `manifest missing matching mcp permission fails with diagnostic naming the uri`() {
+        val manifest = PluginManifest(
+            id = "github-plugin",
+            name = "GitHub Plugin",
+            version = "1.0.0",
+            requiredPermissions = emptyList(),
+            mcpServers = listOf(
+                McpServerDependency(
+                    name = "github",
+                    uri = "mcp://github",
+                ),
+            ),
+        )
+
+        val result = PluginManifestValidator.validate(manifest)
+        val invalid = assertIs<ManifestValidationResult.Invalid>(result)
+
+        val missing = invalid.reasons.filterIsInstance<ManifestValidationReason.MissingMcpServerPermission>()
+        assertEquals(1, missing.size)
+        assertEquals("mcp://github", missing.single().uri)
+        assertEquals("github", missing.single().dependencyName)
+    }
+
+    @Test
+    fun `dependency permission not lifted to manifest is flagged`() {
+        val knowledgeQuery = PluginPermission.KnowledgeQuery("workspace")
+        val manifest = PluginManifest(
+            id = "github-plugin",
+            name = "GitHub Plugin",
+            version = "1.0.0",
+            requiredPermissions = listOf(
+                PluginPermission.MCPServer("mcp://github"),
+            ),
+            mcpServers = listOf(
+                McpServerDependency(
+                    name = "github",
+                    uri = "mcp://github",
+                    requiredPermissions = listOf(knowledgeQuery),
+                ),
+            ),
+        )
+
+        val result = PluginManifestValidator.validate(manifest)
+        val invalid = assertIs<ManifestValidationResult.Invalid>(result)
+
+        val notLifted = invalid.reasons
+            .filterIsInstance<ManifestValidationReason.DependencyPermissionNotLifted>()
+        assertEquals(1, notLifted.size)
+        assertEquals(knowledgeQuery, notLifted.single().permission)
+        assertEquals("github", notLifted.single().dependencyName)
+    }
+
+    @Test
+    fun `manifest with no mcp servers validates regardless of permissions`() {
+        val manifest = PluginManifest(
+            id = "no-mcp-plugin",
+            name = "No MCP Plugin",
+            version = "1.0.0",
+        )
+
+        val result = PluginManifestValidator.validate(manifest)
+
+        assertEquals(ManifestValidationResult.Valid, result)
+    }
+
+    @Test
+    fun `multiple mcp servers all require their own permissions`() {
+        val manifest = PluginManifest(
+            id = "multi-mcp",
+            name = "Multi MCP",
+            version = "1.0.0",
+            requiredPermissions = listOf(
+                PluginPermission.MCPServer("mcp://a"),
+            ),
+            mcpServers = listOf(
+                McpServerDependency(name = "a", uri = "mcp://a"),
+                McpServerDependency(name = "b", uri = "mcp://b"),
+            ),
+        )
+
+        val result = PluginManifestValidator.validate(manifest)
+        val invalid = assertIs<ManifestValidationResult.Invalid>(result)
+
+        val missingUris = invalid.reasons
+            .filterIsInstance<ManifestValidationReason.MissingMcpServerPermission>()
+            .map { it.uri }
+        assertTrue("mcp://b" in missingUris)
+        assertTrue("mcp://a" !in missingUris)
+    }
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/plugin/permission/PluginPermissionSerializationTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/plugin/permission/PluginPermissionSerializationTest.kt
@@ -3,6 +3,7 @@ package link.socket.ampere.plugin.permission
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlinx.serialization.json.Json
+import link.socket.ampere.plugin.McpServerDependency
 import link.socket.ampere.plugin.PluginManifest
 
 class PluginPermissionSerializationTest {
@@ -60,6 +61,53 @@ class PluginPermissionSerializationTest {
         val encoded = json.encodeToString(original)
         val decoded = json.decodeFromString<PluginManifest>(encoded)
 
+        assertEquals(original.requiredPermissions, decoded.requiredPermissions)
+    }
+
+    @Test
+    fun `manifest missing mcp servers defaults to empty list`() {
+        val manifest = json.decodeFromString<PluginManifest>(
+            """
+            {
+              "id": "test-plugin",
+              "name": "Test Plugin",
+              "version": "1.0.0"
+            }
+            """.trimIndent(),
+        )
+
+        assertEquals(emptyList(), manifest.mcpServers)
+    }
+
+    @Test
+    fun `manifest round-trips mcp server dependencies through json`() {
+        val original = PluginManifest(
+            id = "github-plugin",
+            name = "GitHub Plugin",
+            version = "1.0.0",
+            requiredPermissions = listOf(
+                PluginPermission.MCPServer("mcp://github"),
+                PluginPermission.MCPServer("mcp://notion"),
+            ),
+            mcpServers = listOf(
+                McpServerDependency(
+                    name = "github",
+                    uri = "mcp://github",
+                    requiredPermissions = listOf(
+                        PluginPermission.NetworkDomain("api.github.com"),
+                    ),
+                ),
+                McpServerDependency(
+                    name = "notion",
+                    uri = "mcp://notion",
+                ),
+            ),
+        )
+
+        val encoded = json.encodeToString(original)
+        val decoded = json.decodeFromString<PluginManifest>(encoded)
+
+        assertEquals(original.mcpServers, decoded.mcpServers)
         assertEquals(original.requiredPermissions, decoded.requiredPermissions)
     }
 }

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/mcp/McpClientTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/mcp/McpClientTest.kt
@@ -1,0 +1,173 @@
+package link.socket.ampere.mcp
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import link.socket.ampere.agents.tools.mcp.connection.McpServerConnection
+import link.socket.ampere.agents.tools.mcp.protocol.ContentItem
+import link.socket.ampere.agents.tools.mcp.protocol.InitializeResult
+import link.socket.ampere.agents.tools.mcp.protocol.McpToolDescriptor
+import link.socket.ampere.agents.tools.mcp.protocol.ServerCapabilities
+import link.socket.ampere.agents.tools.mcp.protocol.ServerInfo
+import link.socket.ampere.agents.tools.mcp.protocol.ToolCallResult
+import link.socket.ampere.plugin.McpServerDependency
+
+class McpClientTest {
+
+    private val dependency = McpServerDependency(
+        name = "github",
+        uri = "mcp://github",
+    )
+
+    @Test
+    fun `listTools returns descriptors from the underlying connection`() = runTest {
+        val descriptors = listOf(
+            McpToolDescriptor(name = "list_repos", description = "List repos"),
+            McpToolDescriptor(name = "open_issue", description = "Open issue"),
+        )
+        val mock = RecordingMcpConnection(
+            serverId = dependency.uri,
+            toolsToReturn = descriptors,
+        )
+
+        val client = McpClient(
+            dependency = dependency,
+            credentialBinding = InMemoryMcpCredentialBinding(),
+            linkId = LinkId("test-link"),
+            connectionFactory = { _, _ -> mock },
+        )
+
+        client.connect().getOrThrow()
+        val tools = client.listTools().getOrThrow()
+
+        assertEquals(descriptors, tools)
+    }
+
+    @Test
+    fun `callTool round-trips arguments and returns the configured result`() = runTest {
+        val expectedResult = ToolCallResult(
+            content = listOf(ContentItem(type = "text", text = "ok")),
+            isError = false,
+        )
+        val mock = RecordingMcpConnection(
+            serverId = dependency.uri,
+            toolsToReturn = emptyList(),
+            invokeResult = expectedResult,
+        )
+
+        val client = McpClient(
+            dependency = dependency,
+            credentialBinding = InMemoryMcpCredentialBinding(),
+            linkId = LinkId("test-link"),
+            connectionFactory = { _, _ -> mock },
+        )
+
+        client.connect().getOrThrow()
+
+        val args: JsonElement = JsonObject(mapOf("repo" to JsonPrimitive("ampere")))
+        val result = client.callTool("list_repos", args).getOrThrow()
+
+        assertEquals(expectedResult, result)
+        assertEquals(listOf<Pair<String, JsonElement?>>("list_repos" to args), mock.invocations)
+    }
+
+    @Test
+    fun `connect surfaces resolved credential into the connection factory`() = runTest {
+        val binding = InMemoryMcpCredentialBinding()
+        val linkId = LinkId("test-link")
+        val credential = McpCredential(authToken = "secret-token")
+        binding.bind(linkId, dependency.uri, credential).getOrThrow()
+
+        var capturedCredential: McpCredential? = null
+        val mock = RecordingMcpConnection(
+            serverId = dependency.uri,
+            toolsToReturn = emptyList(),
+        )
+
+        val client = McpClient(
+            dependency = dependency,
+            credentialBinding = binding,
+            linkId = linkId,
+            connectionFactory = { _, resolved ->
+                capturedCredential = resolved
+                mock
+            },
+        )
+
+        client.connect().getOrThrow()
+
+        assertNotNull(capturedCredential)
+        assertEquals("secret-token", capturedCredential?.authToken)
+    }
+
+    @Test
+    fun `listTools fails fast when not connected`() = runTest {
+        val client = McpClient(
+            dependency = dependency,
+            credentialBinding = InMemoryMcpCredentialBinding(),
+            linkId = LinkId("test-link"),
+            connectionFactory = { _, _ ->
+                RecordingMcpConnection(serverId = dependency.uri, toolsToReturn = emptyList())
+            },
+        )
+
+        val result = client.listTools()
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is IllegalStateException)
+    }
+}
+
+private class RecordingMcpConnection(
+    override val serverId: String,
+    private val toolsToReturn: List<McpToolDescriptor>,
+    private val invokeResult: ToolCallResult = ToolCallResult(),
+) : McpServerConnection {
+
+    val invocations = mutableListOf<Pair<String, JsonElement?>>()
+
+    override var isConnected: Boolean = false
+        private set
+
+    private var initialized = false
+
+    override suspend fun connect(): Result<Unit> {
+        isConnected = true
+        return Result.success(Unit)
+    }
+
+    override suspend fun initialize(): Result<InitializeResult> {
+        initialized = true
+        return Result.success(
+            InitializeResult(
+                protocolVersion = "2024-11-05",
+                serverInfo = ServerInfo(name = "Recording", version = "0.0.0"),
+                capabilities = ServerCapabilities(),
+            ),
+        )
+    }
+
+    override suspend fun listTools(): Result<List<McpToolDescriptor>> =
+        if (!initialized) {
+            Result.failure(IllegalStateException("not initialized"))
+        } else Result.success(toolsToReturn)
+
+    override suspend fun invokeTool(
+        toolName: String,
+        arguments: JsonElement?,
+    ): Result<ToolCallResult> {
+        invocations += toolName to arguments
+        return Result.success(invokeResult)
+    }
+
+    override suspend fun disconnect(): Result<Unit> {
+        isConnected = false
+        initialized = false
+        return Result.success(Unit)
+    }
+}

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/plugin/PluginContextEndToEndTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/plugin/PluginContextEndToEndTest.kt
@@ -1,0 +1,174 @@
+package link.socket.ampere.plugin
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonElement
+import link.socket.ampere.agents.tools.mcp.connection.McpServerConnection
+import link.socket.ampere.agents.tools.mcp.protocol.ContentItem
+import link.socket.ampere.agents.tools.mcp.protocol.InitializeResult
+import link.socket.ampere.agents.tools.mcp.protocol.McpToolDescriptor
+import link.socket.ampere.agents.tools.mcp.protocol.ServerCapabilities
+import link.socket.ampere.agents.tools.mcp.protocol.ServerInfo
+import link.socket.ampere.agents.tools.mcp.protocol.ToolCallResult
+import link.socket.ampere.mcp.InMemoryMcpCredentialBinding
+import link.socket.ampere.mcp.LinkId
+import link.socket.ampere.plugin.permission.PluginPermission
+import link.socket.ampere.plugin.permission.UserGrants
+import link.socket.ampere.propel.ExecuteResult
+import link.socket.ampere.propel.ExecuteStep
+
+class PluginContextEndToEndTest {
+
+    private val mcpUri = "mcp://github"
+    private val toolName = "list_repos"
+
+    private val manifest = PluginManifest(
+        id = "github-plugin",
+        name = "GitHub Plugin",
+        version = "1.0.0",
+        requiredPermissions = listOf(PluginPermission.MCPServer(mcpUri)),
+        mcpServers = listOf(
+            McpServerDependency(name = "github", uri = mcpUri),
+        ),
+    )
+
+    @Test
+    fun `granted user invokes mcp tool successfully`() = runTest {
+        val expected = ToolCallResult(
+            content = listOf(ContentItem(type = "text", text = "ampere")),
+            isError = false,
+        )
+        val mock = RecordingMcpConnection(
+            serverId = mcpUri,
+            toolsToReturn = listOf(
+                McpToolDescriptor(name = toolName, description = "List repos"),
+            ),
+            invokeResult = expected,
+        )
+
+        val context = PluginContext.create(
+            manifest = manifest,
+            credentialBinding = InMemoryMcpCredentialBinding(),
+            linkId = LinkId("test-link"),
+            connectionFactory = { _, _ -> mock },
+        ).getOrThrow()
+
+        val step = ExecuteStep(
+            context = context,
+            userGrantProvider = { UserGrants.granted(PluginPermission.MCPServer(mcpUri)) },
+        )
+
+        val toolId = "github:$toolName"
+        val result = step.execute(toolId, arguments = null)
+
+        val success = assertIs<ExecuteResult.Success>(result)
+        assertEquals(expected, success.result)
+        assertEquals(1, mock.invocations.size)
+        assertEquals(toolName, mock.invocations.single().first)
+    }
+
+    @Test
+    fun `missing grant denies dispatch and never invokes the connection`() = runTest {
+        val mock = RecordingMcpConnection(
+            serverId = mcpUri,
+            toolsToReturn = listOf(
+                McpToolDescriptor(name = toolName, description = "List repos"),
+            ),
+        )
+
+        val context = PluginContext.create(
+            manifest = manifest,
+            credentialBinding = InMemoryMcpCredentialBinding(),
+            linkId = LinkId("test-link"),
+            connectionFactory = { _, _ -> mock },
+        ).getOrThrow()
+
+        val step = ExecuteStep(
+            context = context,
+            userGrantProvider = { UserGrants() },
+        )
+
+        val toolId = "github:$toolName"
+        val result = step.execute(toolId, arguments = null)
+
+        val denied = assertIs<ExecuteResult.PermissionDenied>(result)
+        assertEquals(PluginPermission.MCPServer(mcpUri), denied.permission)
+        assertTrue(mock.invocations.isEmpty())
+    }
+
+    @Test
+    fun `unknown tool id returns UnknownTool`() = runTest {
+        val mock = RecordingMcpConnection(
+            serverId = mcpUri,
+            toolsToReturn = emptyList(),
+        )
+
+        val context = PluginContext.create(
+            manifest = manifest,
+            credentialBinding = InMemoryMcpCredentialBinding(),
+            linkId = LinkId("test-link"),
+            connectionFactory = { _, _ -> mock },
+        ).getOrThrow()
+
+        val step = ExecuteStep(
+            context = context,
+            userGrantProvider = { UserGrants.granted(PluginPermission.MCPServer(mcpUri)) },
+        )
+
+        val result = step.execute("github:does_not_exist", arguments = null)
+
+        assertIs<ExecuteResult.UnknownTool>(result)
+    }
+}
+
+private class RecordingMcpConnection(
+    override val serverId: String,
+    private val toolsToReturn: List<McpToolDescriptor>,
+    private val invokeResult: ToolCallResult = ToolCallResult(),
+) : McpServerConnection {
+
+    val invocations = mutableListOf<Pair<String, JsonElement?>>()
+
+    override var isConnected: Boolean = false
+        private set
+
+    private var initialized = false
+
+    override suspend fun connect(): Result<Unit> {
+        isConnected = true
+        return Result.success(Unit)
+    }
+
+    override suspend fun initialize(): Result<InitializeResult> {
+        initialized = true
+        return Result.success(
+            InitializeResult(
+                protocolVersion = "2024-11-05",
+                serverInfo = ServerInfo(name = "Mock", version = "0.0.0"),
+                capabilities = ServerCapabilities(),
+            ),
+        )
+    }
+
+    override suspend fun listTools(): Result<List<McpToolDescriptor>> =
+        if (!initialized) {
+            Result.failure(IllegalStateException("not initialized"))
+        } else Result.success(toolsToReturn)
+
+    override suspend fun invokeTool(
+        toolName: String,
+        arguments: JsonElement?,
+    ): Result<ToolCallResult> {
+        invocations += toolName to arguments
+        return Result.success(invokeResult)
+    }
+
+    override suspend fun disconnect(): Result<Unit> {
+        isConnected = false
+        initialized = false
+        return Result.success(Unit)
+    }
+}


### PR DESCRIPTION
## Summary
- I added `mcpServers` to `PluginManifest` plus an `McpServerDependency` schema and a `PluginManifestValidator` that enforces every declared MCP URI has a matching `MCPServer(uri)` permission and that dep-level permissions are lifted to the manifest.
- I introduced a plugin-facing `McpClient` (with `connectionFactory` test seam over the existing `HttpMcpConnection`/protocol layer) plus an `McpCredentialBinding` interface with an in-memory implementation, ahead of the future Link-backed credential store.
- I built `PluginContext.create(...)` to validate the manifest, open one client per dep with per-server failure capture, and expose discovered tools as `McpTool`s carrying the manifest, then routed plugin tool dispatch through a single `ExecuteStep` that runs `PluginPermissionGate.check` before calling the matching client — no bypass path.

Closes #464

## Test plan
- [x] `./gradlew :ampere-core:jvmTest`
- [x] `./gradlew ktlintFormat` and `./gradlew :ampere-core:ktlintCheck`
- [x] New tests cover: manifest validation, manifest serialization round-trip, `McpClient` list/call/credential-surfacing, `McpCredentialBinding` bind/resolve/unbind/scoping, and end-to-end `ExecuteStep` granted vs missing-grant paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)