### PR TITLE
AMPR-154 #463: add plugin bundle format spec

### DIFF
--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/bundle/OkioPluginBundleSource.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/bundle/OkioPluginBundleSource.kt
@@ -1,0 +1,63 @@
+package link.socket.ampere.bundle
+
+import okio.FileSystem
+import okio.IOException
+import okio.Path
+
+/**
+ * [PluginBundleSource] backed by an okio [FileSystem].
+ *
+ * Used by [PluginBundleSource.fromDirectory] (commonMain) and
+ * `PluginBundleSource.fromZipFile` (jvmMain — okio's `openZip` is JVM-only
+ * in this version).
+ *
+ * Entry keys are normalised to forward-slash paths relative to the bundle
+ * root, so a bundle imported as a directory and the same bundle imported as a
+ * ZIP produce identical [PluginBundleSource.entries] sets.
+ */
+internal class OkioPluginBundleSource(
+    private val fileSystem: FileSystem,
+    private val root: Path,
+) : PluginBundleSource {
+
+    private val index: Map<String, Path> by lazy { buildIndex() }
+
+    override fun entries(): Set<String> = index.keys
+
+    override fun readEntry(path: String): ByteArray? {
+        val resolved = index[path] ?: return null
+        return try {
+            fileSystem.read(resolved) { readByteArray() }
+        } catch (e: IOException) {
+            null
+        }
+    }
+
+    override fun totalSize(): Long =
+        index.values.sumOf { fileSystem.metadataOrNull(it)?.size ?: 0L }
+
+    private fun buildIndex(): Map<String, Path> {
+        val rootMeta = fileSystem.metadataOrNull(root) ?: return emptyMap()
+        if (!rootMeta.isDirectory) return emptyMap()
+
+        val entries = mutableMapOf<String, Path>()
+        for (entry in fileSystem.listRecursively(root)) {
+            val meta = fileSystem.metadataOrNull(entry) ?: continue
+            if (!meta.isRegularFile) continue
+            val key = entry.relativeTo(root).toString().replace('\\', '/')
+            if (key.isNotEmpty()) entries[key] = entry
+        }
+        return entries
+    }
+}
+
+/**
+ * Reads a bundle from an unpacked directory at [directory].
+ *
+ * If [directory] does not exist or is not a directory, the returned source
+ * is empty and the parser will surface [BundleParseError.MissingManifest].
+ */
+fun PluginBundleSource.Companion.fromDirectory(
+    directory: Path,
+    fileSystem: FileSystem,
+): PluginBundleSource = OkioPluginBundleSource(fileSystem, directory)

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/bundle/PluginBundle.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/bundle/PluginBundle.kt
@@ -1,0 +1,95 @@
+package link.socket.ampere.bundle
+
+import kotlinx.serialization.Serializable
+import link.socket.ampere.plugin.PluginManifest
+
+/**
+ * Bundle format version supported by this build.
+ *
+ * Bumping this constant signals a structural change to the bundle layout (file
+ * names, required entries, on-disk encoding). Field-level additions to
+ * [PluginManifest] do not require a bump.
+ */
+const val CURRENT_BUNDLE_FORMAT_VERSION: Int = 1
+
+/**
+ * Path of the manifest file at the root of every bundle.
+ */
+const val BUNDLE_MANIFEST_PATH: String = "manifest.json"
+
+/**
+ * Optional asset directory prefix. Files under this path are surfaced as
+ * [PluginBundle.assets] keyed by their path relative to the bundle root.
+ */
+const val BUNDLE_ASSETS_PREFIX: String = "assets/"
+
+/**
+ * Optional detached signature for the manifest. Production verification arrives
+ * in a follow-up; today the file is read into [PluginBundle.signature] verbatim
+ * so the parser surface matches what marketplace UI imports against.
+ */
+const val BUNDLE_SIGNATURE_PATH: String = "signature.sig"
+
+/**
+ * On-disk representation of `manifest.json`.
+ *
+ * Wrapping [PluginManifest] keeps the W0.1 plugin contract untouched while
+ * letting the bundle format declare its own [bundleFormatVersion]. Older
+ * manifests written before the bundle spec lacked this wrapper; the parser
+ * does not attempt to read those — bundle import is opt-in for plugins
+ * shipping through the marketplace.
+ */
+@Serializable
+data class BundleManifest(
+    val bundleFormatVersion: Int,
+    val plugin: PluginManifest,
+)
+
+/**
+ * A successfully parsed plugin bundle.
+ *
+ * @property bundleFormatVersion the format version declared by the bundle, as
+ *   read from `manifest.json`. Validated against [CURRENT_BUNDLE_FORMAT_VERSION]
+ *   by the parser before this value is observable.
+ * @property manifest the W0.1 [PluginManifest] embedded in the bundle.
+ * @property assets file contents from `assets/`, keyed by path relative to the
+ *   bundle root (e.g. `assets/icon.png`). Empty when the bundle has no assets.
+ * @property signature raw bytes of `signature.sig` if present. Verification is
+ *   the responsibility of [PluginBundleSignatureVerifier]; the parser does not
+ *   inspect the bytes.
+ */
+data class PluginBundle(
+    val bundleFormatVersion: Int,
+    val manifest: PluginManifest,
+    val assets: Map<String, ByteArray>,
+    val signature: ByteArray?,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is PluginBundle) return false
+        if (bundleFormatVersion != other.bundleFormatVersion) return false
+        if (manifest != other.manifest) return false
+        if (assets.keys != other.assets.keys) return false
+        for ((path, bytes) in assets) {
+            if (!bytes.contentEquals(other.assets[path])) return false
+        }
+        if (signature == null) {
+            if (other.signature != null) return false
+        } else {
+            if (other.signature == null) return false
+            if (!signature.contentEquals(other.signature)) return false
+        }
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = bundleFormatVersion
+        result = 31 * result + manifest.hashCode()
+        for ((path, bytes) in assets) {
+            result = 31 * result + path.hashCode()
+            result = 31 * result + bytes.contentHashCode()
+        }
+        result = 31 * result + (signature?.contentHashCode() ?: 0)
+        return result
+    }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/bundle/PluginBundleParser.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/bundle/PluginBundleParser.kt
@@ -1,0 +1,127 @@
+package link.socket.ampere.bundle
+
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+
+/**
+ * Maximum total byte size accepted by [PluginBundleParser].
+ *
+ * Bundles are user-importable artefacts; the cap prevents a malicious or
+ * malformed archive from exhausting memory before validation begins. The
+ * value is intentionally generous — current first-party plugins ship under
+ * 1 MiB, but bundled assets (icons, sample data) can grow.
+ */
+const val MAX_BUNDLE_SIZE_BYTES: Long = 50L * 1024 * 1024
+
+/**
+ * Outcome of [PluginBundleParser.parse]. Either a parsed bundle or a typed
+ * error describing why parsing failed.
+ */
+sealed interface BundleParseResult {
+
+    data class Ok(val bundle: PluginBundle) : BundleParseResult
+
+    data class Failed(val error: BundleParseError) : BundleParseResult
+}
+
+/**
+ * Reasons a bundle may fail to parse. The list is closed; callers can rely on
+ * `when` being exhaustive.
+ */
+sealed interface BundleParseError {
+
+    /** The bundle has no `manifest.json` entry. */
+    data object MissingManifest : BundleParseError
+
+    /** `manifest.json` exists but is not valid JSON or does not match the schema. */
+    data class InvalidManifest(val message: String) : BundleParseError
+
+    /**
+     * Total entry size exceeds [MAX_BUNDLE_SIZE_BYTES].
+     *
+     * Reported with the actual size so callers (e.g. marketplace UI) can show
+     * the user how far over the limit a bundle ran.
+     */
+    data class BundleTooLarge(val sizeBytes: Long, val limitBytes: Long) : BundleParseError
+
+    /**
+     * The manifest declares a [bundleFormatVersion] this build does not
+     * understand. Distinguished from [InvalidManifest] so newer bundles
+     * surface a clear "upgrade required" message rather than looking
+     * malformed.
+     */
+    data class UnknownVersion(val declared: Int, val supported: Int) : BundleParseError
+}
+
+/**
+ * Parses a [PluginBundleSource] into a [PluginBundle].
+ *
+ * The parser only enforces structural rules that determine whether the
+ * bundle is *readable*: size cap, manifest presence, manifest schema, and
+ * format version. Semantic checks (permission well-formedness, id rules,
+ * etc.) are the responsibility of [PluginBundleValidator].
+ */
+class PluginBundleParser(
+    private val maxBundleSizeBytes: Long = MAX_BUNDLE_SIZE_BYTES,
+    private val supportedFormatVersion: Int = CURRENT_BUNDLE_FORMAT_VERSION,
+) {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        classDiscriminator = "type"
+        encodeDefaults = true
+    }
+
+    fun parse(source: PluginBundleSource): BundleParseResult {
+        val totalSize = source.totalSize()
+        if (totalSize > maxBundleSizeBytes) {
+            return BundleParseResult.Failed(
+                BundleParseError.BundleTooLarge(
+                    sizeBytes = totalSize,
+                    limitBytes = maxBundleSizeBytes,
+                ),
+            )
+        }
+
+        val manifestBytes = source.readEntry(BUNDLE_MANIFEST_PATH)
+            ?: return BundleParseResult.Failed(BundleParseError.MissingManifest)
+
+        val bundleManifest = try {
+            json.decodeFromString(BundleManifest.serializer(), manifestBytes.decodeToString())
+        } catch (e: SerializationException) {
+            return BundleParseResult.Failed(
+                BundleParseError.InvalidManifest(e.message ?: "manifest.json failed to decode"),
+            )
+        } catch (e: IllegalArgumentException) {
+            return BundleParseResult.Failed(
+                BundleParseError.InvalidManifest(e.message ?: "manifest.json failed to decode"),
+            )
+        }
+
+        if (bundleManifest.bundleFormatVersion != supportedFormatVersion) {
+            return BundleParseResult.Failed(
+                BundleParseError.UnknownVersion(
+                    declared = bundleManifest.bundleFormatVersion,
+                    supported = supportedFormatVersion,
+                ),
+            )
+        }
+
+        val assets = source.entries()
+            .asSequence()
+            .filter { it.startsWith(BUNDLE_ASSETS_PREFIX) && it != BUNDLE_ASSETS_PREFIX }
+            .mapNotNull { path -> source.readEntry(path)?.let { path to it } }
+            .toMap()
+
+        val signature = source.readEntry(BUNDLE_SIGNATURE_PATH)
+
+        return BundleParseResult.Ok(
+            PluginBundle(
+                bundleFormatVersion = bundleManifest.bundleFormatVersion,
+                manifest = bundleManifest.plugin,
+                assets = assets,
+                signature = signature,
+            ),
+        )
+    }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/bundle/PluginBundleSignatureVerifier.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/bundle/PluginBundleSignatureVerifier.kt
@@ -1,0 +1,62 @@
+package link.socket.ampere.bundle
+
+import co.touchlab.kermit.Logger
+
+/**
+ * Outcome of [PluginBundleSignatureVerifier.verify].
+ *
+ * [Verified.Skipped] and [Verified.Trusted] are both safe to surface as
+ * "verified" to the user, but marketplace UI (W1.10) is expected to badge
+ * them differently — `Skipped` exists only because production crypto has
+ * not landed yet, and lets unsigned bundles flow through the import pipeline
+ * during W0/W1 without forcing the importer to special-case `null`.
+ */
+sealed interface PluginBundleSignatureVerification {
+
+    sealed interface Verified : PluginBundleSignatureVerification {
+
+        /** A real signature was checked against a trusted key. */
+        data object Trusted : Verified
+
+        /** No verification was performed. Production crypto is deferred. */
+        data object Skipped : Verified
+    }
+
+    /** A signature was present but did not validate. Bundle must be rejected. */
+    data class Invalid(val reason: String) : PluginBundleSignatureVerification
+}
+
+/**
+ * Verifies the detached signature on a [PluginBundle].
+ *
+ * The interface exists today so marketplace UI can wire its import pipeline
+ * against a stable surface. The default implementation,
+ * [NoOpPluginBundleSignatureVerifier], always returns [Verified.Skipped]
+ * with a logged warning. A real, key-pinned implementation lands in a
+ * follow-up ticket.
+ */
+fun interface PluginBundleSignatureVerifier {
+
+    suspend fun verify(bundle: PluginBundle): PluginBundleSignatureVerification
+}
+
+/**
+ * Default no-op signature verifier.
+ *
+ * Logs a warning the first time it is invoked per process so a stray
+ * production deployment cannot silently bypass signature checks. The
+ * follow-up production verifier replaces this object entirely; do not extend
+ * it.
+ */
+object NoOpPluginBundleSignatureVerifier : PluginBundleSignatureVerifier {
+
+    private val log = Logger.withTag("ampere/bundle/signature")
+
+    override suspend fun verify(bundle: PluginBundle): PluginBundleSignatureVerification {
+        log.w {
+            "Signature verification is stubbed (no-op). " +
+                "Bundle '${bundle.manifest.id}' v${bundle.manifest.version} accepted without crypto."
+        }
+        return PluginBundleSignatureVerification.Verified.Skipped
+    }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/bundle/PluginBundleSource.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/bundle/PluginBundleSource.kt
@@ -1,0 +1,58 @@
+package link.socket.ampere.bundle
+
+/**
+ * Read-only view over the entries of a plugin bundle.
+ *
+ * The parser is intentionally agnostic about how a bundle is laid out on disk
+ * — ZIP archives, on-disk directories, and in-memory test fixtures are all
+ * exposed through this interface. Concrete platform-specific implementations
+ * (e.g. ZIP-on-JVM) live alongside their platform's source set; commonMain
+ * ships only [MapBundleSource] for tests and trusted in-process callers.
+ */
+interface PluginBundleSource {
+
+    /**
+     * Lists every entry path in the bundle, relative to the bundle root.
+     *
+     * Paths use forward slashes regardless of host platform. Implementations
+     * must not include directory entries — only files that [readEntry] can
+     * resolve. The returned collection is not required to be sorted.
+     */
+    fun entries(): Set<String>
+
+    /**
+     * Returns the bytes for the entry at [path], or `null` if absent.
+     *
+     * Path matching is case-sensitive. Calls are expected to be idempotent;
+     * repeated reads of the same entry must return equal byte content.
+     */
+    fun readEntry(path: String): ByteArray?
+
+    /**
+     * Total byte size of the bundle, summed across every entry.
+     *
+     * Used by the parser to enforce the oversized-bundle guard before any
+     * entry is decoded. Implementations may compute this lazily but must
+     * return a stable value for a given source.
+     */
+    fun totalSize(): Long
+
+    companion object
+}
+
+/**
+ * In-memory [PluginBundleSource] backed by a map of entry paths to bytes.
+ *
+ * Suitable for tests and for callers that have already materialised a bundle
+ * (e.g. a freshly downloaded archive that has been unpacked into memory).
+ */
+class MapBundleSource(
+    private val entries: Map<String, ByteArray>,
+) : PluginBundleSource {
+
+    override fun entries(): Set<String> = entries.keys
+
+    override fun readEntry(path: String): ByteArray? = entries[path]
+
+    override fun totalSize(): Long = entries.values.sumOf { it.size.toLong() }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/bundle/PluginBundleValidator.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/bundle/PluginBundleValidator.kt
@@ -1,0 +1,74 @@
+package link.socket.ampere.bundle
+
+import link.socket.ampere.plugin.permission.PluginPermission
+
+/**
+ * Outcome of [PluginBundleValidator.validate].
+ *
+ * On success, the validator surfaces the de-duplicated permission set so the
+ * marketplace UI (W1.10) can present an authoritative consent dialog without
+ * re-walking the manifest. On failure, every reason is reported at once so
+ * callers can render a complete diagnostic instead of forcing a fix-and-retry
+ * loop.
+ */
+sealed interface BundleValidation {
+
+    data class Ok(val permissions: List<PluginPermission>) : BundleValidation
+
+    data class Failed(val reasons: List<String>) : BundleValidation
+}
+
+/**
+ * Semantic validator for a parsed [PluginBundle].
+ *
+ * Distinct from [PluginBundleParser]: the parser ensures the bundle is
+ * *readable*; the validator ensures it is *importable*. Failures here are
+ * recoverable by the plugin author (fix the manifest) rather than the host
+ * runtime.
+ */
+class PluginBundleValidator {
+
+    fun validate(bundle: PluginBundle): BundleValidation {
+        val reasons = mutableListOf<String>()
+
+        if (bundle.bundleFormatVersion != CURRENT_BUNDLE_FORMAT_VERSION) {
+            reasons += "Unsupported bundleFormatVersion ${bundle.bundleFormatVersion}; " +
+                "this build understands $CURRENT_BUNDLE_FORMAT_VERSION."
+        }
+
+        val manifest = bundle.manifest
+        if (manifest.id.isBlank()) reasons += "manifest.id is blank."
+        if (manifest.name.isBlank()) reasons += "manifest.name is blank."
+        if (manifest.version.isBlank()) reasons += "manifest.version is blank."
+
+        manifest.requiredPermissions.forEachIndexed { index, permission ->
+            val permissionReason = validatePermission(permission, index)
+            if (permissionReason != null) reasons += permissionReason
+        }
+
+        if (bundle.signature != null && bundle.signature.isEmpty()) {
+            reasons += "signature.sig is present but empty."
+        }
+
+        return if (reasons.isEmpty()) {
+            BundleValidation.Ok(permissions = manifest.requiredPermissions.distinct())
+        } else {
+            BundleValidation.Failed(reasons = reasons.toList())
+        }
+    }
+
+    private fun validatePermission(permission: PluginPermission, index: Int): String? {
+        val (field, value) = when (permission) {
+            is PluginPermission.NetworkDomain -> "host" to permission.host
+            is PluginPermission.MCPServer -> "uri" to permission.uri
+            is PluginPermission.KnowledgeQuery -> "scope" to permission.scope
+            is PluginPermission.NativeAction -> "actionId" to permission.actionId
+            is PluginPermission.LinkAccess -> "linkId" to permission.linkId
+        }
+        return if (value.isBlank()) {
+            "requiredPermissions[$index] (${permission::class.simpleName}) has blank $field."
+        } else {
+            null
+        }
+    }
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/bundle/PluginBundleParserTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/bundle/PluginBundleParserTest.kt
@@ -1,0 +1,157 @@
+package link.socket.ampere.bundle
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+import link.socket.ampere.plugin.PluginManifest
+import link.socket.ampere.plugin.permission.PluginPermission
+
+class PluginBundleParserTest {
+
+    private val json = Json {
+        classDiscriminator = "type"
+        encodeDefaults = true
+    }
+
+    private val parser = PluginBundleParser()
+
+    @Test
+    fun `happy path parses manifest assets and signature`() {
+        val manifest = BundleManifest(
+            bundleFormatVersion = 1,
+            plugin = PluginManifest(
+                id = "github-plugin",
+                name = "GitHub Plugin",
+                version = "1.0.0",
+                requiredPermissions = listOf(
+                    PluginPermission.NetworkDomain("api.github.com"),
+                ),
+            ),
+        )
+        val source = MapBundleSource(
+            mapOf(
+                BUNDLE_MANIFEST_PATH to json.encodeToString(BundleManifest.serializer(), manifest)
+                    .encodeToByteArray(),
+                "assets/icon.png" to byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47),
+                BUNDLE_SIGNATURE_PATH to byteArrayOf(0x01, 0x02, 0x03),
+            ),
+        )
+
+        val result = parser.parse(source)
+
+        val ok = assertIs<BundleParseResult.Ok>(result)
+        assertEquals(1, ok.bundle.bundleFormatVersion)
+        assertEquals(manifest.plugin, ok.bundle.manifest)
+        assertEquals(setOf("assets/icon.png"), ok.bundle.assets.keys)
+        assertTrue(
+            byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47).contentEquals(ok.bundle.assets.getValue("assets/icon.png")),
+        )
+        assertTrue(byteArrayOf(0x01, 0x02, 0x03).contentEquals(ok.bundle.signature!!))
+    }
+
+    @Test
+    fun `bundle without optional entries omits assets and signature`() {
+        val manifest = BundleManifest(
+            bundleFormatVersion = 1,
+            plugin = PluginManifest(id = "x", name = "X", version = "0.1.0"),
+        )
+        val source = MapBundleSource(
+            mapOf(
+                BUNDLE_MANIFEST_PATH to json.encodeToString(BundleManifest.serializer(), manifest)
+                    .encodeToByteArray(),
+            ),
+        )
+
+        val ok = assertIs<BundleParseResult.Ok>(parser.parse(source))
+
+        assertEquals(emptyMap(), ok.bundle.assets)
+        assertEquals(null, ok.bundle.signature)
+    }
+
+    @Test
+    fun `missing manifest returns MissingManifest`() {
+        val source = MapBundleSource(
+            mapOf("assets/readme.txt" to "hello".encodeToByteArray()),
+        )
+
+        val failed = assertIs<BundleParseResult.Failed>(parser.parse(source))
+        assertEquals(BundleParseError.MissingManifest, failed.error)
+    }
+
+    @Test
+    fun `invalid manifest schema returns InvalidManifest`() {
+        val source = MapBundleSource(
+            mapOf(BUNDLE_MANIFEST_PATH to "{ this is not valid json".encodeToByteArray()),
+        )
+
+        val failed = assertIs<BundleParseResult.Failed>(parser.parse(source))
+        assertIs<BundleParseError.InvalidManifest>(failed.error)
+    }
+
+    @Test
+    fun `manifest missing required fields returns InvalidManifest`() {
+        val source = MapBundleSource(
+            mapOf(
+                BUNDLE_MANIFEST_PATH to """{"bundleFormatVersion": 1}""".encodeToByteArray(),
+            ),
+        )
+
+        val failed = assertIs<BundleParseResult.Failed>(parser.parse(source))
+        assertIs<BundleParseError.InvalidManifest>(failed.error)
+    }
+
+    @Test
+    fun `oversized bundle returns BundleTooLarge`() {
+        val parserWithSmallLimit = PluginBundleParser(maxBundleSizeBytes = 16)
+        val source = MapBundleSource(
+            mapOf(
+                BUNDLE_MANIFEST_PATH to """{"bundleFormatVersion":1,"plugin":{"id":"x","name":"x","version":"1"}}"""
+                    .encodeToByteArray(),
+                "assets/big.bin" to ByteArray(1024),
+            ),
+        )
+
+        val failed = assertIs<BundleParseResult.Failed>(parserWithSmallLimit.parse(source))
+        val tooLarge = assertIs<BundleParseError.BundleTooLarge>(failed.error)
+        assertEquals(16L, tooLarge.limitBytes)
+        assertTrue(tooLarge.sizeBytes > 16L)
+    }
+
+    @Test
+    fun `unknown bundleFormatVersion returns UnknownVersion`() {
+        val source = MapBundleSource(
+            mapOf(
+                BUNDLE_MANIFEST_PATH to """
+                    {
+                      "bundleFormatVersion": 999,
+                      "plugin": { "id": "x", "name": "x", "version": "1.0.0" }
+                    }
+                """.trimIndent().encodeToByteArray(),
+            ),
+        )
+
+        val failed = assertIs<BundleParseResult.Failed>(parser.parse(source))
+        val unknown = assertIs<BundleParseError.UnknownVersion>(failed.error)
+        assertEquals(999, unknown.declared)
+        assertEquals(CURRENT_BUNDLE_FORMAT_VERSION, unknown.supported)
+    }
+
+    @Test
+    fun `unknown manifest fields are tolerated`() {
+        val source = MapBundleSource(
+            mapOf(
+                BUNDLE_MANIFEST_PATH to """
+                    {
+                      "bundleFormatVersion": 1,
+                      "plugin": { "id": "x", "name": "x", "version": "1.0.0" },
+                      "futureField": "ignored"
+                    }
+                """.trimIndent().encodeToByteArray(),
+            ),
+        )
+
+        assertIs<BundleParseResult.Ok>(parser.parse(source))
+    }
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/bundle/PluginBundleSignatureVerifierTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/bundle/PluginBundleSignatureVerifierTest.kt
@@ -1,0 +1,34 @@
+package link.socket.ampere.bundle
+
+import kotlin.test.Test
+import kotlin.test.assertSame
+import kotlinx.coroutines.test.runTest
+import link.socket.ampere.plugin.PluginManifest
+
+class PluginBundleSignatureVerifierTest {
+
+    private val bundle = PluginBundle(
+        bundleFormatVersion = 1,
+        manifest = PluginManifest(id = "x", name = "X", version = "1.0.0"),
+        assets = emptyMap(),
+        signature = byteArrayOf(0x01, 0x02),
+    )
+
+    @Test
+    fun `default no-op verifier returns Verified Skipped`() = runTest {
+        val result = NoOpPluginBundleSignatureVerifier.verify(bundle)
+        assertSame(PluginBundleSignatureVerification.Verified.Skipped, result)
+    }
+
+    @Test
+    fun `default no-op verifier returns Verified Skipped even when signature is absent`() = runTest {
+        val unsigned = PluginBundle(
+            bundleFormatVersion = 1,
+            manifest = PluginManifest(id = "x", name = "X", version = "1.0.0"),
+            assets = emptyMap(),
+            signature = null,
+        )
+        val result = NoOpPluginBundleSignatureVerifier.verify(unsigned)
+        assertSame(PluginBundleSignatureVerification.Verified.Skipped, result)
+    }
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/bundle/PluginBundleValidatorTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/bundle/PluginBundleValidatorTest.kt
@@ -1,0 +1,134 @@
+package link.socket.ampere.bundle
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import link.socket.ampere.plugin.PluginManifest
+import link.socket.ampere.plugin.permission.PluginPermission
+
+class PluginBundleValidatorTest {
+
+    private val validator = PluginBundleValidator()
+
+    private fun bundle(
+        manifest: PluginManifest = PluginManifest(id = "x", name = "X", version = "1.0.0"),
+        bundleFormatVersion: Int = CURRENT_BUNDLE_FORMAT_VERSION,
+        signature: ByteArray? = null,
+        assets: Map<String, ByteArray> = emptyMap(),
+    ): PluginBundle = PluginBundle(
+        bundleFormatVersion = bundleFormatVersion,
+        manifest = manifest,
+        assets = assets,
+        signature = signature,
+    )
+
+    @Test
+    fun `well-formed bundle validates and surfaces deduplicated permissions`() {
+        val permissions = listOf(
+            PluginPermission.NetworkDomain("api.github.com"),
+            PluginPermission.NetworkDomain("api.github.com"),
+            PluginPermission.MCPServer("mcp://github"),
+        )
+        val result = validator.validate(
+            bundle(
+                manifest = PluginManifest(
+                    id = "github-plugin",
+                    name = "GitHub",
+                    version = "1.0.0",
+                    requiredPermissions = permissions,
+                ),
+            ),
+        )
+
+        val ok = assertIs<BundleValidation.Ok>(result)
+        assertEquals(
+            listOf(
+                PluginPermission.NetworkDomain("api.github.com"),
+                PluginPermission.MCPServer("mcp://github"),
+            ),
+            ok.permissions,
+        )
+    }
+
+    @Test
+    fun `unsupported bundleFormatVersion is reported`() {
+        val result = validator.validate(bundle(bundleFormatVersion = 999))
+        val failed = assertIs<BundleValidation.Failed>(result)
+        assertTrue(failed.reasons.any { it.contains("bundleFormatVersion 999") })
+    }
+
+    @Test
+    fun `blank manifest id is reported`() {
+        val result = validator.validate(
+            bundle(manifest = PluginManifest(id = "  ", name = "x", version = "1.0.0")),
+        )
+        val failed = assertIs<BundleValidation.Failed>(result)
+        assertEquals(listOf("manifest.id is blank."), failed.reasons)
+    }
+
+    @Test
+    fun `blank manifest name is reported`() {
+        val result = validator.validate(
+            bundle(manifest = PluginManifest(id = "x", name = "", version = "1.0.0")),
+        )
+        val failed = assertIs<BundleValidation.Failed>(result)
+        assertEquals(listOf("manifest.name is blank."), failed.reasons)
+    }
+
+    @Test
+    fun `blank manifest version is reported`() {
+        val result = validator.validate(
+            bundle(manifest = PluginManifest(id = "x", name = "x", version = "")),
+        )
+        val failed = assertIs<BundleValidation.Failed>(result)
+        assertEquals(listOf("manifest.version is blank."), failed.reasons)
+    }
+
+    @Test
+    fun `blank permission discriminator field is reported per variant`() {
+        val variants: List<Pair<PluginPermission, String>> = listOf(
+            PluginPermission.NetworkDomain("") to "host",
+            PluginPermission.MCPServer(" ") to "uri",
+            PluginPermission.KnowledgeQuery("") to "scope",
+            PluginPermission.NativeAction("") to "actionId",
+            PluginPermission.LinkAccess(" ") to "linkId",
+        )
+
+        variants.forEach { (permission, field) ->
+            val result = validator.validate(
+                bundle(
+                    manifest = PluginManifest(
+                        id = "x",
+                        name = "x",
+                        version = "1.0.0",
+                        requiredPermissions = listOf(permission),
+                    ),
+                ),
+            )
+            val failed = assertIs<BundleValidation.Failed>(result)
+            assertEquals(1, failed.reasons.size)
+            assertTrue(failed.reasons.single().contains(field))
+            assertTrue(failed.reasons.single().contains(permission::class.simpleName!!))
+        }
+    }
+
+    @Test
+    fun `empty signature is reported`() {
+        val result = validator.validate(bundle(signature = ByteArray(0)))
+        val failed = assertIs<BundleValidation.Failed>(result)
+        assertEquals(listOf("signature.sig is present but empty."), failed.reasons)
+    }
+
+    @Test
+    fun `multiple failures are reported together`() {
+        val result = validator.validate(
+            bundle(
+                bundleFormatVersion = 999,
+                manifest = PluginManifest(id = "", name = "", version = ""),
+            ),
+        )
+        val failed = assertIs<BundleValidation.Failed>(result)
+        assertTrue(failed.reasons.size >= 4)
+    }
+}

--- a/ampere-core/src/jvmMain/kotlin/link/socket/ampere/bundle/PluginBundleSource.jvm.kt
+++ b/ampere-core/src/jvmMain/kotlin/link/socket/ampere/bundle/PluginBundleSource.jvm.kt
@@ -1,0 +1,27 @@
+package link.socket.ampere.bundle
+
+import okio.FileSystem
+import okio.Path
+import okio.Path.Companion.toPath
+import okio.openZip
+
+/**
+ * Reads a bundle from a ZIP archive at [zipFile].
+ *
+ * Lives in jvmMain because [FileSystem.openZip] is JVM-only in okio 3.11.
+ * Other targets currently must unpack the archive and use
+ * [PluginBundleSource.fromDirectory]; an iOS/Native ZIP reader is a
+ * follow-up.
+ *
+ * The ZIP is opened read-only; the underlying file handle is held for the
+ * lifetime of the returned source. Bundles are imported once and discarded,
+ * so this is fine in practice — but do not retain the source longer than
+ * the import operation.
+ */
+fun PluginBundleSource.Companion.fromZipFile(
+    zipFile: Path,
+    fileSystem: FileSystem,
+): PluginBundleSource = OkioPluginBundleSource(
+    fileSystem = fileSystem.openZip(zipFile),
+    root = "/".toPath(),
+)

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/bundle/OkioPluginBundleSourceTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/bundle/OkioPluginBundleSourceTest.kt
@@ -1,0 +1,137 @@
+package link.socket.ampere.bundle
+
+import java.nio.file.Files
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import kotlin.io.path.createDirectories
+import kotlin.io.path.writeBytes
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+import link.socket.ampere.plugin.PluginManifest
+import link.socket.ampere.plugin.permission.PluginPermission
+import okio.FileSystem
+import okio.Path.Companion.toOkioPath
+
+class OkioPluginBundleSourceTest {
+
+    private val tempRoot = Files.createTempDirectory("plugin-bundle-test")
+    private val json = Json {
+        classDiscriminator = "type"
+        encodeDefaults = true
+    }
+    private val parser = PluginBundleParser()
+
+    private val fixtureManifest = BundleManifest(
+        bundleFormatVersion = 1,
+        plugin = PluginManifest(
+            id = "github-plugin",
+            name = "GitHub Plugin",
+            version = "1.0.0",
+            requiredPermissions = listOf(
+                PluginPermission.NetworkDomain("api.github.com"),
+                PluginPermission.MCPServer("mcp://github"),
+            ),
+        ),
+    )
+    private val fixtureManifestBytes: ByteArray =
+        json.encodeToString(BundleManifest.serializer(), fixtureManifest).encodeToByteArray()
+    private val fixtureIcon = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A)
+    private val fixtureSignature = byteArrayOf(0x73, 0x69, 0x67)
+
+    @AfterTest
+    fun tearDown() {
+        Files.walk(tempRoot)
+            .sorted(Comparator.reverseOrder())
+            .forEach(Files::deleteIfExists)
+    }
+
+    @Test
+    fun `fromDirectory parses a bundle laid out on disk`() {
+        val bundleDir = tempRoot.resolve("bundle").also { it.createDirectories() }
+        bundleDir.resolve(BUNDLE_MANIFEST_PATH).writeBytes(fixtureManifestBytes)
+        bundleDir.resolve("assets").createDirectories()
+        bundleDir.resolve("assets/icon.png").writeBytes(fixtureIcon)
+        bundleDir.resolve(BUNDLE_SIGNATURE_PATH).writeBytes(fixtureSignature)
+
+        val source = PluginBundleSource.fromDirectory(bundleDir.toOkioPath(), FileSystem.SYSTEM)
+        val ok = assertIs<BundleParseResult.Ok>(parser.parse(source))
+
+        assertEquals(fixtureManifest.plugin, ok.bundle.manifest)
+        assertContentEquals(fixtureIcon, ok.bundle.assets.getValue("assets/icon.png"))
+        assertContentEquals(fixtureSignature, ok.bundle.signature)
+    }
+
+    @Test
+    fun `fromDirectory handles a directory with no assets and no signature`() {
+        val bundleDir = tempRoot.resolve("minimal").also { it.createDirectories() }
+        bundleDir.resolve(BUNDLE_MANIFEST_PATH).writeBytes(fixtureManifestBytes)
+
+        val source = PluginBundleSource.fromDirectory(bundleDir.toOkioPath(), FileSystem.SYSTEM)
+        val ok = assertIs<BundleParseResult.Ok>(parser.parse(source))
+
+        assertEquals(emptyMap(), ok.bundle.assets)
+        assertNull(ok.bundle.signature)
+    }
+
+    @Test
+    fun `fromDirectory on a missing path surfaces MissingManifest via parser`() {
+        val ghost = tempRoot.resolve("does-not-exist").toOkioPath()
+
+        val source = PluginBundleSource.fromDirectory(ghost, FileSystem.SYSTEM)
+        val failed = assertIs<BundleParseResult.Failed>(parser.parse(source))
+
+        assertEquals(BundleParseError.MissingManifest, failed.error)
+    }
+
+    @Test
+    fun `fromZipFile parses a bundle stored as a ZIP archive`() {
+        val zipFile = tempRoot.resolve("bundle.zip")
+        ZipOutputStream(Files.newOutputStream(zipFile)).use { zip ->
+            zip.putEntry(BUNDLE_MANIFEST_PATH, fixtureManifestBytes)
+            zip.putEntry("assets/icon.png", fixtureIcon)
+            zip.putEntry(BUNDLE_SIGNATURE_PATH, fixtureSignature)
+        }
+
+        val source = PluginBundleSource.fromZipFile(zipFile.toOkioPath(), FileSystem.SYSTEM)
+        val ok = assertIs<BundleParseResult.Ok>(parser.parse(source))
+
+        assertEquals(fixtureManifest.plugin, ok.bundle.manifest)
+        assertContentEquals(fixtureIcon, ok.bundle.assets.getValue("assets/icon.png"))
+        assertContentEquals(fixtureSignature, ok.bundle.signature)
+    }
+
+    @Test
+    fun `fromZipFile entries are keyed identically to fromDirectory`() {
+        val bundleDir = tempRoot.resolve("dir-bundle").also { it.createDirectories() }
+        bundleDir.resolve(BUNDLE_MANIFEST_PATH).writeBytes(fixtureManifestBytes)
+        bundleDir.resolve("assets").createDirectories()
+        bundleDir.resolve("assets/icon.png").writeBytes(fixtureIcon)
+
+        val zipFile = tempRoot.resolve("zip-bundle.zip")
+        ZipOutputStream(Files.newOutputStream(zipFile)).use { zip ->
+            zip.putEntry(BUNDLE_MANIFEST_PATH, fixtureManifestBytes)
+            zip.putEntry("assets/icon.png", fixtureIcon)
+        }
+
+        val dirEntries =
+            PluginBundleSource.fromDirectory(bundleDir.toOkioPath(), FileSystem.SYSTEM).entries()
+        val zipEntries =
+            PluginBundleSource.fromZipFile(zipFile.toOkioPath(), FileSystem.SYSTEM).entries()
+
+        assertEquals(dirEntries, zipEntries)
+        assertTrue(BUNDLE_MANIFEST_PATH in dirEntries)
+        assertTrue("assets/icon.png" in dirEntries)
+    }
+
+    private fun ZipOutputStream.putEntry(path: String, bytes: ByteArray) {
+        putNextEntry(ZipEntry(path))
+        write(bytes)
+        closeEntry()
+    }
+}

--- a/docs/ampere/plugin-bundle-format.md
+++ b/docs/ampere/plugin-bundle-format.md
@@ -1,0 +1,153 @@
+# Plugin bundle format
+
+A **plugin bundle** is the portable distribution unit Ampere uses to ship plugins outside the in-repo tree. The marketplace (W1.10) and share-sheet import (W1.11) both consume bundles. This document is the source of truth for the on-disk layout, manifest schema, signature surface, and forward-compatibility rules.
+
+## Design goals
+
+- **Portable.** A bundle is a flat set of files keyed by forward-slash paths. Hosts may ship bundles as ZIP archives, on-disk directories, or in-memory blobs; the parser is agnostic.
+- **Versioned.** Every bundle declares a `bundleFormatVersion`. Parsers reject unknown versions with a typed error rather than guessing.
+- **Schema-driven.** The manifest is `kotlinx.serialization` JSON over the W0.1 [`PluginManifest`][PluginManifest] type. Permissions reuse the W0.1 [`PluginPermission`][PluginPermission] schema verbatim — bundles never redefine the permission shape.
+- **Trust-aware but crypto-deferred.** A detached signature surface ships now so marketplace UI can wire its import pipeline. Real verification lands in a follow-up; today's default returns `Verified.Skipped` with a logged warning.
+
+## Layout
+
+A bundle is a set of entries at known paths. All paths are relative to the bundle root, use forward slashes, and are case-sensitive.
+
+| Path | Required | Purpose |
+| --- | --- | --- |
+| `manifest.json` | Yes | Bundle metadata (`BundleManifest`) — see [Manifest schema](#manifest-schema). |
+| `assets/**` | No | Arbitrary plugin-owned files (icons, sample data, vendored prompts). Parsed entries are keyed by their full path including the `assets/` prefix. |
+| `signature.sig` | No | Detached signature over `manifest.json`. Verification is stubbed (`Verified.Skipped`) until production crypto lands. |
+
+Unknown top-level entries are ignored by the parser. This keeps the format additive: future revisions may stage new optional entries without breaking older parsers, provided the `bundleFormatVersion` is bumped when their presence is *required*.
+
+## Manifest schema
+
+`manifest.json` decodes to `link.socket.ampere.bundle.BundleManifest`:
+
+```json
+{
+  "bundleFormatVersion": 1,
+  "plugin": {
+    "id": "github-plugin",
+    "name": "GitHub Plugin",
+    "version": "1.0.0",
+    "description": "Open and review GitHub PRs from inside Ampere.",
+    "entrypoint": "main",
+    "requiredPermissions": [
+      { "type": "network_domain", "host": "api.github.com" },
+      { "type": "mcp_server", "uri": "mcp://github" }
+    ]
+  }
+}
+```
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `bundleFormatVersion` | `Int` | Yes | Currently `1`. Parsers reject any other value with `UnknownVersion`. |
+| `plugin` | `PluginManifest` | Yes | The W0.1 plugin manifest, embedded verbatim. |
+| `plugin.id` | `String` | Yes | Stable identifier; must be non-blank. |
+| `plugin.name` | `String` | Yes | Human-readable name; must be non-blank. |
+| `plugin.version` | `String` | Yes | Plugin's own version; must be non-blank. Independent of `bundleFormatVersion`. |
+| `plugin.description` | `String?` | No | Free-form description. |
+| `plugin.entrypoint` | `String?` | No | Plugin-defined entry handle; opaque to the bundle format. |
+| `plugin.requiredPermissions` | `List<PluginPermission>` | No (defaults to `[]`) | W0.1 permission objects. |
+
+`PluginPermission` uses `type` as its discriminator and is reused unchanged from W0.1. See [`PluginPermission.kt`][PluginPermission] for the closed set of variants (`network_domain`, `mcp_server`, `knowledge_query`, `native_action`, `link_access`).
+
+## Reading a bundle
+
+`PluginBundleParser` runs in commonMain. It accepts a `PluginBundleSource` — an abstraction over "a set of named byte entries". Three concrete sources ship today:
+
+| Source | Source set | Use |
+| --- | --- | --- |
+| `MapBundleSource` | commonMain | Tests and callers that already have entries materialised in memory. |
+| `PluginBundleSource.fromDirectory(path, fileSystem)` | commonMain | Bundle laid out as a directory tree under `path`, read via okio. |
+| `PluginBundleSource.fromZipFile(path, fileSystem)` | jvmMain | ZIP archive, opened read-only via `FileSystem.openZip`. JVM-only because okio's `openZip` is JVM-only in 3.11; iOS/Native ZIP support is a follow-up. |
+
+Both okio-backed factories yield identical entry keys for the same bundle whether shipped as a directory or a ZIP, so consumers can pick a layout without changing downstream code.
+
+```kotlin
+val parser = PluginBundleParser()
+when (val result = parser.parse(source)) {
+    is BundleParseResult.Ok -> handle(result.bundle)
+    is BundleParseResult.Failed -> when (val error = result.error) {
+        BundleParseError.MissingManifest -> /* manifest.json absent */
+        is BundleParseError.InvalidManifest -> /* JSON or schema failure: error.message */
+        is BundleParseError.BundleTooLarge -> /* error.sizeBytes vs error.limitBytes */
+        is BundleParseError.UnknownVersion -> /* error.declared vs error.supported */
+    }
+}
+```
+
+The parser enforces **structural** rules only:
+
+1. Total entry size must not exceed `MAX_BUNDLE_SIZE_BYTES` (50 MiB by default; configurable for hosted environments with larger budgets).
+2. `manifest.json` must exist.
+3. `manifest.json` must decode against `BundleManifest`.
+4. `bundleFormatVersion` must equal the build's `CURRENT_BUNDLE_FORMAT_VERSION`.
+
+A bundle that passes parsing is *readable*; it is not yet *importable*.
+
+## Validating a bundle
+
+`PluginBundleValidator` runs over a parsed `PluginBundle` and enforces semantic rules. It returns `BundleValidation.Ok(permissions)` or `BundleValidation.Failed(reasons)` with **every** reason at once — callers can render a complete diagnostic without forcing a fix-and-retry loop.
+
+Failure modes today:
+
+| Mode | Trigger |
+| --- | --- |
+| Unsupported version | `bundleFormatVersion` mismatches `CURRENT_BUNDLE_FORMAT_VERSION` (defence in depth — the parser already rejects this). |
+| Blank `id` / `name` / `version` | Any of the required `PluginManifest` strings is empty or whitespace. |
+| Blank permission field | A `PluginPermission` variant carries an empty discriminator field (e.g. `NetworkDomain.host`). |
+| Empty signature | `signature.sig` is present but zero bytes. |
+
+`BundleValidation.Ok` surfaces the de-duplicated permission list so consent UI can render a single authoritative list.
+
+## Signature surface
+
+```kotlin
+fun interface PluginBundleSignatureVerifier {
+    suspend fun verify(bundle: PluginBundle): PluginBundleSignatureVerification
+}
+```
+
+`PluginBundleSignatureVerification` is sealed:
+
+| Variant | Meaning |
+| --- | --- |
+| `Verified.Trusted` | A real signature was checked against a trusted key. |
+| `Verified.Skipped` | No crypto was performed. The default no-op verifier returns this. |
+| `Invalid(reason)` | A signature was present but did not validate; the bundle must be rejected. |
+
+The default `NoOpPluginBundleSignatureVerifier` always returns `Verified.Skipped` and logs a warning so a stray production deployment cannot silently bypass signature checks. Marketplace UI is expected to badge `Verified.Skipped` differently from `Verified.Trusted` even before real crypto lands.
+
+Production crypto (key pinning, signature algorithm, distribution of trust roots) is **intentionally deferred** to a follow-up ticket. This ticket establishes only the surface so the import pipeline can be wired now.
+
+## Versioning rules
+
+`CURRENT_BUNDLE_FORMAT_VERSION` is `1` today.
+
+- **Bump** the version when a structural change is made: a required entry is added or removed, on-disk encoding changes, the meaning of a path changes.
+- **Do not bump** the version when adding optional fields with defaults to `PluginManifest` or `BundleManifest` — those are source-compatible and decode unchanged.
+- Old hosts encountering a new version see `BundleParseError.UnknownVersion(declared, supported)` and can render a clear "upgrade required" message rather than a generic parse failure.
+
+A v999 bundle today returns `UnknownVersion(999, 1)` rather than crashing. This is the forward-compatibility contract; tests in `commonTest` pin it.
+
+## File reference
+
+| Symbol | Location |
+| --- | --- |
+| `BundleManifest` | `commonMain/.../bundle/PluginBundle.kt` |
+| `PluginBundle` | `commonMain/.../bundle/PluginBundle.kt` |
+| `PluginBundleSource`, `MapBundleSource` | `commonMain/.../bundle/PluginBundleSource.kt` |
+| `OkioPluginBundleSource`, `fromDirectory` | `commonMain/.../bundle/OkioPluginBundleSource.kt` |
+| `fromZipFile` | `jvmMain/.../bundle/PluginBundleSource.jvm.kt` |
+| `PluginBundleParser`, `BundleParseResult`, `BundleParseError` | `commonMain/.../bundle/PluginBundleParser.kt` |
+| `PluginBundleValidator`, `BundleValidation` | `commonMain/.../bundle/PluginBundleValidator.kt` |
+| `PluginBundleSignatureVerifier`, `PluginBundleSignatureVerification`, `NoOpPluginBundleSignatureVerifier` | `commonMain/.../bundle/PluginBundleSignatureVerifier.kt` |
+| `PluginManifest` | `commonMain/.../plugin/PluginManifest.kt` |
+| `PluginPermission` | `commonMain/.../plugin/permission/PluginPermission.kt` |
+
+[PluginManifest]: ../../ampere-core/src/commonMain/kotlin/link/socket/ampere/plugin/PluginManifest.kt
+[PluginPermission]: ../../ampere-core/src/commonMain/kotlin/link/socket/ampere/plugin/permission/PluginPermission.kt


### PR DESCRIPTION
## Summary

- Defines the W0.6 portable Plugin bundle format (`manifest.json` + optional `assets/` + optional `signature.sig`) with a versioned schema referencing the W0.1 `PluginManifest`/`PluginPermission` types verbatim.
- Adds `PluginBundleParser` (typed errors: `MissingManifest`, `InvalidManifest`, `BundleTooLarge`, `UnknownVersion`), `PluginBundleValidator` (schema + permission enumeration), and a stubbed `PluginBundleSignatureVerifier` returning `Verified.Skipped` so W1.10 marketplace UI can wire against a stable surface while production crypto is still pending.
- Ships three concrete sources — `MapBundleSource` (commonMain), `PluginBundleSource.fromDirectory` (commonMain via okio), and `PluginBundleSource.fromZipFile` (jvmMain; `openZip` is JVM-only in okio 3.11).

Closes #463

## Test plan

- [x] `./gradlew :ampere-core:jvmTest` — 23 new bundle tests pass; full module suite green
- [x] `./gradlew jvmTest` — full repo green
- [x] `./gradlew :ampere-core:ktlintFormat` clean
- [x] Forward-compat: v999 bundle returns `UnknownVersion(999, 1)`
- [x] dir-vs-ZIP entry parity asserted in `OkioPluginBundleSourceTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)