### PR TITLE
AMPR-156 #465: add plugin-callable knowledge query primitive

### DIFF
--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/knowledge/HybridQueryRanker.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/knowledge/HybridQueryRanker.kt
@@ -1,0 +1,96 @@
+package link.socket.ampere.knowledge
+
+/**
+ * Blends a semantic ([QueryMode.SEMANTIC]) and a keyword ([QueryMode.KEYWORD])
+ * result list into a single [QueryMode.HYBRID] ranking.
+ *
+ * Each input list is independently max-normalised so its top hit becomes
+ * `1.0`. The two normalised scores are then combined via a weighted sum:
+ *
+ * ```
+ * hybrid = semanticWeight * semantic_norm + keywordWeight * keyword_norm
+ * ```
+ *
+ * Chunks present in only one list have score `0` for the other dimension,
+ * so they still surface — they just rank below chunks that appear in both.
+ *
+ * The weights default to `0.5 / 0.5`. They are configurable but intentionally
+ * not auto-tuned in this ticket; downstream platform pipelines may revisit
+ * once real corpora exist.
+ *
+ * Stateless and pure: no I/O, no allocation beyond the result list. Safe to
+ * share across coroutines.
+ */
+class HybridQueryRanker(
+    val semanticWeight: Float = DEFAULT_SEMANTIC_WEIGHT,
+    val keywordWeight: Float = DEFAULT_KEYWORD_WEIGHT,
+) {
+
+    init {
+        require(semanticWeight >= 0f) { "semanticWeight must be >= 0, got $semanticWeight" }
+        require(keywordWeight >= 0f) { "keywordWeight must be >= 0, got $keywordWeight" }
+        require(semanticWeight + keywordWeight > 0f) {
+            "At least one weight must be positive (semantic=$semanticWeight, keyword=$keywordWeight)"
+        }
+    }
+
+    /**
+     * Combine [semanticResults] and [keywordResults] into a single ranked list.
+     *
+     * Each input list is normalised independently. The output is ordered by
+     * descending blended score and truncated to [limit].
+     *
+     * Inputs may carry duplicate chunk IDs (from earlier merge passes) — the
+     * highest score per chunk in each list is used.
+     */
+    fun rank(
+        semanticResults: List<KnowledgeQueryResult>,
+        keywordResults: List<KnowledgeQueryResult>,
+        limit: Int = KnowledgeStore.DEFAULT_QUERY_LIMIT,
+    ): List<KnowledgeQueryResult> {
+        require(limit > 0) { "limit must be positive, got $limit" }
+
+        val semanticById = bestScoresById(semanticResults)
+        val keywordById = bestScoresById(keywordResults)
+
+        val semanticMax = semanticById.values.maxOrNull() ?: 0f
+        val keywordMax = keywordById.values.maxOrNull() ?: 0f
+
+        // Pick a canonical KnowledgeQueryResult per chunk id so we keep the
+        // underlying chunk + sourceUri + scopes when blending. Prefer the
+        // semantic hit so its enrichment wins ties (semantic queries usually
+        // walk the document table; keyword search may not).
+        val canonicalById = mutableMapOf<String, KnowledgeQueryResult>()
+        keywordResults.forEach { canonicalById.putIfAbsent(it.chunk.id, it) }
+        semanticResults.forEach { canonicalById[it.chunk.id] = it }
+
+        return canonicalById.values
+            .map { hit ->
+                val semanticNorm = normalise(semanticById[hit.chunk.id] ?: 0f, semanticMax)
+                val keywordNorm = normalise(keywordById[hit.chunk.id] ?: 0f, keywordMax)
+                val blended = semanticWeight * semanticNorm + keywordWeight * keywordNorm
+                hit.copy(score = blended)
+            }
+            .sortedByDescending { it.score }
+            .take(limit)
+    }
+
+    private fun bestScoresById(results: List<KnowledgeQueryResult>): Map<String, Float> {
+        val byId = mutableMapOf<String, Float>()
+        results.forEach { hit ->
+            val current = byId[hit.chunk.id]
+            if (current == null || hit.score > current) {
+                byId[hit.chunk.id] = hit.score
+            }
+        }
+        return byId
+    }
+
+    private fun normalise(score: Float, max: Float): Float =
+        if (max <= 0f) 0f else (score / max).coerceIn(0f, 1f)
+
+    companion object {
+        const val DEFAULT_SEMANTIC_WEIGHT: Float = 0.5f
+        const val DEFAULT_KEYWORD_WEIGHT: Float = 0.5f
+    }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/knowledge/KnowledgeScope.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/knowledge/KnowledgeScope.kt
@@ -1,0 +1,44 @@
+package link.socket.ampere.knowledge
+
+import kotlinx.serialization.Serializable
+
+/**
+ * A named scope tag that partitions [KnowledgeDocument]s for permission gating
+ * and filtered retrieval.
+ *
+ * Plugins request `knowledge.query(text, scope)` and the on-device
+ * [KnowledgeStore] only surfaces chunks whose document is tagged with at least
+ * one of the requested scopes.
+ * [PluginPermission.KnowledgeQuery][link.socket.ampere.plugin.permission.PluginPermission.KnowledgeQuery]
+ * gates which scope strings a plugin may even request.
+ *
+ * Scopes are open-ended strings — platform import pipelines own which scopes
+ * apply to which documents. The [companion object][Companion] exposes the
+ * well-known names the AMPERE default plugin tool registry references.
+ *
+ * Documents persisted before the W2.3 scope schema landed have no scope rows.
+ * They are returned for unfiltered queries (matching W0.5 behaviour) and
+ * excluded from any scope-filtered query.
+ */
+@Serializable
+data class KnowledgeScope(val name: String) {
+
+    init {
+        require(name.isNotBlank()) { "KnowledgeScope name must not be blank" }
+        require(name.trim() == name) {
+            "KnowledgeScope name must not have leading/trailing whitespace"
+        }
+    }
+
+    companion object {
+
+        /** Personal documents: notes, journals, private correspondence. */
+        val Personal: KnowledgeScope = KnowledgeScope("personal")
+
+        /** Work documents: meeting notes, design docs, internal references. */
+        val Work: KnowledgeScope = KnowledgeScope("work")
+
+        /** Reading material: imported articles, book excerpts, web clippings. */
+        val Reading: KnowledgeScope = KnowledgeScope("reading")
+    }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/knowledge/KnowledgeStore.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/knowledge/KnowledgeStore.kt
@@ -38,15 +38,52 @@ interface KnowledgeStore {
     /**
      * Retrieve chunks relevant to [text] using the supplied [mode].
      *
+     * Results may be restricted to documents tagged with at least one of
+     * [scopes]. An empty [scopes] (the default) disables scope filtering and
+     * preserves the W0.5 behaviour. Documents with no scope rows are returned
+     * only when [scopes] is empty.
+     *
      * @param text Free-form query.
      * @param limit Maximum number of results to return.
      * @param mode Retrieval strategy. Defaults to [QueryMode.HYBRID].
+     * @param scopes Optional scope set. Empty = no scope filter (W0.5 behaviour).
      */
     suspend fun query(
         text: String,
         limit: Int = DEFAULT_QUERY_LIMIT,
         mode: QueryMode = QueryMode.HYBRID,
+        scopes: Set<KnowledgeScope> = emptySet(),
     ): Result<List<KnowledgeQueryResult>>
+
+    /**
+     * Look up a previously-imported document by [id], or return `null` if no
+     * such document exists.
+     *
+     * Surfaces the [KnowledgeDocument.sourceUri] that retrieval consumers
+     * need to render a citation alongside each chunk.
+     */
+    suspend fun getDocument(id: String): Result<KnowledgeDocument?>
+
+    /**
+     * Replace the scope set associated with [documentId].
+     *
+     * The previous scope set is cleared atomically and replaced by [scopes].
+     * Calling with an empty [scopes] removes all scope tags (the document
+     * becomes scope-less and is excluded from any scope-filtered query).
+     *
+     * Implementations must be idempotent: calling twice with the same
+     * arguments leaves the store in the same state.
+     */
+    suspend fun setDocumentScopes(
+        documentId: String,
+        scopes: Set<KnowledgeScope>,
+    ): Result<Unit>
+
+    /**
+     * Return the scope set associated with [documentId], or an empty set
+     * when the document has no scope tags.
+     */
+    suspend fun getDocumentScopes(documentId: String): Result<Set<KnowledgeScope>>
 
     companion object {
         const val DEFAULT_QUERY_LIMIT: Int = 10
@@ -106,8 +143,15 @@ data class KnowledgeChunk(
  * @param chunk The matching chunk.
  * @param score Mode-dependent score (cosine similarity, FTS rank, or hybrid blend).
  *        Higher scores indicate better matches.
+ * @param sourceUri Source URI from the parent [KnowledgeDocument], populated
+ *        when the store knows it. May be `null` when the document has no
+ *        source URI or when the store cannot resolve it without an extra read.
+ * @param scopes Scope tags associated with the parent document. Empty when
+ *        the document has no scope tags or when scope data is not loaded.
  */
 data class KnowledgeQueryResult(
     val chunk: KnowledgeChunk,
     val score: Float,
+    val sourceUri: String? = null,
+    val scopes: Set<KnowledgeScope> = emptySet(),
 )

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/tools/DefaultToolRegistry.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/tools/DefaultToolRegistry.kt
@@ -1,0 +1,52 @@
+package link.socket.ampere.tools
+
+import link.socket.ampere.agents.config.AgentActionAutonomy
+import link.socket.ampere.agents.execution.tools.Tool
+import link.socket.ampere.knowledge.KnowledgeStore
+import link.socket.ampere.plugin.PluginManifest
+
+/**
+ * Factory for the AMPERE default Plugin tool registry (W2.3 / AMPR-156).
+ *
+ * Plugins ship a [PluginManifest] declaring the permissions they require
+ * (W0.1). When a plugin loads, the host calls [createDefaultPluginTools] with
+ * the manifest and the on-device [KnowledgeStore] to build the tool list the
+ * plugin can actually invoke. Each tool carries the manifest, so the
+ * [PluginPermissionGate][link.socket.ampere.plugin.permission.PluginPermissionGate]
+ * inside
+ * [ToolExecutionEngine][link.socket.ampere.agents.execution.ToolExecutionEngine]
+ * checks
+ * [PluginPermission.KnowledgeQuery][link.socket.ampere.plugin.permission.PluginPermission.KnowledgeQuery]
+ * against the user's grants before dispatching anything.
+ *
+ * The registry is intentionally minimal in this ticket — only the knowledge
+ * query primitive is wired in. Future plugin-callable primitives (native
+ * actions, link access, etc.) plug in here as new factory entries.
+ */
+object DefaultToolRegistry {
+
+    /**
+     * Build the default tool list for the plugin described by [manifest].
+     *
+     * @param store The on-device knowledge store the plugin will query.
+     * @param manifest The plugin's manifest. Tools are stamped with this
+     *        manifest so the permission gate can attribute and enforce.
+     * @param requiredAutonomy Minimum agent autonomy level for the bundled
+     *        knowledge query tool. Defaults to
+     *        [AgentActionAutonomy.FULLY_AUTONOMOUS] (read-only, gated by
+     *        scope grants).
+     */
+    fun createDefaultPluginTools(
+        store: KnowledgeStore,
+        manifest: PluginManifest,
+        requiredAutonomy: AgentActionAutonomy = AgentActionAutonomy.FULLY_AUTONOMOUS,
+    ): List<Tool<*>> {
+        return listOf(
+            KnowledgeQueryTool(
+                store = store,
+                pluginManifest = manifest,
+                requiredAgentAutonomy = requiredAutonomy,
+            ),
+        )
+    }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/tools/KnowledgeQueryTool.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/tools/KnowledgeQueryTool.kt
@@ -1,0 +1,203 @@
+package link.socket.ampere.tools
+
+import kotlinx.datetime.Clock
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import link.socket.ampere.agents.config.AgentActionAutonomy
+import link.socket.ampere.agents.domain.outcome.ExecutionOutcome
+import link.socket.ampere.agents.execution.request.ExecutionContext
+import link.socket.ampere.agents.execution.request.ExecutionRequest
+import link.socket.ampere.agents.execution.tools.FunctionTool
+import link.socket.ampere.knowledge.KnowledgeQueryResult
+import link.socket.ampere.knowledge.KnowledgeScope
+import link.socket.ampere.knowledge.KnowledgeStore
+import link.socket.ampere.knowledge.QueryMode
+import link.socket.ampere.plugin.PluginManifest
+
+/**
+ * Plugin-callable knowledge query primitive (W2.3 / AMPR-156).
+ *
+ * Wraps the on-device [KnowledgeStore] as a [FunctionTool] that plugins may
+ * invoke to retrieve ranked chunks for a free-form query. The [PluginManifest]
+ * threaded through here is the same manifest the
+ * [PluginPermissionGate][link.socket.ampere.plugin.permission.PluginPermissionGate]
+ * checks before the
+ * [ToolExecutionEngine][link.socket.ampere.agents.execution.ToolExecutionEngine]
+ * dispatches the tool, so the gate can deny on a missing
+ * [PluginPermission.KnowledgeQuery][link.socket.ampere.plugin.permission.PluginPermission.KnowledgeQuery]
+ * grant before any store I/O.
+ *
+ * Inputs ([KnowledgeQueryRequest]) and outputs ([KnowledgeQueryResponse])
+ * round-trip through [ExecutionRequest.context]'s `instructions` and the
+ * resulting [ExecutionOutcome.NoChanges.Success.message] as JSON, which is
+ * how the [ToolExecutionEngine][link.socket.ampere.agents.execution.ToolExecutionEngine]
+ * already wires LLM-generated parameters and tool replies. Callers that
+ * already have a typed request should call [executeKnowledgeQuery] directly
+ * to skip the JSON round-trip.
+ */
+@Serializable
+data class KnowledgeQueryRequest(
+    val text: String,
+    val scopes: Set<KnowledgeScope> = emptySet(),
+    val limit: Int = KnowledgeStore.DEFAULT_QUERY_LIMIT,
+    val mode: QueryMode = QueryMode.HYBRID,
+)
+
+/**
+ * One ranked chunk returned by [KnowledgeQueryTool].
+ *
+ * Keeps just the fields a plugin caller actually needs — the underlying
+ * [KnowledgeQueryResult] is not exposed verbatim because [KnowledgeQueryResult]
+ * is intentionally store-shaped (it carries the full chunk record).
+ */
+@Serializable
+data class KnowledgeQueryHit(
+    val chunkId: String,
+    val documentId: String,
+    val text: String,
+    val source: String?,
+    val score: Float,
+    val scopes: Set<KnowledgeScope> = emptySet(),
+)
+
+@Serializable
+data class KnowledgeQueryResponse(
+    val hits: List<KnowledgeQueryHit>,
+)
+
+/**
+ * Stable JSON encoder shared between [KnowledgeQueryTool] invocations.
+ *
+ * Uses `ignoreUnknownKeys = true` so a future request schema addition does
+ * not break tools that already encoded older requests.
+ */
+internal val knowledgeQueryToolJson: Json = Json {
+    ignoreUnknownKeys = true
+    encodeDefaults = true
+}
+
+/**
+ * Direct typed entry point used by tests and by callers that already have a
+ * typed [KnowledgeQueryRequest]. The tool factory delegates to this after
+ * decoding the request from JSON.
+ */
+suspend fun executeKnowledgeQuery(
+    store: KnowledgeStore,
+    request: KnowledgeQueryRequest,
+): Result<KnowledgeQueryResponse> {
+    return store.query(
+        text = request.text,
+        limit = request.limit,
+        mode = request.mode,
+        scopes = request.scopes,
+    ).map { results ->
+        KnowledgeQueryResponse(
+            hits = results.map { it.toHit() },
+        )
+    }
+}
+
+/**
+ * Build a [FunctionTool] that exposes [KnowledgeStore.query] to plugins.
+ *
+ * Hybrid scoring lives inside the store
+ * ([HybridQueryRanker][link.socket.ampere.knowledge.HybridQueryRanker]) so
+ * the tool stays a thin permission-gated facade.
+ *
+ * @param store The on-device knowledge store. Same instance per plugin.
+ * @param pluginManifest Manifest of the plugin that owns this tool. The
+ *        manifest's `requiredPermissions` should include at least one
+ *        [PluginPermission.KnowledgeQuery][link.socket.ampere.plugin.permission.PluginPermission.KnowledgeQuery]
+ *        so the gate can match the requested scope.
+ * @param requiredAgentAutonomy Minimum autonomy level. Defaults to
+ *        [AgentActionAutonomy.FULLY_AUTONOMOUS] because the tool reads only
+ *        and the permission gate enforces scope.
+ */
+@Suppress("FunctionName")
+fun KnowledgeQueryTool(
+    store: KnowledgeStore,
+    pluginManifest: PluginManifest? = null,
+    requiredAgentAutonomy: AgentActionAutonomy = AgentActionAutonomy.FULLY_AUTONOMOUS,
+    json: Json = knowledgeQueryToolJson,
+): FunctionTool<ExecutionContext.NoChanges> {
+    return FunctionTool(
+        id = ID,
+        name = NAME,
+        description = DESCRIPTION,
+        requiredAgentAutonomy = requiredAgentAutonomy,
+        pluginManifest = pluginManifest,
+        executionFunction = { executionRequest ->
+            executeAsOutcome(
+                store = store,
+                executionRequest = executionRequest,
+                json = json,
+            )
+        },
+    )
+}
+
+private suspend fun executeAsOutcome(
+    store: KnowledgeStore,
+    executionRequest: ExecutionRequest<ExecutionContext.NoChanges>,
+    json: Json,
+): ExecutionOutcome.NoChanges {
+    val context = executionRequest.context
+    val startTimestamp = Clock.System.now()
+
+    val request = runCatching {
+        json.decodeFromString(KnowledgeQueryRequest.serializer(), context.instructions)
+    }.getOrElse { error ->
+        return ExecutionOutcome.NoChanges.Failure(
+            executorId = context.executorId,
+            ticketId = context.ticket.id,
+            taskId = context.task.id,
+            executionStartTimestamp = startTimestamp,
+            executionEndTimestamp = Clock.System.now(),
+            message = "knowledge_query: invalid request payload — ${error.message}",
+        )
+    }
+
+    return executeKnowledgeQuery(store, request).fold(
+        onSuccess = { response ->
+            ExecutionOutcome.NoChanges.Success(
+                executorId = context.executorId,
+                ticketId = context.ticket.id,
+                taskId = context.task.id,
+                executionStartTimestamp = startTimestamp,
+                executionEndTimestamp = Clock.System.now(),
+                message = json.encodeToString(KnowledgeQueryResponse.serializer(), response),
+            )
+        },
+        onFailure = { error ->
+            ExecutionOutcome.NoChanges.Failure(
+                executorId = context.executorId,
+                ticketId = context.ticket.id,
+                taskId = context.task.id,
+                executionStartTimestamp = startTimestamp,
+                executionEndTimestamp = Clock.System.now(),
+                message = "knowledge_query: store query failed — ${error.message}",
+            )
+        },
+    )
+}
+
+private fun KnowledgeQueryResult.toHit(): KnowledgeQueryHit =
+    KnowledgeQueryHit(
+        chunkId = chunk.id,
+        documentId = chunk.documentId,
+        text = chunk.text,
+        source = sourceUri,
+        score = score,
+        scopes = scopes,
+    )
+
+const val KNOWLEDGE_QUERY_TOOL_ID: String = "knowledge_query"
+const val KNOWLEDGE_QUERY_TOOL_NAME: String = "Query Knowledge"
+
+private const val ID = KNOWLEDGE_QUERY_TOOL_ID
+private const val NAME = KNOWLEDGE_QUERY_TOOL_NAME
+private const val DESCRIPTION =
+    "Searches the on-device knowledge store for chunks relevant to a query. " +
+        "Inputs: query text, optional scope set (e.g., 'work', 'personal'), and a result limit. " +
+        "Output: ranked chunks with text, source URI, and similarity score. " +
+        "Scope-restricted plugins must hold the matching KnowledgeQuery permission grant."

--- a/ampere-core/src/commonMain/sqldelight/link/socket/ampere/db/Knowledge.sq
+++ b/ampere-core/src/commonMain/sqldelight/link/socket/ampere/db/Knowledge.sq
@@ -42,6 +42,21 @@ CREATE TABLE IF NOT EXISTS knowledge_embeddings (
 CREATE INDEX IF NOT EXISTS idx_knowledge_embeddings_model_id
     ON knowledge_embeddings(model_id);
 
+-- Per-document scope tags (W2.3 / AMPR-156).
+-- A document may belong to zero, one, or many scopes. Scope strings are
+-- open-ended (`personal`, `work`, `reading`, plus platform-defined names).
+-- Documents with no rows are scope-less: returned by unfiltered queries,
+-- filtered out of any scope-restricted query.
+CREATE TABLE IF NOT EXISTS document_scopes (
+    document_id TEXT NOT NULL,
+    scope TEXT NOT NULL,
+    PRIMARY KEY (document_id, scope),
+    FOREIGN KEY (document_id) REFERENCES knowledge_documents(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_document_scopes_scope
+    ON document_scopes(scope);
+
 -- =============================================================================
 -- DOCUMENT QUERIES
 -- =============================================================================
@@ -143,3 +158,24 @@ DELETE FROM knowledge_embeddings WHERE model_id = ?;
 
 countEmbeddings:
 SELECT COUNT(*) FROM knowledge_embeddings;
+
+-- =============================================================================
+-- DOCUMENT SCOPE QUERIES
+-- =============================================================================
+
+-- Replace a document's scope set in two steps: clear, then re-insert each scope.
+clearDocumentScopes:
+DELETE FROM document_scopes WHERE document_id = ?;
+
+insertDocumentScope:
+INSERT OR IGNORE INTO document_scopes(document_id, scope) VALUES (?, ?);
+
+getScopesForDocument:
+SELECT scope FROM document_scopes
+WHERE document_id = ?
+ORDER BY scope ASC;
+
+-- Returns the document IDs that match at least one of the supplied scopes.
+listDocumentsInScopes:
+SELECT DISTINCT document_id FROM document_scopes
+WHERE scope IN ?;

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/knowledge/HybridQueryRankerTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/knowledge/HybridQueryRankerTest.kt
@@ -1,0 +1,207 @@
+package link.socket.ampere.knowledge
+
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class HybridQueryRankerTest {
+
+    @Test
+    fun `weights default to balanced`() {
+        val ranker = HybridQueryRanker()
+        assertEquals(HybridQueryRanker.DEFAULT_SEMANTIC_WEIGHT, ranker.semanticWeight)
+        assertEquals(HybridQueryRanker.DEFAULT_KEYWORD_WEIGHT, ranker.keywordWeight)
+    }
+
+    @Test
+    fun `negative weights are rejected`() {
+        assertFailsWith<IllegalArgumentException> {
+            HybridQueryRanker(semanticWeight = -0.1f, keywordWeight = 0.5f)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            HybridQueryRanker(semanticWeight = 0.5f, keywordWeight = -0.1f)
+        }
+    }
+
+    @Test
+    fun `both-zero weights are rejected`() {
+        assertFailsWith<IllegalArgumentException> {
+            HybridQueryRanker(semanticWeight = 0f, keywordWeight = 0f)
+        }
+    }
+
+    @Test
+    fun `non-positive limit is rejected`() {
+        val ranker = HybridQueryRanker()
+        assertFailsWith<IllegalArgumentException> {
+            ranker.rank(emptyList(), emptyList(), limit = 0)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            ranker.rank(emptyList(), emptyList(), limit = -1)
+        }
+    }
+
+    @Test
+    fun `empty inputs return an empty list`() {
+        val ranker = HybridQueryRanker()
+        assertTrue(ranker.rank(emptyList(), emptyList(), limit = 5).isEmpty())
+    }
+
+    @Test
+    fun `chunk only in semantic list still surfaces`() {
+        val ranker = HybridQueryRanker(semanticWeight = 0.5f, keywordWeight = 0.5f)
+        val results = ranker.rank(
+            semanticResults = listOf(hit("only-semantic", 0.9f)),
+            keywordResults = emptyList(),
+            limit = 5,
+        )
+        assertEquals(listOf("only-semantic"), results.map { it.chunk.id })
+        // Score is 0.5 * 1.0 (max-normalised) + 0.5 * 0 = 0.5
+        assertApproximately(0.5f, results.first().score)
+    }
+
+    @Test
+    fun `chunk only in keyword list still surfaces`() {
+        val ranker = HybridQueryRanker(semanticWeight = 0.5f, keywordWeight = 0.5f)
+        val results = ranker.rank(
+            semanticResults = emptyList(),
+            keywordResults = listOf(hit("only-keyword", 0.7f)),
+            limit = 5,
+        )
+        assertEquals(listOf("only-keyword"), results.map { it.chunk.id })
+        assertApproximately(0.5f, results.first().score)
+    }
+
+    @Test
+    fun `weights bias the ranking when only one signal fires`() {
+        val semanticHeavy = HybridQueryRanker(semanticWeight = 0.9f, keywordWeight = 0.1f)
+        val results = semanticHeavy.rank(
+            semanticResults = listOf(hit("a", 1f), hit("b", 0.1f)),
+            keywordResults = listOf(hit("a", 0.1f), hit("b", 1f)),
+            limit = 5,
+        )
+        // a: 0.9*1 + 0.1*0.1 = 0.91; b: 0.9*0.1 + 0.1*1 = 0.19
+        assertEquals(listOf("a", "b"), results.map { it.chunk.id })
+    }
+
+    @Test
+    fun `result list is truncated to the limit`() {
+        val ranker = HybridQueryRanker()
+        val semantic = (1..10).map { hit("c$it", it.toFloat() / 10f) }
+        val keyword = (1..10).map { hit("c$it", (11 - it).toFloat() / 10f) }
+        val results = ranker.rank(semantic, keyword, limit = 3)
+        assertEquals(3, results.size)
+    }
+
+    @Test
+    fun `hybrid ranking beats pure semantic when keyword signal is decisive`() {
+        // Fixture:
+        // - target  : strong on both signals
+        // - semantic-distractor : top semantic match, no keyword match
+        // - keyword-distractor : strong keyword match, weak semantic match
+        // Pure semantic alone ranks the semantic-distractor on top — wrong.
+        // Pure keyword alone ranks the keyword-distractor on top — also wrong.
+        // Hybrid catches both signals and ranks `target` first.
+        val semanticResults = listOf(
+            hit(id = "semantic-distractor", score = 1.0f),
+            hit(id = "target", score = 0.7f),
+            hit(id = "keyword-distractor", score = 0.0f),
+        )
+        val keywordResults = listOf(
+            hit(id = "keyword-distractor", score = 1.0f),
+            hit(id = "target", score = 0.5f),
+        )
+
+        val ranker = HybridQueryRanker(semanticWeight = 0.5f, keywordWeight = 0.5f)
+
+        val pureSemantic = semanticResults.sortedByDescending { it.score }
+        val pureKeyword = keywordResults.sortedByDescending { it.score }
+        val hybrid = ranker.rank(semanticResults, keywordResults, limit = 3)
+
+        assertEquals("semantic-distractor", pureSemantic.first().chunk.id)
+        assertEquals("keyword-distractor", pureKeyword.first().chunk.id)
+        assertEquals(
+            "target",
+            hybrid.first().chunk.id,
+            "Hybrid should put `target` first because both signals fire on it",
+        )
+
+        // Hybrid `target` outscores either sibling.
+        val targetScore = hybrid.first { it.chunk.id == "target" }.score
+        val distractorScores = hybrid
+            .filter { it.chunk.id != "target" }
+            .map { it.score }
+        distractorScores.forEach { distractor ->
+            assertTrue(
+                targetScore > distractor,
+                "Hybrid score for target ($targetScore) should beat distractor ($distractor)",
+            )
+        }
+    }
+
+    @Test
+    fun `duplicate chunk ids in one input collapse to the best score`() {
+        val ranker = HybridQueryRanker(semanticWeight = 1f, keywordWeight = 0f)
+        val results = ranker.rank(
+            semanticResults = listOf(hit("dup", 0.3f), hit("dup", 0.9f)),
+            keywordResults = emptyList(),
+            limit = 5,
+        )
+        assertEquals(1, results.size)
+        // semantic max = 0.9 (best), so normalised score is 1.0; weighted by 1.0 = 1.0
+        assertApproximately(1.0f, results.first().score)
+    }
+
+    @Test
+    fun `enrichment fields from semantic hit are preserved over keyword hit`() {
+        val ranker = HybridQueryRanker()
+        val semanticHit = hit(
+            id = "shared",
+            score = 0.5f,
+            sourceUri = "from-semantic",
+            scopes = setOf(KnowledgeScope.Work),
+        )
+        val keywordHit = hit(
+            id = "shared",
+            score = 0.5f,
+            sourceUri = "from-keyword",
+            scopes = setOf(KnowledgeScope.Personal),
+        )
+        val results = ranker.rank(listOf(semanticHit), listOf(keywordHit), limit = 1)
+        val merged = results.single()
+        // Semantic hit wins enrichment because it has the more authoritative
+        // document join.
+        assertEquals("from-semantic", merged.sourceUri)
+        assertEquals(setOf(KnowledgeScope.Work), merged.scopes)
+        assertNotEquals("from-keyword", merged.sourceUri)
+    }
+
+    private fun hit(
+        id: String,
+        score: Float,
+        sourceUri: String? = null,
+        scopes: Set<KnowledgeScope> = emptySet(),
+    ): KnowledgeQueryResult = KnowledgeQueryResult(
+        chunk = KnowledgeChunk(
+            id = id,
+            documentId = "doc-$id",
+            chunkIndex = 0,
+            text = "text-$id",
+            charStart = 0,
+            charEnd = 10,
+        ),
+        score = score,
+        sourceUri = sourceUri,
+        scopes = scopes,
+    )
+
+    private fun assertApproximately(expected: Float, actual: Float, epsilon: Float = 1e-5f) {
+        assertTrue(
+            abs(expected - actual) < epsilon,
+            "Expected ~$expected, got $actual",
+        )
+    }
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/knowledge/InMemoryKnowledgeStore.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/knowledge/InMemoryKnowledgeStore.kt
@@ -1,0 +1,268 @@
+package link.socket.ampere.knowledge
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * In-memory [KnowledgeStore] used by AMPERE-side tests and by downstream
+ * platform-store conformance harnesses.
+ *
+ * Designed as a behaviour fixture, not a production engine: scoring is
+ * deterministic and easy to reason about, so tests can express "for this
+ * fixture corpus and this query the ranker should beat pure semantic /
+ * pure keyword" without depending on a real ANN index.
+ *
+ * Seeding paths:
+ *
+ * 1. [addDocument] + [chunkAndEmbed] mirror the production wiring. The
+ *    [embedder] parameter is invoked once per chunk to produce its
+ *    [EmbeddingVector].
+ * 2. [seedChunks] lets a test pin chunks **and** their embeddings explicitly
+ *    so the test author has full control over similarity scores.
+ *
+ * Scoring details:
+ *
+ * - **Semantic** scores are cosine similarity between the query embedding
+ *   (produced by [embedder]) and each stored chunk embedding.
+ * - **Keyword** scores are case-insensitive token-overlap fractions:
+ *   `(# unique query tokens present in the chunk) / (# unique query tokens)`.
+ * - **Hybrid** scores blend the two via [HybridQueryRanker].
+ *
+ * Concurrency: state is guarded by a single [Mutex]. Concurrent reads serialise
+ * through it, which is fine for fixture sizes.
+ */
+class InMemoryKnowledgeStore(
+    private val embedder: (String) -> EmbeddingVector = ::tokenBagEmbedder,
+    private val ranker: HybridQueryRanker = HybridQueryRanker(),
+    private val defaultModelId: String = DEFAULT_MODEL_ID,
+    private val chunker: (KnowledgeDocument) -> List<KnowledgeChunk> = ::singleChunkChunker,
+) : KnowledgeStore {
+
+    private val mutex = Mutex()
+    private val documentsById = mutableMapOf<String, KnowledgeDocument>()
+    private val chunksByDocument = mutableMapOf<String, MutableList<KnowledgeChunk>>()
+    private val embeddingsByChunkAndModel = mutableMapOf<Pair<String, String>, EmbeddingVector>()
+    private val scopesByDocument = mutableMapOf<String, MutableSet<KnowledgeScope>>()
+
+    override suspend fun addDocument(document: KnowledgeDocument): Result<KnowledgeDocument> =
+        mutex.withLock {
+            runCatching {
+                val existingByHash = documentsById.values.firstOrNull {
+                    it.contentHash == document.contentHash
+                }
+                if (existingByHash != null && existingByHash.id != document.id) {
+                    // Same content hash but a different id — treat as duplicate import,
+                    // surface the previously-stored document.
+                    return@runCatching existingByHash
+                }
+                documentsById[document.id] = document
+                chunksByDocument.getOrPut(document.id) { mutableListOf() }
+                document
+            }
+        }
+
+    override suspend fun chunkAndEmbed(
+        documentId: String,
+        modelId: String,
+    ): Result<List<KnowledgeChunk>> = mutex.withLock {
+        runCatching {
+            val document = documentsById[documentId]
+                ?: throw NoSuchElementException("Document $documentId not found")
+
+            val chunks = chunker(document)
+            val perDocument = chunksByDocument.getOrPut(documentId) { mutableListOf() }
+            perDocument.clear()
+            perDocument += chunks
+
+            chunks.forEach { chunk ->
+                embeddingsByChunkAndModel[chunk.id to modelId] = embedder(chunk.text)
+            }
+
+            chunks.toList()
+        }
+    }
+
+    override suspend fun query(
+        text: String,
+        limit: Int,
+        mode: QueryMode,
+        scopes: Set<KnowledgeScope>,
+    ): Result<List<KnowledgeQueryResult>> = mutex.withLock {
+        runCatching {
+            require(limit > 0) { "limit must be positive, got $limit" }
+
+            val allowedDocumentIds = if (scopes.isEmpty()) {
+                null
+            } else {
+                scopesByDocument.entries
+                    .filter { (_, docScopes) -> docScopes.any { it in scopes } }
+                    .map { it.key }
+                    .toSet()
+            }
+
+            val candidateChunks = chunksByDocument
+                .filter { (docId, _) -> allowedDocumentIds == null || docId in allowedDocumentIds }
+                .flatMap { (_, chunks) -> chunks }
+
+            val semanticHits = scoreSemantic(text, candidateChunks)
+            val keywordHits = scoreKeyword(text, candidateChunks)
+
+            val ranked = when (mode) {
+                QueryMode.SEMANTIC -> semanticHits.sortedByDescending { it.score }
+                QueryMode.KEYWORD -> keywordHits.sortedByDescending { it.score }
+                QueryMode.HYBRID -> ranker.rank(semanticHits, keywordHits, limit = limit)
+            }
+
+            ranked
+                .take(limit)
+                .map { hit -> enrich(hit) }
+        }
+    }
+
+    override suspend fun getDocument(id: String): Result<KnowledgeDocument?> = mutex.withLock {
+        runCatching { documentsById[id] }
+    }
+
+    override suspend fun setDocumentScopes(
+        documentId: String,
+        scopes: Set<KnowledgeScope>,
+    ): Result<Unit> = mutex.withLock {
+        runCatching {
+            if (documentId !in documentsById) {
+                throw NoSuchElementException("Document $documentId not found")
+            }
+            if (scopes.isEmpty()) {
+                scopesByDocument.remove(documentId)
+            } else {
+                scopesByDocument[documentId] = scopes.toMutableSet()
+            }
+            Unit
+        }
+    }
+
+    override suspend fun getDocumentScopes(documentId: String): Result<Set<KnowledgeScope>> =
+        mutex.withLock {
+            runCatching {
+                scopesByDocument[documentId]?.toSet() ?: emptySet()
+            }
+        }
+
+    /**
+     * Pin chunks **and** their embeddings for [documentId] explicitly.
+     *
+     * Use when a test wants full control over similarity scores rather than
+     * relying on the default token-bag [embedder].
+     *
+     * Replaces any existing chunks for the document. The document must have
+     * been added via [addDocument] beforehand.
+     */
+    suspend fun seedChunks(
+        documentId: String,
+        chunks: List<Pair<KnowledgeChunk, EmbeddingVector>>,
+        modelId: String = defaultModelId,
+    ): Result<Unit> = mutex.withLock {
+        runCatching {
+            if (documentId !in documentsById) {
+                throw NoSuchElementException("Document $documentId not found")
+            }
+            val perDocument = chunksByDocument.getOrPut(documentId) { mutableListOf() }
+            perDocument.clear()
+            perDocument += chunks.map { it.first }
+            chunks.forEach { (chunk, vector) ->
+                embeddingsByChunkAndModel[chunk.id to modelId] = vector
+            }
+        }
+    }
+
+    private fun scoreSemantic(
+        text: String,
+        candidateChunks: List<KnowledgeChunk>,
+    ): List<KnowledgeQueryResult> {
+        val queryVector = embedder(text)
+        return candidateChunks.mapNotNull { chunk ->
+            val vector = embeddingsByChunkAndModel[chunk.id to defaultModelId]
+                ?: return@mapNotNull null
+            if (vector.dimension != queryVector.dimension) return@mapNotNull null
+            KnowledgeQueryResult(
+                chunk = chunk,
+                score = vector.cosineSimilarity(queryVector),
+            )
+        }
+    }
+
+    private fun scoreKeyword(
+        text: String,
+        candidateChunks: List<KnowledgeChunk>,
+    ): List<KnowledgeQueryResult> {
+        val queryTokens = tokenize(text)
+        if (queryTokens.isEmpty()) return emptyList()
+        return candidateChunks.mapNotNull { chunk ->
+            val chunkTokens = tokenize(chunk.text)
+            if (chunkTokens.isEmpty()) return@mapNotNull null
+            val matches = queryTokens.count { it in chunkTokens }
+            if (matches == 0) return@mapNotNull null
+            KnowledgeQueryResult(
+                chunk = chunk,
+                score = matches.toFloat() / queryTokens.size.toFloat(),
+            )
+        }
+    }
+
+    private fun enrich(hit: KnowledgeQueryResult): KnowledgeQueryResult {
+        val document = documentsById[hit.chunk.documentId]
+        val scopes = scopesByDocument[hit.chunk.documentId]?.toSet().orEmpty()
+        return hit.copy(
+            sourceUri = document?.sourceUri,
+            scopes = scopes,
+        )
+    }
+
+    companion object {
+        const val DEFAULT_MODEL_ID: String = "in-memory-test-embedder"
+    }
+}
+
+/**
+ * Bag-of-tokens embedder used by [InMemoryKnowledgeStore] when callers do
+ * not supply their own. Each unique token contributes 1.0 to a fixed-size
+ * hashed dimension; the resulting vector is roughly proportional to token
+ * presence and gives non-zero similarity between chunks that share tokens.
+ *
+ * Deterministic across runs and platforms — relies only on [String.hashCode]
+ * folded into the configured dimension.
+ */
+internal fun tokenBagEmbedder(text: String, dimension: Int = 64): EmbeddingVector {
+    val values = FloatArray(dimension)
+    tokenize(text).forEach { token ->
+        // Stable fold from String.hashCode into [0, dimension).
+        val bucket = ((token.hashCode() % dimension) + dimension) % dimension
+        values[bucket] += 1f
+    }
+    if (values.all { it == 0f }) {
+        // Avoid zero vectors so cosine-similarity is well defined; pick a
+        // single canary dimension so empty/whitespace text is orthogonal to
+        // any real text.
+        values[0] = 1f
+    }
+    return EmbeddingVector(values)
+}
+
+private fun tokenize(text: String): Set<String> =
+    text.lowercase()
+        .split(Regex("[^\\p{L}\\p{Nd}]+"))
+        .filter { it.isNotBlank() }
+        .toSet()
+
+internal fun singleChunkChunker(document: KnowledgeDocument): List<KnowledgeChunk> {
+    val content = document.content
+    return listOf(
+        KnowledgeChunk(
+            id = "${document.id}:0",
+            documentId = document.id,
+            chunkIndex = 0,
+            text = content,
+            charStart = 0,
+            charEnd = content.length,
+        ),
+    )
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/knowledge/InMemoryKnowledgeStoreTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/knowledge/InMemoryKnowledgeStoreTest.kt
@@ -1,0 +1,255 @@
+package link.socket.ampere.knowledge
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+
+class InMemoryKnowledgeStoreTest {
+
+    @Test
+    fun `addDocument is idempotent on content hash`() = runTest {
+        val store = InMemoryKnowledgeStore()
+        val doc = makeDocument("doc-1", "hash-1", "Hello world")
+        val first = store.addDocument(doc).getOrThrow()
+        val second = store.addDocument(makeDocument("doc-2", "hash-1", "Hello world")).getOrThrow()
+        assertEquals(first.id, second.id)
+    }
+
+    @Test
+    fun `getDocument returns null for unknown id`() = runTest {
+        val store = InMemoryKnowledgeStore()
+        assertNull(store.getDocument("missing").getOrThrow())
+    }
+
+    @Test
+    fun `chunkAndEmbed indexes the document then query returns its chunks`() = runTest {
+        val store = InMemoryKnowledgeStore()
+        store.addDocument(makeDocument("doc-1", "hash-1", "Lighthouses guide ships."))
+        store.chunkAndEmbed("doc-1", InMemoryKnowledgeStore.DEFAULT_MODEL_ID).getOrThrow()
+
+        val results = store.query(
+            text = "lighthouses",
+            limit = 5,
+            mode = QueryMode.KEYWORD,
+        ).getOrThrow()
+
+        assertEquals(1, results.size)
+        assertEquals("doc-1", results.first().chunk.documentId)
+        assertTrue(
+            results.first().chunk.text.contains("Lighthouses"),
+            "Returned chunk should contain the indexed text",
+        )
+    }
+
+    @Test
+    fun `setDocumentScopes round-trips`() = runTest {
+        val store = InMemoryKnowledgeStore()
+        store.addDocument(makeDocument("doc-1", "hash-1", "Sample text."))
+
+        store.setDocumentScopes(
+            documentId = "doc-1",
+            scopes = setOf(KnowledgeScope.Work, KnowledgeScope("custom")),
+        ).getOrThrow()
+
+        val scopes = store.getDocumentScopes("doc-1").getOrThrow()
+        assertEquals(setOf(KnowledgeScope.Work, KnowledgeScope("custom")), scopes)
+    }
+
+    @Test
+    fun `setDocumentScopes with empty set clears scope tags`() = runTest {
+        val store = InMemoryKnowledgeStore()
+        store.addDocument(makeDocument("doc-1", "hash-1", "Sample text."))
+        store.setDocumentScopes("doc-1", setOf(KnowledgeScope.Work)).getOrThrow()
+        store.setDocumentScopes("doc-1", emptySet()).getOrThrow()
+        assertEquals(emptySet(), store.getDocumentScopes("doc-1").getOrThrow())
+    }
+
+    @Test
+    fun `setDocumentScopes for unknown document fails`() = runTest {
+        val store = InMemoryKnowledgeStore()
+        val result = store.setDocumentScopes("missing", setOf(KnowledgeScope.Work))
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun `scope filter excludes unscoped documents and other scopes`() = runTest {
+        val store = InMemoryKnowledgeStore()
+        store.addDocument(makeDocument("work-doc", "hash-w", "Lighthouse maintenance work log."))
+        store.addDocument(makeDocument("personal-doc", "hash-p", "Lighthouse vacation diary."))
+        store.addDocument(makeDocument("untagged-doc", "hash-u", "Lighthouse trivia."))
+
+        store.chunkAndEmbed("work-doc", InMemoryKnowledgeStore.DEFAULT_MODEL_ID).getOrThrow()
+        store.chunkAndEmbed("personal-doc", InMemoryKnowledgeStore.DEFAULT_MODEL_ID).getOrThrow()
+        store.chunkAndEmbed("untagged-doc", InMemoryKnowledgeStore.DEFAULT_MODEL_ID).getOrThrow()
+
+        store.setDocumentScopes("work-doc", setOf(KnowledgeScope.Work)).getOrThrow()
+        store.setDocumentScopes("personal-doc", setOf(KnowledgeScope.Personal)).getOrThrow()
+
+        val workResults = store.query(
+            text = "lighthouse",
+            limit = 10,
+            mode = QueryMode.KEYWORD,
+            scopes = setOf(KnowledgeScope.Work),
+        ).getOrThrow()
+        assertEquals(listOf("work-doc"), workResults.map { it.chunk.documentId })
+        assertEquals(setOf(KnowledgeScope.Work), workResults.first().scopes)
+
+        val unfiltered = store.query(
+            text = "lighthouse",
+            limit = 10,
+            mode = QueryMode.KEYWORD,
+        ).getOrThrow()
+        assertEquals(
+            setOf("work-doc", "personal-doc", "untagged-doc"),
+            unfiltered.map { it.chunk.documentId }.toSet(),
+        )
+    }
+
+    @Test
+    fun `query enriches results with the document source uri`() = runTest {
+        val store = InMemoryKnowledgeStore()
+        store.addDocument(
+            makeDocument(
+                id = "doc-1",
+                contentHash = "hash-1",
+                content = "Lighthouse history.",
+                sourceUri = "file:///docs/lighthouse.md",
+            ),
+        )
+        store.chunkAndEmbed("doc-1", InMemoryKnowledgeStore.DEFAULT_MODEL_ID).getOrThrow()
+
+        val hit = store.query(text = "lighthouse", mode = QueryMode.KEYWORD)
+            .getOrThrow()
+            .single()
+        assertEquals("file:///docs/lighthouse.md", hit.sourceUri)
+    }
+
+    @Test
+    fun `seedChunks lets a test pin embeddings explicitly`() = runTest {
+        // Override the embedder to a 3-dim vector so it lines up with the seeded
+        // chunk dimension.
+        val store = InMemoryKnowledgeStore(
+            embedder = { _ -> EmbeddingVector(floatArrayOf(1f, 0f, 0f)) },
+        )
+        store.addDocument(makeDocument("doc-1", "hash-1", "ignored")).getOrThrow()
+
+        val chunk = KnowledgeChunk(
+            id = "c1",
+            documentId = "doc-1",
+            chunkIndex = 0,
+            text = "explicit",
+            charStart = 0,
+            charEnd = 8,
+        )
+        val embedding = EmbeddingVector(floatArrayOf(1f, 0f, 0f))
+        store.seedChunks("doc-1", listOf(chunk to embedding)).getOrThrow()
+
+        val results = store.query(
+            text = "anything",
+            limit = 5,
+            mode = QueryMode.SEMANTIC,
+        ).getOrThrow()
+
+        // Single seeded chunk; semantic mode returns it with a defined score.
+        assertEquals(listOf("c1"), results.map { it.chunk.id })
+    }
+
+    @Test
+    fun `hybrid mode beats pure semantic and pure keyword on a controlled fixture`() = runTest {
+        // Fixture
+        // - target              : keyword match for "lighthouse" + moderate semantic vector
+        // - semantic-distractor : top semantic match, no keyword overlap with the query
+        // - keyword-distractor  : keyword match on both query tokens but semantically orthogonal
+        //
+        // Pure semantic ranks `semantic-distractor` first — wrong.
+        // Pure keyword ranks `keyword-distractor` first — wrong.
+        // Hybrid uses both signals and ranks `target` first.
+        //
+        // The embedder is stubbed: the query "lighthouse navigate" embeds to
+        // [1, 0, 0]; chunk embeddings are pinned via seedChunks so semantic
+        // ranking is fully determined and decoupled from the keyword text.
+        val queryText = "lighthouse navigate"
+        val store = InMemoryKnowledgeStore(
+            embedder = { text ->
+                if (text == queryText) {
+                    EmbeddingVector(floatArrayOf(1f, 0f, 0f))
+                } else {
+                    EmbeddingVector(floatArrayOf(0f, 0f, 1f))
+                }
+            },
+        )
+        store.addDocument(makeDocument("doc-target", "h-t", "lighthouse seaside")).getOrThrow()
+        store.addDocument(makeDocument("doc-sd", "h-sd", "harbor lights at dusk")).getOrThrow()
+        store.addDocument(makeDocument("doc-kd", "h-kd", "lighthouse navigate trip overview")).getOrThrow()
+
+        store.seedChunks(
+            documentId = "doc-target",
+            chunks = listOf(
+                KnowledgeChunk(
+                    id = "target",
+                    documentId = "doc-target",
+                    chunkIndex = 0,
+                    text = "lighthouse seaside",
+                    charStart = 0,
+                    charEnd = 18,
+                ) to EmbeddingVector(floatArrayOf(0.7f, 0.7f, 0f)),
+            ),
+        ).getOrThrow()
+        store.seedChunks(
+            documentId = "doc-sd",
+            chunks = listOf(
+                KnowledgeChunk(
+                    id = "semantic-distractor",
+                    documentId = "doc-sd",
+                    chunkIndex = 0,
+                    text = "harbor lights at dusk",
+                    charStart = 0,
+                    charEnd = 21,
+                ) to EmbeddingVector(floatArrayOf(1f, 0f, 0f)),
+            ),
+        ).getOrThrow()
+        store.seedChunks(
+            documentId = "doc-kd",
+            chunks = listOf(
+                KnowledgeChunk(
+                    id = "keyword-distractor",
+                    documentId = "doc-kd",
+                    chunkIndex = 0,
+                    text = "lighthouse navigate trip overview",
+                    charStart = 0,
+                    charEnd = 33,
+                ) to EmbeddingVector(floatArrayOf(0f, 0f, 1f)),
+            ),
+        ).getOrThrow()
+
+        val pureSemantic = store.query(queryText, mode = QueryMode.SEMANTIC, limit = 5).getOrThrow()
+        val pureKeyword = store.query(queryText, mode = QueryMode.KEYWORD, limit = 5).getOrThrow()
+        val hybrid = store.query(queryText, mode = QueryMode.HYBRID, limit = 5).getOrThrow()
+
+        assertEquals("semantic-distractor", pureSemantic.first().chunk.id)
+        assertEquals("keyword-distractor", pureKeyword.first().chunk.id)
+        assertEquals("target", hybrid.first().chunk.id)
+        assertNotEquals(hybrid.first().chunk.id, pureSemantic.first().chunk.id)
+        assertNotEquals(hybrid.first().chunk.id, pureKeyword.first().chunk.id)
+    }
+
+    private fun makeDocument(
+        id: String,
+        contentHash: String,
+        content: String,
+        sourceUri: String? = null,
+    ): KnowledgeDocument {
+        return KnowledgeDocument(
+            id = id,
+            title = "Document $id",
+            sourceUri = sourceUri,
+            importedAt = Clock.System.now(),
+            contentHash = contentHash,
+            content = content,
+        )
+    }
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/knowledge/KnowledgeScopeTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/knowledge/KnowledgeScopeTest.kt
@@ -1,0 +1,39 @@
+package link.socket.ampere.knowledge
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotEquals
+
+class KnowledgeScopeTest {
+
+    @Test
+    fun `predefined scopes have stable canonical names`() {
+        assertEquals("personal", KnowledgeScope.Personal.name)
+        assertEquals("work", KnowledgeScope.Work.name)
+        assertEquals("reading", KnowledgeScope.Reading.name)
+    }
+
+    @Test
+    fun `scopes with the same name are equal`() {
+        assertEquals(KnowledgeScope("work"), KnowledgeScope.Work)
+        assertEquals(KnowledgeScope("custom-scope"), KnowledgeScope("custom-scope"))
+    }
+
+    @Test
+    fun `scopes with different names are not equal`() {
+        assertNotEquals(KnowledgeScope.Work, KnowledgeScope.Personal)
+    }
+
+    @Test
+    fun `blank scope name is rejected`() {
+        assertFailsWith<IllegalArgumentException> { KnowledgeScope("") }
+        assertFailsWith<IllegalArgumentException> { KnowledgeScope("   ") }
+    }
+
+    @Test
+    fun `scope name with surrounding whitespace is rejected`() {
+        assertFailsWith<IllegalArgumentException> { KnowledgeScope(" work") }
+        assertFailsWith<IllegalArgumentException> { KnowledgeScope("work ") }
+    }
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/tools/DefaultToolRegistryTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/tools/DefaultToolRegistryTest.kt
@@ -1,0 +1,104 @@
+package link.socket.ampere.tools
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import link.socket.ampere.agents.config.AgentActionAutonomy
+import link.socket.ampere.agents.execution.tools.FunctionTool
+import link.socket.ampere.knowledge.InMemoryKnowledgeStore
+import link.socket.ampere.plugin.PluginManifest
+import link.socket.ampere.plugin.permission.GateResult
+import link.socket.ampere.plugin.permission.PluginPermission
+import link.socket.ampere.plugin.permission.PluginPermissionGate
+import link.socket.ampere.plugin.permission.PluginToolCall
+import link.socket.ampere.plugin.permission.UserGrants
+
+class DefaultToolRegistryTest {
+
+    @Test
+    fun `default plugin tool list contains the knowledge query tool`() {
+        val tools = DefaultToolRegistry.createDefaultPluginTools(
+            store = InMemoryKnowledgeStore(),
+            manifest = manifest("pl-1", PluginPermission.KnowledgeQuery("work")),
+        )
+
+        val tool = tools.single()
+        assertEquals(KNOWLEDGE_QUERY_TOOL_ID, tool.id)
+        assertIs<FunctionTool<*>>(tool)
+    }
+
+    @Test
+    fun `default tool stamps the manifest so the gate can attribute calls`() {
+        val manifest = manifest("pl-1", PluginPermission.KnowledgeQuery("work"))
+        val tool = DefaultToolRegistry.createDefaultPluginTools(
+            store = InMemoryKnowledgeStore(),
+            manifest = manifest,
+        ).single()
+
+        assertNotNull(tool.pluginManifest)
+        assertEquals(manifest.id, tool.pluginManifest?.id)
+        assertEquals(
+            listOf(PluginPermission.KnowledgeQuery("work")),
+            tool.pluginManifest?.requiredPermissions,
+        )
+    }
+
+    @Test
+    fun `default registry honours the requested autonomy override`() {
+        val tool = DefaultToolRegistry.createDefaultPluginTools(
+            store = InMemoryKnowledgeStore(),
+            manifest = manifest("pl-1"),
+            requiredAutonomy = AgentActionAutonomy.ASK_BEFORE_ACTION,
+        ).single()
+
+        assertEquals(AgentActionAutonomy.ASK_BEFORE_ACTION, tool.requiredAgentAutonomy)
+    }
+
+    @Test
+    fun `gate denies a missing scope grant for a tool from the default registry`() {
+        val manifest = manifest("pl-1", PluginPermission.KnowledgeQuery("work"))
+        val tool = DefaultToolRegistry.createDefaultPluginTools(
+            store = InMemoryKnowledgeStore(),
+            manifest = manifest,
+        ).single()
+
+        val gateResult = PluginPermissionGate.check(
+            toolCall = PluginToolCall(pluginId = manifest.id, toolId = tool.id),
+            manifest = manifest,
+            userGrants = UserGrants(),
+        )
+
+        assertEquals(
+            GateResult.DenyMissing(PluginPermission.KnowledgeQuery("work")),
+            gateResult,
+        )
+    }
+
+    @Test
+    fun `gate allows when the matching scope grant is present`() {
+        val manifest = manifest("pl-1", PluginPermission.KnowledgeQuery("work"))
+        val tool = DefaultToolRegistry.createDefaultPluginTools(
+            store = InMemoryKnowledgeStore(),
+            manifest = manifest,
+        ).single()
+
+        val gateResult = PluginPermissionGate.check(
+            toolCall = PluginToolCall(pluginId = manifest.id, toolId = tool.id),
+            manifest = manifest,
+            userGrants = UserGrants.granted(PluginPermission.KnowledgeQuery("work")),
+        )
+
+        assertEquals(GateResult.Allow, gateResult)
+    }
+
+    private fun manifest(
+        id: String,
+        vararg permissions: PluginPermission,
+    ): PluginManifest = PluginManifest(
+        id = id,
+        name = "Test plugin $id",
+        version = "1.0.0",
+        requiredPermissions = permissions.toList(),
+    )
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/tools/KnowledgeQueryToolTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/tools/KnowledgeQueryToolTest.kt
@@ -1,0 +1,300 @@
+package link.socket.ampere.tools
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import kotlinx.serialization.json.Json
+import link.socket.ampere.agents.config.AgentActionAutonomy
+import link.socket.ampere.agents.domain.outcome.ExecutionOutcome
+import link.socket.ampere.agents.domain.status.TaskStatus
+import link.socket.ampere.agents.domain.status.TicketStatus
+import link.socket.ampere.agents.domain.task.Task
+import link.socket.ampere.agents.events.tickets.Ticket
+import link.socket.ampere.agents.events.tickets.TicketPriority
+import link.socket.ampere.agents.events.tickets.TicketType
+import link.socket.ampere.agents.execution.request.ExecutionConstraints
+import link.socket.ampere.agents.execution.request.ExecutionContext
+import link.socket.ampere.agents.execution.request.ExecutionRequest
+import link.socket.ampere.agents.execution.tools.FunctionTool
+import link.socket.ampere.knowledge.InMemoryKnowledgeStore
+import link.socket.ampere.knowledge.KnowledgeDocument
+import link.socket.ampere.knowledge.KnowledgeScope
+import link.socket.ampere.knowledge.QueryMode
+import link.socket.ampere.plugin.PluginManifest
+import link.socket.ampere.plugin.permission.GateResult
+import link.socket.ampere.plugin.permission.PluginPermission
+import link.socket.ampere.plugin.permission.PluginPermissionGate
+import link.socket.ampere.plugin.permission.PluginToolCall
+import link.socket.ampere.plugin.permission.UserGrants
+
+class KnowledgeQueryToolTest {
+
+    private val json: Json = knowledgeQueryToolJson
+
+    @Test
+    fun `factory builds a FunctionTool with the canonical metadata`() {
+        val store = InMemoryKnowledgeStore()
+        val tool = KnowledgeQueryTool(store = store)
+
+        assertEquals(KNOWLEDGE_QUERY_TOOL_ID, tool.id)
+        assertEquals(KNOWLEDGE_QUERY_TOOL_NAME, tool.name)
+        assertEquals(AgentActionAutonomy.FULLY_AUTONOMOUS, tool.requiredAgentAutonomy)
+        assertTrue(tool.description.contains("knowledge"), "Description should mention knowledge")
+        assertTrue(
+            tool.description.contains("scope"),
+            "Description should mention scope so plugin authors know it is gated",
+        )
+        assertIs<FunctionTool<*>>(tool)
+    }
+
+    @Test
+    fun `factory threads pluginManifest through to the tool`() {
+        val store = InMemoryKnowledgeStore()
+        val manifest = manifest("pl-1", PluginPermission.KnowledgeQuery("work"))
+        val tool = KnowledgeQueryTool(store = store, pluginManifest = manifest)
+
+        assertNotNull(tool.pluginManifest)
+        assertEquals("pl-1", tool.pluginManifest?.id)
+    }
+
+    @Test
+    fun `factory accepts a custom autonomy level`() {
+        val store = InMemoryKnowledgeStore()
+        val tool = KnowledgeQueryTool(
+            store = store,
+            requiredAgentAutonomy = AgentActionAutonomy.ASK_BEFORE_ACTION,
+        )
+        assertEquals(AgentActionAutonomy.ASK_BEFORE_ACTION, tool.requiredAgentAutonomy)
+    }
+
+    @Test
+    fun `tool execution returns ranked chunks for fixture documents`() = runTest {
+        val store = InMemoryKnowledgeStore()
+        store.addDocument(makeDocument("d1", "Lighthouses guide ships through fog.")).getOrThrow()
+        store.addDocument(makeDocument("d2", "Beach sand erosion patterns.")).getOrThrow()
+        store.chunkAndEmbed("d1", InMemoryKnowledgeStore.DEFAULT_MODEL_ID).getOrThrow()
+        store.chunkAndEmbed("d2", InMemoryKnowledgeStore.DEFAULT_MODEL_ID).getOrThrow()
+
+        val tool = KnowledgeQueryTool(store = store)
+        val outcome = tool.execute(executionRequestFor(KnowledgeQueryRequest(text = "lighthouses")))
+
+        val success = assertIs<ExecutionOutcome.NoChanges.Success>(outcome)
+        val response = json.decodeFromString(KnowledgeQueryResponse.serializer(), success.message)
+
+        assertTrue(response.hits.isNotEmpty(), "Lighthouse query must return at least one hit")
+        // Top hit should be the lighthouse-bearing document because pure-keyword wins.
+        assertEquals("d1", response.hits.first().documentId)
+        assertTrue(response.hits.first().text.contains("Lighthouses"))
+    }
+
+    @Test
+    fun `tool execution surfaces source uri and scopes for each hit`() = runTest {
+        val store = InMemoryKnowledgeStore()
+        store.addDocument(
+            KnowledgeDocument(
+                id = "d1",
+                title = "Lighthouse manual",
+                sourceUri = "file:///docs/lighthouse.md",
+                importedAt = Clock.System.now(),
+                contentHash = "h-1",
+                content = "Lighthouses guide ships.",
+            ),
+        ).getOrThrow()
+        store.chunkAndEmbed("d1", InMemoryKnowledgeStore.DEFAULT_MODEL_ID).getOrThrow()
+        store.setDocumentScopes("d1", setOf(KnowledgeScope.Work)).getOrThrow()
+
+        val tool = KnowledgeQueryTool(store = store)
+        val outcome = tool.execute(
+            executionRequestFor(
+                KnowledgeQueryRequest(
+                    text = "lighthouses",
+                    scopes = setOf(KnowledgeScope.Work),
+                ),
+            ),
+        )
+
+        val success = assertIs<ExecutionOutcome.NoChanges.Success>(outcome)
+        val response = json.decodeFromString(KnowledgeQueryResponse.serializer(), success.message)
+        val hit = response.hits.single()
+        assertEquals("file:///docs/lighthouse.md", hit.source)
+        assertEquals(setOf(KnowledgeScope.Work), hit.scopes)
+    }
+
+    @Test
+    fun `scope-filtered query returns only documents in the requested scope`() = runTest {
+        val store = InMemoryKnowledgeStore()
+        store.addDocument(makeDocument("work-doc", "Lighthouse work meeting.")).getOrThrow()
+        store.addDocument(makeDocument("personal-doc", "Lighthouse vacation diary.")).getOrThrow()
+        store.chunkAndEmbed("work-doc", InMemoryKnowledgeStore.DEFAULT_MODEL_ID).getOrThrow()
+        store.chunkAndEmbed("personal-doc", InMemoryKnowledgeStore.DEFAULT_MODEL_ID).getOrThrow()
+        store.setDocumentScopes("work-doc", setOf(KnowledgeScope.Work)).getOrThrow()
+        store.setDocumentScopes("personal-doc", setOf(KnowledgeScope.Personal)).getOrThrow()
+
+        val tool = KnowledgeQueryTool(store = store)
+        val outcome = tool.execute(
+            executionRequestFor(
+                KnowledgeQueryRequest(
+                    text = "lighthouse",
+                    scopes = setOf(KnowledgeScope.Work),
+                ),
+            ),
+        )
+
+        val success = assertIs<ExecutionOutcome.NoChanges.Success>(outcome)
+        val response = json.decodeFromString(KnowledgeQueryResponse.serializer(), success.message)
+        assertEquals(listOf("work-doc"), response.hits.map { it.documentId })
+    }
+
+    @Test
+    fun `permission gate denies when the matching scope grant is missing`() {
+        val tool = KnowledgeQueryTool(
+            store = InMemoryKnowledgeStore(),
+            pluginManifest = manifest("pl-1", PluginPermission.KnowledgeQuery("work")),
+        )
+
+        val gateResult = PluginPermissionGate.check(
+            toolCall = PluginToolCall(pluginId = "pl-1", toolId = tool.id),
+            manifest = tool.pluginManifest!!,
+            userGrants = UserGrants(),
+        )
+
+        assertEquals(
+            GateResult.DenyMissing(PluginPermission.KnowledgeQuery("work")),
+            gateResult,
+        )
+    }
+
+    @Test
+    fun `permission gate denies when the wrong scope is granted`() {
+        val tool = KnowledgeQueryTool(
+            store = InMemoryKnowledgeStore(),
+            pluginManifest = manifest("pl-1", PluginPermission.KnowledgeQuery("work")),
+        )
+
+        val gateResult = PluginPermissionGate.check(
+            toolCall = PluginToolCall(pluginId = "pl-1", toolId = tool.id),
+            manifest = tool.pluginManifest!!,
+            // User granted "personal" — not the "work" the manifest requires.
+            userGrants = UserGrants.granted(PluginPermission.KnowledgeQuery("personal")),
+        )
+
+        assertEquals(
+            GateResult.DenyMissing(PluginPermission.KnowledgeQuery("work")),
+            gateResult,
+        )
+    }
+
+    @Test
+    fun `permission gate allows when the required scope is granted`() {
+        val tool = KnowledgeQueryTool(
+            store = InMemoryKnowledgeStore(),
+            pluginManifest = manifest("pl-1", PluginPermission.KnowledgeQuery("work")),
+        )
+
+        val gateResult = PluginPermissionGate.check(
+            toolCall = PluginToolCall(pluginId = "pl-1", toolId = tool.id),
+            manifest = tool.pluginManifest!!,
+            userGrants = UserGrants.granted(PluginPermission.KnowledgeQuery("work")),
+        )
+
+        assertEquals(GateResult.Allow, gateResult)
+    }
+
+    @Test
+    fun `tool returns failure outcome when the request payload is malformed`() = runTest {
+        val tool = KnowledgeQueryTool(store = InMemoryKnowledgeStore())
+        val outcome = tool.execute(rawExecutionRequest("not valid json"))
+
+        val failure = assertIs<ExecutionOutcome.NoChanges.Failure>(outcome)
+        assertTrue(
+            failure.message.contains("invalid request payload", ignoreCase = true),
+            "Failure message should call out the payload error, got: ${failure.message}",
+        )
+    }
+
+    @Test
+    fun `executeKnowledgeQuery convenience returns ranked hits without JSON round trip`() =
+        runTest {
+            val store = InMemoryKnowledgeStore()
+            store.addDocument(makeDocument("d1", "Lighthouses guide ships.")).getOrThrow()
+            store.chunkAndEmbed("d1", InMemoryKnowledgeStore.DEFAULT_MODEL_ID).getOrThrow()
+
+            val response = executeKnowledgeQuery(
+                store = store,
+                request = KnowledgeQueryRequest(
+                    text = "lighthouses",
+                    mode = QueryMode.KEYWORD,
+                ),
+            ).getOrThrow()
+
+            assertEquals("d1", response.hits.single().documentId)
+            assertNull(response.hits.single().source) // Document had no source URI.
+        }
+
+    private fun manifest(
+        id: String,
+        vararg permissions: PluginPermission,
+    ): PluginManifest = PluginManifest(
+        id = id,
+        name = "Test plugin $id",
+        version = "1.0.0",
+        requiredPermissions = permissions.toList(),
+    )
+
+    private fun makeDocument(id: String, content: String): KnowledgeDocument =
+        KnowledgeDocument(
+            id = id,
+            title = "Document $id",
+            sourceUri = null,
+            importedAt = Clock.System.now(),
+            contentHash = "h-$id",
+            content = content,
+        )
+
+    private fun executionRequestFor(
+        request: KnowledgeQueryRequest,
+    ): ExecutionRequest<ExecutionContext.NoChanges> = rawExecutionRequest(
+        json.encodeToString(KnowledgeQueryRequest.serializer(), request),
+    )
+
+    private fun rawExecutionRequest(
+        instructions: String,
+    ): ExecutionRequest<ExecutionContext.NoChanges> {
+        val now = Clock.System.now()
+        val ticket = Ticket(
+            id = "ticket-1",
+            title = "Ticket",
+            description = "desc",
+            type = TicketType.TASK,
+            priority = TicketPriority.MEDIUM,
+            status = TicketStatus.InProgress,
+            assignedAgentId = "agent-1",
+            createdByAgentId = "agent-1",
+            createdAt = now,
+            updatedAt = now,
+        )
+        val task = Task.CodeChange(
+            id = "task-1",
+            status = TaskStatus.Pending,
+            description = "Run knowledge query",
+        )
+        val context = ExecutionContext.NoChanges(
+            executorId = "executor-1",
+            ticket = ticket,
+            task = task,
+            instructions = instructions,
+        )
+        return ExecutionRequest(
+            context = context,
+            constraints = ExecutionConstraints(
+                requireTests = false,
+                requireLinting = false,
+            ),
+        )
+    }
+}

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/knowledge/DocumentScopesSchemaTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/knowledge/DocumentScopesSchemaTest.kt
@@ -1,0 +1,96 @@
+package link.socket.ampere.knowledge
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import link.socket.ampere.db.Database
+
+class DocumentScopesSchemaTest {
+
+    private lateinit var driver: JdbcSqliteDriver
+    private lateinit var database: Database
+
+    @BeforeTest
+    fun setUp() {
+        driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        Database.Schema.create(driver)
+        database = Database(driver)
+        // Foreign keys must be enabled per connection on SQLite.
+        driver.execute(null, "PRAGMA foreign_keys = ON;", 0)
+        seedDocument("doc-1")
+        seedDocument("doc-2")
+    }
+
+    @AfterTest
+    fun tearDown() {
+        driver.close()
+    }
+
+    @Test
+    fun `scopes can be inserted and listed for a document`() {
+        database.knowledgeQueries.insertDocumentScope("doc-1", "work")
+        database.knowledgeQueries.insertDocumentScope("doc-1", "personal")
+
+        val scopes = database.knowledgeQueries.getScopesForDocument("doc-1").executeAsList()
+        assertEquals(listOf("personal", "work"), scopes)
+    }
+
+    @Test
+    fun `clearDocumentScopes removes all scope rows for the document`() {
+        database.knowledgeQueries.insertDocumentScope("doc-1", "work")
+        database.knowledgeQueries.insertDocumentScope("doc-1", "personal")
+        database.knowledgeQueries.clearDocumentScopes("doc-1")
+
+        val remaining = database.knowledgeQueries.getScopesForDocument("doc-1").executeAsList()
+        assertTrue(remaining.isEmpty())
+    }
+
+    @Test
+    fun `listDocumentsInScopes returns each matching document at most once`() {
+        database.knowledgeQueries.insertDocumentScope("doc-1", "work")
+        database.knowledgeQueries.insertDocumentScope("doc-1", "reading")
+        database.knowledgeQueries.insertDocumentScope("doc-2", "personal")
+
+        val workOnly = database.knowledgeQueries
+            .listDocumentsInScopes(listOf("work"))
+            .executeAsList()
+        assertEquals(listOf("doc-1"), workOnly)
+
+        val multi = database.knowledgeQueries
+            .listDocumentsInScopes(listOf("work", "personal", "reading"))
+            .executeAsList()
+            .toSet()
+        assertEquals(setOf("doc-1", "doc-2"), multi)
+    }
+
+    @Test
+    fun `inserting a duplicate scope is a no-op`() {
+        database.knowledgeQueries.insertDocumentScope("doc-1", "work")
+        database.knowledgeQueries.insertDocumentScope("doc-1", "work")
+
+        val scopes = database.knowledgeQueries.getScopesForDocument("doc-1").executeAsList()
+        assertEquals(listOf("work"), scopes)
+    }
+
+    @Test
+    fun `deleting a document cascades to its scopes`() {
+        database.knowledgeQueries.insertDocumentScope("doc-1", "work")
+        database.knowledgeQueries.deleteDocument("doc-1")
+
+        val scopes = database.knowledgeQueries.getScopesForDocument("doc-1").executeAsList()
+        assertTrue(scopes.isEmpty())
+    }
+
+    private fun seedDocument(id: String) {
+        database.knowledgeQueries.insertDocument(
+            id = id,
+            title = "Doc $id",
+            source_uri = null,
+            imported_at = 1_000L,
+            content_hash = "hash-$id",
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Closes #465.

I added a permission-gated `KnowledgeQueryTool` that wraps the on-device `KnowledgeStore` as a `FunctionTool` plugins can invoke for ranked-chunk retrieval, plus the supporting building blocks: a `KnowledgeScope` concept and `document_scopes` schema, a `HybridQueryRanker` that blends semantic and keyword scores under configurable weights, and an `InMemoryKnowledgeStore` conformance fixture for downstream platform stores. `DefaultToolRegistry` stamps each tool with the plugin manifest so the existing `PluginPermissionGate` enforces `KnowledgeQuery` scope grants before dispatch.

## Test plan

- [x] `./gradlew :ampere-core:jvmTest` — full suite passes, 53 new tests cover scope filtering, gate denies/allows, and hybrid > pure-semantic / pure-keyword on a fully controlled fixture
- [x] `./gradlew :ampere-core:ktlintCheck` — clean
- [ ] Downstream platform stores (W1.8 iOS, W1.9 Android) wire actual `KnowledgeStore` implementations against the now-stable contract once this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)