### PR TITLE
AMPR-157 #466: ship AgentSurface developer docs and CLI renderer

### DIFF
--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/surface/AgentSurfaceCliRenderer.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/surface/AgentSurfaceCliRenderer.kt
@@ -1,0 +1,419 @@
+package link.socket.ampere.cli.surface
+
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.io.PrintWriter
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import link.socket.ampere.agents.definition.AgentId
+import link.socket.ampere.agents.domain.event.AgentSurfaceEvent
+import link.socket.ampere.agents.domain.event.EventSource
+import link.socket.ampere.agents.events.bus.EventSerialBus
+import link.socket.ampere.agents.events.bus.subscribe
+import link.socket.ampere.agents.events.subscription.EventSubscription
+import link.socket.ampere.agents.events.surface.AgentSurface
+import link.socket.ampere.agents.events.surface.AgentSurfaceField
+import link.socket.ampere.agents.events.surface.AgentSurfaceFieldValue
+import link.socket.ampere.agents.events.surface.AgentSurfaceResponse
+import link.socket.ampere.agents.events.surface.FieldValidationResult
+import link.socket.ampere.agents.events.utils.generateUUID
+
+/**
+ * Generic terminal renderer for [AgentSurface] events.
+ *
+ * Subscribes to [AgentSurfaceEvent.Requested.EVENT_TYPE] on the supplied bus,
+ * renders each surface variant to [output], reads input from [input], and
+ * publishes [AgentSurfaceEvent.Responded] with the matching `correlationId`.
+ *
+ * No Compose / SwiftUI / UIKit dependencies — usable on every JVM target
+ * AMPERE runs on, including non-TTY environments (with [ansi] = false).
+ *
+ * Renders one surface at a time; concurrent emits queue behind a [Mutex] so
+ * the terminal never has two prompts fighting for stdin.
+ *
+ * The user can abort a multi-step prompt (Form, Choice, Card with actions)
+ * by typing the [cancelToken] (default `:cancel`). A [Confirmation] does not
+ * need a separate cancel token — anything other than the confirm verb is
+ * treated as cancel.
+ */
+class AgentSurfaceCliRenderer(
+    private val bus: EventSerialBus,
+    private val agentId: AgentId = "cli-surface-renderer",
+    private val input: BufferedReader = BufferedReader(InputStreamReader(System.`in`)),
+    private val output: PrintWriter = PrintWriter(System.out, true),
+    private val ansi: Boolean = true,
+    private val cancelToken: String = ":cancel",
+    private val readSecret: () -> String? = ::defaultReadSecret,
+    private val now: () -> Instant = { Clock.System.now() },
+) {
+
+    private val mutex = Mutex()
+
+    /** Subscribe to surface requests. Idempotent for a given `(bus, agentId)` pair. */
+    fun start() {
+        bus.subscribe<AgentSurfaceEvent.Requested, EventSubscription.ByEventClassType>(
+            agentId = agentId,
+            eventType = AgentSurfaceEvent.Requested.EVENT_TYPE,
+        ) { event, _ ->
+            val response = mutex.withLock {
+                renderSurface(event.surface)
+            }
+            bus.publish(
+                AgentSurfaceEvent.Responded(
+                    eventId = generateUUID(event.correlationId, agentId),
+                    timestamp = now(),
+                    eventSource = EventSource.Agent(agentId),
+                    response = response,
+                ),
+            )
+        }
+    }
+
+    private fun renderSurface(surface: AgentSurface): AgentSurfaceResponse = when (surface) {
+        is AgentSurface.Confirmation -> renderConfirmation(surface)
+        is AgentSurface.Choice -> renderChoice(surface)
+        is AgentSurface.Form -> renderForm(surface)
+        is AgentSurface.Card -> renderCard(surface)
+    }
+
+    private fun renderConfirmation(surface: AgentSurface.Confirmation): AgentSurfaceResponse {
+        printHeader("CONFIRMATION", surface.severity)
+        output.println(surface.prompt)
+        output.println()
+        output.println("  [1] ${styledLabel(surface.confirmLabel, surface.severity)}")
+        output.println("  [2] ${surface.cancelLabel}")
+        output.println()
+        output.print("Confirm? (1=${surface.confirmLabel}, 2=${surface.cancelLabel}) > ")
+        output.flush()
+
+        val raw = readNonNullLine().trim().lowercase()
+        return when (raw) {
+            "1", "y", "yes", surface.confirmLabel.lowercase() ->
+                AgentSurfaceResponse.Submitted(correlationId = surface.correlationId)
+            else -> AgentSurfaceResponse.Cancelled(
+                correlationId = surface.correlationId,
+                reason = if (raw.isEmpty()) "no-input" else "user-dismissed",
+            )
+        }
+    }
+
+    private fun renderChoice(surface: AgentSurface.Choice): AgentSurfaceResponse {
+        printHeader("CHOICE", null)
+        output.println(bold(surface.title))
+        surface.description?.let { output.println(it) }
+        output.println()
+
+        surface.options.forEachIndexed { index, option ->
+            val number = index + 1
+            val disabledTag = if (!option.enabled) dim(" (disabled)") else ""
+            output.println("  [$number] ${option.label}$disabledTag")
+            option.description?.let { output.println("        ${dim(it)}") }
+        }
+        output.println()
+
+        val prompt = if (surface.multiSelect) {
+            "Pick ${surface.minSelections}-${surface.maxSelections} (comma-separated numbers, '$cancelToken' to cancel)"
+        } else {
+            "Pick one (number, '$cancelToken' to cancel)"
+        }
+
+        while (true) {
+            output.print("$prompt > ")
+            output.flush()
+            val raw = readNonNullLine().trim()
+            if (raw == cancelToken) {
+                return AgentSurfaceResponse.Cancelled(
+                    correlationId = surface.correlationId,
+                    reason = "user-dismissed",
+                )
+            }
+            val parsed = parseSelections(raw, surface.options.size)
+            if (parsed == null) {
+                output.println(error("Couldn't parse selection — type '$cancelToken' to abort."))
+                continue
+            }
+            val selectedOptions = parsed.map { surface.options[it - 1] }
+            val disabled = selectedOptions.filter { !it.enabled }
+            if (disabled.isNotEmpty()) {
+                output.println(error("Disabled options not selectable: ${disabled.joinToString { it.label }}"))
+                continue
+            }
+            if (parsed.size < surface.minSelections) {
+                output.println(error("Pick at least ${surface.minSelections}"))
+                continue
+            }
+            if (parsed.size > surface.maxSelections) {
+                output.println(error("Pick at most ${surface.maxSelections}"))
+                continue
+            }
+            val ids = selectedOptions.map { it.id }
+            return AgentSurfaceResponse.Submitted(
+                correlationId = surface.correlationId,
+                values = mapOf(
+                    AgentSurfaceResponse.SELECTION_KEY to AgentSurfaceFieldValue.SelectionValue(
+                        selectedIds = ids,
+                    ),
+                ),
+            )
+        }
+    }
+
+    private fun renderForm(surface: AgentSurface.Form): AgentSurfaceResponse {
+        printHeader("FORM", null)
+        output.println(bold(surface.title))
+        surface.description?.let { output.println(it) }
+        output.println()
+        output.println(dim("Type '$cancelToken' on any prompt to cancel the form."))
+        output.println()
+
+        val values = mutableMapOf<String, AgentSurfaceFieldValue>()
+        for (field in surface.fields) {
+            val outcome = promptField(field) ?: return AgentSurfaceResponse.Cancelled(
+                correlationId = surface.correlationId,
+                reason = "user-dismissed",
+            )
+            outcome.value?.let { values[field.id] = it }
+        }
+
+        output.println()
+        output.print("Submit '${surface.submitLabel}'? (1=submit, 2=${surface.cancelLabel}) > ")
+        output.flush()
+        val confirm = readNonNullLine().trim().lowercase()
+        return if (confirm == "1" || confirm == "y" || confirm == "yes" || confirm == surface.submitLabel.lowercase()) {
+            AgentSurfaceResponse.Submitted(correlationId = surface.correlationId, values = values)
+        } else {
+            AgentSurfaceResponse.Cancelled(
+                correlationId = surface.correlationId,
+                reason = "user-dismissed",
+            )
+        }
+    }
+
+    private fun renderCard(surface: AgentSurface.Card): AgentSurfaceResponse {
+        printHeader("CARD", null)
+        output.println(bold(surface.title))
+        output.println()
+
+        for (slot in surface.slots) {
+            when (slot) {
+                is AgentSurface.Card.Slot.Heading -> {
+                    val prefix = "#".repeat(slot.level.coerceAtLeast(1).coerceAtMost(6))
+                    output.println("$prefix ${bold(slot.text)}")
+                    output.println()
+                }
+                is AgentSurface.Card.Slot.Body -> {
+                    output.println(slot.text)
+                    output.println()
+                }
+                is AgentSurface.Card.Slot.KeyValue -> {
+                    output.println("  ${bold(slot.key)}: ${slot.value}")
+                }
+                is AgentSurface.Card.Slot.Image -> {
+                    val alt = slot.altText?.let { " — $it" }.orEmpty()
+                    output.println("  [image: ${slot.url}$alt]")
+                }
+                is AgentSurface.Card.Slot.Code -> {
+                    val tag = slot.language?.let { " ($it)" }.orEmpty()
+                    output.println(dim("```$tag"))
+                    slot.source.lines().forEach { output.println("  $it") }
+                    output.println(dim("```"))
+                    output.println()
+                }
+            }
+        }
+
+        if (surface.actions.isEmpty()) {
+            output.print("Press enter to dismiss > ")
+            output.flush()
+            readNonNullLine()
+            return AgentSurfaceResponse.Cancelled(
+                correlationId = surface.correlationId,
+                reason = "dismissed",
+            )
+        }
+
+        output.println()
+        surface.actions.forEachIndexed { index, action ->
+            output.println("  [${index + 1}] ${styledLabel(action.label, action.severity)}")
+        }
+        output.println("  [0] Dismiss")
+        output.println()
+
+        while (true) {
+            output.print("Pick action (number, '$cancelToken' to dismiss) > ")
+            output.flush()
+            val raw = readNonNullLine().trim()
+            if (raw == cancelToken || raw == "0" || raw.isEmpty()) {
+                return AgentSurfaceResponse.Cancelled(
+                    correlationId = surface.correlationId,
+                    reason = "dismissed",
+                )
+            }
+            val number = raw.toIntOrNull()
+            if (number == null || number < 1 || number > surface.actions.size) {
+                output.println(error("Pick a number between 1 and ${surface.actions.size}, or 0 to dismiss."))
+                continue
+            }
+            val action = surface.actions[number - 1]
+            return AgentSurfaceResponse.Submitted(
+                correlationId = surface.correlationId,
+                chosenAction = action.id,
+            )
+        }
+    }
+
+    /**
+     * Prompt the user for one field. Returns:
+     *  - `Some(value)` — the user supplied a valid value (or skipped an
+     *     optional field with empty input).
+     *  - `Some(null)` — the user supplied empty input on an optional field
+     *     (encoded as a "no entry" outcome).
+     *  - `null` — the user typed [cancelToken]; abort the whole form.
+     */
+    private fun promptField(field: AgentSurfaceField): FieldOutcome? {
+        val labelLine = buildString {
+            append(bold(field.label))
+            if (field.required) append(dim(" (required)"))
+            field.helpText?.let { append("\n  ${dim(it)}") }
+        }
+        output.println(labelLine)
+        printFieldHint(field)
+
+        while (true) {
+            output.print("> ")
+            output.flush()
+
+            val raw = if (field is AgentSurfaceField.Secret) {
+                readSecret() ?: ""
+            } else {
+                readNonNullLine()
+            }
+
+            if (raw == cancelToken) return null
+
+            val parsed = parseFieldValue(field, raw)
+            val validation = field.validate(parsed)
+            when (validation) {
+                FieldValidationResult.Valid -> return FieldOutcome(parsed)
+                is FieldValidationResult.Invalid -> {
+                    validation.errors.forEach { output.println(error("  - $it")) }
+                }
+            }
+        }
+    }
+
+    private fun printFieldHint(field: AgentSurfaceField) {
+        val hint = when (field) {
+            is AgentSurfaceField.Text -> buildString {
+                if (field.multiline) append("multi-line, end with empty line")
+                if (field.minLength > 0) append(if (isEmpty()) "min ${field.minLength}" else ", min ${field.minLength}")
+                field.maxLength?.let { append(if (isEmpty()) "max $it" else ", max $it") }
+                field.pattern?.let { append(if (isEmpty()) "matches /$it/" else ", matches /$it/") }
+            }
+            is AgentSurfaceField.Number -> buildString {
+                if (field.integerOnly) append("integer")
+                field.min?.let { append(if (isEmpty()) "min $it" else ", min $it") }
+                field.max?.let { append(if (isEmpty()) "max $it" else ", max $it") }
+            }
+            is AgentSurfaceField.Toggle -> "yes/no (default ${if (field.default) "yes" else "no"})"
+            is AgentSurfaceField.DateTime ->
+                if (field.includeTime) "ISO-8601 instant (e.g., 2026-04-29T10:00:00Z)" else "ISO-8601 date (e.g., 2026-04-29)"
+            is AgentSurfaceField.Selection -> {
+                val opts = field.options.mapIndexed { i, o -> "${i + 1}=${o.id}" }.joinToString(", ")
+                if (field.multiSelect) "comma-separated, $opts" else "one of: $opts"
+            }
+            is AgentSurfaceField.Secret -> "input hidden"
+        }
+        if (hint.isNotEmpty()) output.println(dim("  ($hint)"))
+    }
+
+    private fun parseFieldValue(field: AgentSurfaceField, raw: String): AgentSurfaceFieldValue? {
+        if (raw.isEmpty()) return null
+        return when (field) {
+            is AgentSurfaceField.Text -> {
+                val text = if (field.multiline) readMultilineContinuation(raw) else raw
+                AgentSurfaceFieldValue.TextValue(text)
+            }
+            is AgentSurfaceField.Number -> raw.toDoubleOrNull()?.let { AgentSurfaceFieldValue.NumberValue(it) }
+            is AgentSurfaceField.Toggle -> when (raw.trim().lowercase()) {
+                "y", "yes", "1", "true", "on" -> AgentSurfaceFieldValue.ToggleValue(true)
+                "n", "no", "0", "false", "off" -> AgentSurfaceFieldValue.ToggleValue(false)
+                else -> null
+            }
+            is AgentSurfaceField.DateTime -> runCatching {
+                AgentSurfaceFieldValue.DateTimeValue(Instant.parse(raw))
+            }.getOrNull()
+            is AgentSurfaceField.Selection -> {
+                val numbers = parseSelections(raw, field.options.size) ?: return null
+                val ids = numbers.map { field.options[it - 1].id }
+                AgentSurfaceFieldValue.SelectionValue(selectedIds = ids)
+            }
+            is AgentSurfaceField.Secret -> AgentSurfaceFieldValue.SecretValue(raw)
+        }
+    }
+
+    private fun readMultilineContinuation(firstLine: String): String {
+        val builder = StringBuilder(firstLine)
+        while (true) {
+            output.print(dim("…> "))
+            output.flush()
+            val next = input.readLine() ?: return builder.toString()
+            if (next.isEmpty()) return builder.toString()
+            builder.append('\n').append(next)
+        }
+    }
+
+    private fun parseSelections(raw: String, maxNumber: Int): List<Int>? {
+        if (raw.isEmpty()) return null
+        val parts = raw.split(',', ' ').map { it.trim() }.filter { it.isNotEmpty() }
+        val numbers = parts.mapNotNull { it.toIntOrNull() }
+        if (numbers.size != parts.size) return null
+        if (numbers.any { it < 1 || it > maxNumber }) return null
+        return numbers.distinct()
+    }
+
+    private fun readNonNullLine(): String = input.readLine() ?: ""
+
+    private fun printHeader(label: String, severity: AgentSurface.Confirmation.Severity?) {
+        val tag = severity?.let { " — ${it.name.uppercase()}" }.orEmpty()
+        val styled = when (severity) {
+            AgentSurface.Confirmation.Severity.Destructive -> red(label + tag)
+            AgentSurface.Confirmation.Severity.Warning -> yellow(label + tag)
+            else -> bold(label + tag)
+        }
+        output.println()
+        output.println("═══ $styled ═══")
+    }
+
+    private fun styledLabel(label: String, severity: AgentSurface.Confirmation.Severity): String =
+        when (severity) {
+            AgentSurface.Confirmation.Severity.Destructive -> red(bold(label))
+            AgentSurface.Confirmation.Severity.Warning -> yellow(bold(label))
+            AgentSurface.Confirmation.Severity.Info -> bold(label)
+        }
+
+    private fun bold(text: String): String = if (ansi) "[1m$text[0m" else text
+    private fun dim(text: String): String = if (ansi) "[2m$text[0m" else text
+    private fun red(text: String): String = if (ansi) "[31m$text[0m" else text
+    private fun yellow(text: String): String = if (ansi) "[33m$text[0m" else text
+    private fun error(text: String): String = if (ansi) "[31m$text[0m" else "! $text"
+
+    /** Marker for a successfully read field value (or `null` for skipped optional). */
+    private data class FieldOutcome(val value: AgentSurfaceFieldValue?)
+}
+
+/**
+ * Default secret reader. Uses `System.console().readPassword()` if a console
+ * is attached so the value isn't echoed; falls back to plain `readLine` if
+ * no console (e.g., redirected stdin in CI), printing a one-time warning.
+ */
+private fun defaultReadSecret(): String? {
+    val console = System.console()
+    return if (console != null) {
+        console.readPassword()?.concatToString()
+    } else {
+        readlnOrNull()
+    }
+}

--- a/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/cli/surface/AgentSurfaceCliRendererTest.kt
+++ b/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/cli/surface/AgentSurfaceCliRendererTest.kt
@@ -1,0 +1,487 @@
+package link.socket.ampere.cli.surface
+
+import java.io.BufferedReader
+import java.io.PrintWriter
+import java.io.StringReader
+import java.io.StringWriter
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import link.socket.ampere.agents.domain.event.EventSource
+import link.socket.ampere.agents.events.bus.EventSerialBus
+import link.socket.ampere.agents.events.surface.AgentSurface
+import link.socket.ampere.agents.events.surface.AgentSurfaceField
+import link.socket.ampere.agents.events.surface.AgentSurfaceFieldValue
+import link.socket.ampere.agents.events.surface.AgentSurfaceResponse
+import link.socket.ampere.agents.events.surface.awaitSurfaceResponse
+import link.socket.ampere.agents.events.surface.emitSurfaceRequest
+
+/**
+ * End-to-end tests for [AgentSurfaceCliRenderer]: a real [EventSerialBus] with
+ * the renderer subscribed, emitting through `emitSurfaceRequest`, awaiting via
+ * `awaitSurfaceResponse`, and reading rendered output verbatim.
+ */
+class AgentSurfaceCliRendererTest {
+
+    @Test
+    fun `Confirmation accepts on input '1'`() = runTest {
+        coroutineScope {
+            val harness = harness(
+                stdin = "1\n",
+                bus = EventSerialBus(scope = this),
+            )
+
+            val response = harness.driveTo(
+                surface = AgentSurface.Confirmation(
+                    correlationId = "confirm-1",
+                    prompt = "Delete branch 'feature/old'?",
+                    severity = AgentSurface.Confirmation.Severity.Destructive,
+                    confirmLabel = "Delete",
+                    cancelLabel = "Keep",
+                ),
+            )
+
+            assertIs<AgentSurfaceResponse.Submitted>(response)
+            assertEquals("confirm-1", response.correlationId)
+            assertTrue(harness.stdout().contains("CONFIRMATION"))
+            assertTrue(harness.stdout().contains("Delete branch 'feature/old'?"))
+            assertTrue(harness.stdout().contains("[1] Delete"))
+            assertTrue(harness.stdout().contains("[2] Keep"))
+        }
+    }
+
+    @Test
+    fun `Confirmation accepts on input 'y'`() = runTest {
+        coroutineScope {
+            val harness = harness(stdin = "y\n", bus = EventSerialBus(scope = this))
+            val response = harness.driveTo(
+                AgentSurface.Confirmation(
+                    correlationId = "confirm-y",
+                    prompt = "Continue?",
+                ),
+            )
+            assertIs<AgentSurfaceResponse.Submitted>(response)
+        }
+    }
+
+    @Test
+    fun `Confirmation cancels on input '2'`() = runTest {
+        coroutineScope {
+            val harness = harness(stdin = "2\n", bus = EventSerialBus(scope = this))
+            val response = harness.driveTo(
+                AgentSurface.Confirmation(
+                    correlationId = "confirm-cancel",
+                    prompt = "Continue?",
+                ),
+            )
+            val cancelled = assertIs<AgentSurfaceResponse.Cancelled>(response)
+            assertEquals("user-dismissed", cancelled.reason)
+        }
+    }
+
+    @Test
+    fun `Confirmation cancels on empty input`() = runTest {
+        coroutineScope {
+            val harness = harness(stdin = "\n", bus = EventSerialBus(scope = this))
+            val response = harness.driveTo(
+                AgentSurface.Confirmation(
+                    correlationId = "confirm-empty",
+                    prompt = "Continue?",
+                ),
+            )
+            val cancelled = assertIs<AgentSurfaceResponse.Cancelled>(response)
+            assertEquals("no-input", cancelled.reason)
+        }
+    }
+
+    @Test
+    fun `Choice single-select picks by number`() = runTest {
+        coroutineScope {
+            val harness = harness(stdin = "2\n", bus = EventSerialBus(scope = this))
+            val response = harness.driveTo(
+                AgentSurface.Choice(
+                    correlationId = "choice-single",
+                    title = "Pick a base branch",
+                    options = listOf(
+                        AgentSurface.Choice.Option(id = "main", label = "main"),
+                        AgentSurface.Choice.Option(id = "develop", label = "develop"),
+                    ),
+                ),
+            )
+            val submitted = assertIs<AgentSurfaceResponse.Submitted>(response)
+            val selection = submitted.values[AgentSurfaceResponse.SELECTION_KEY]
+                as AgentSurfaceFieldValue.SelectionValue
+            assertEquals(listOf("develop"), selection.selectedIds)
+        }
+    }
+
+    @Test
+    fun `Choice multi-select picks comma-separated numbers`() = runTest {
+        coroutineScope {
+            val harness = harness(stdin = "1, 3\n", bus = EventSerialBus(scope = this))
+            val response = harness.driveTo(
+                AgentSurface.Choice(
+                    correlationId = "choice-multi",
+                    title = "Pick reviewers",
+                    options = listOf(
+                        AgentSurface.Choice.Option(id = "@alice", label = "Alice"),
+                        AgentSurface.Choice.Option(id = "@bob", label = "Bob"),
+                        AgentSurface.Choice.Option(id = "@carol", label = "Carol"),
+                    ),
+                    multiSelect = true,
+                    minSelections = 1,
+                    maxSelections = 3,
+                ),
+            )
+            val submitted = assertIs<AgentSurfaceResponse.Submitted>(response)
+            val selection = submitted.values[AgentSurfaceResponse.SELECTION_KEY]
+                as AgentSurfaceFieldValue.SelectionValue
+            assertEquals(listOf("@alice", "@carol"), selection.selectedIds)
+        }
+    }
+
+    @Test
+    fun `Choice rejects disabled option and re-prompts`() = runTest {
+        coroutineScope {
+            val harness = harness(stdin = "3\n1\n", bus = EventSerialBus(scope = this))
+            val response = harness.driveTo(
+                AgentSurface.Choice(
+                    correlationId = "choice-disabled",
+                    title = "Pick a base branch",
+                    options = listOf(
+                        AgentSurface.Choice.Option(id = "main", label = "main"),
+                        AgentSurface.Choice.Option(id = "develop", label = "develop"),
+                        AgentSurface.Choice.Option(id = "release", label = "release", enabled = false),
+                    ),
+                ),
+            )
+            val submitted = assertIs<AgentSurfaceResponse.Submitted>(response)
+            val selection = submitted.values[AgentSurfaceResponse.SELECTION_KEY]
+                as AgentSurfaceFieldValue.SelectionValue
+            assertEquals(listOf("main"), selection.selectedIds)
+            assertTrue(harness.stdout().contains("Disabled options not selectable"))
+        }
+    }
+
+    @Test
+    fun `Choice cancels on cancel token`() = runTest {
+        coroutineScope {
+            val harness = harness(stdin = ":cancel\n", bus = EventSerialBus(scope = this))
+            val response = harness.driveTo(
+                AgentSurface.Choice(
+                    correlationId = "choice-cancel",
+                    title = "Pick one",
+                    options = listOf(AgentSurface.Choice.Option(id = "a", label = "A")),
+                ),
+            )
+            assertIs<AgentSurfaceResponse.Cancelled>(response)
+        }
+    }
+
+    @Test
+    fun `Form collects typed values from each field`() = runTest {
+        coroutineScope {
+            val harness = harness(
+                stdin = "feature/test\n\nyes\n1\n",
+                bus = EventSerialBus(scope = this),
+            )
+            val response = harness.driveTo(
+                AgentSurface.Form(
+                    correlationId = "form-1",
+                    title = "Open a pull request",
+                    fields = listOf(
+                        AgentSurfaceField.Text(
+                            id = "branch",
+                            label = "Branch name",
+                            required = true,
+                            minLength = 1,
+                        ),
+                        AgentSurfaceField.Text(
+                            id = "description",
+                            label = "Description",
+                        ),
+                        AgentSurfaceField.Toggle(
+                            id = "draft",
+                            label = "Open as draft",
+                        ),
+                    ),
+                    submitLabel = "Open PR",
+                ),
+            )
+            val submitted = assertIs<AgentSurfaceResponse.Submitted>(response)
+            assertEquals(
+                "feature/test",
+                (submitted.values["branch"] as AgentSurfaceFieldValue.TextValue).value,
+            )
+            // optional empty Text field is skipped (no entry in the map)
+            assertEquals(false, submitted.values.containsKey("description"))
+            assertEquals(
+                true,
+                (submitted.values["draft"] as AgentSurfaceFieldValue.ToggleValue).value,
+            )
+        }
+    }
+
+    @Test
+    fun `Form re-prompts a field that fails validation`() = runTest {
+        coroutineScope {
+            val harness = harness(
+                stdin = "ab\nfeature\n1\n",
+                bus = EventSerialBus(scope = this),
+            )
+            val response = harness.driveTo(
+                AgentSurface.Form(
+                    correlationId = "form-validate",
+                    title = "Branch name",
+                    fields = listOf(
+                        AgentSurfaceField.Text(
+                            id = "branch",
+                            label = "Branch",
+                            required = true,
+                            minLength = 3,
+                        ),
+                    ),
+                ),
+            )
+            val submitted = assertIs<AgentSurfaceResponse.Submitted>(response)
+            assertEquals(
+                "feature",
+                (submitted.values["branch"] as AgentSurfaceFieldValue.TextValue).value,
+            )
+            assertTrue(harness.stdout().contains("at least 3"))
+        }
+    }
+
+    @Test
+    fun `Form cancels with cancel token mid-field`() = runTest {
+        coroutineScope {
+            val harness = harness(stdin = ":cancel\n", bus = EventSerialBus(scope = this))
+            val response = harness.driveTo(
+                AgentSurface.Form(
+                    correlationId = "form-cancel",
+                    title = "Form",
+                    fields = listOf(
+                        AgentSurfaceField.Text(
+                            id = "x",
+                            label = "X",
+                            required = true,
+                        ),
+                    ),
+                ),
+            )
+            val cancelled = assertIs<AgentSurfaceResponse.Cancelled>(response)
+            assertEquals("user-dismissed", cancelled.reason)
+        }
+    }
+
+    @Test
+    fun `Form Secret field reads via injected readSecret`() = runTest {
+        coroutineScope {
+            val harness = harness(
+                stdin = "1\n",
+                bus = EventSerialBus(scope = this),
+                readSecret = { "supersecret" },
+            )
+            val response = harness.driveTo(
+                AgentSurface.Form(
+                    correlationId = "form-secret",
+                    title = "API token",
+                    fields = listOf(
+                        AgentSurfaceField.Secret(
+                            id = "token",
+                            label = "Token",
+                            required = true,
+                            minLength = 8,
+                        ),
+                    ),
+                ),
+            )
+            val submitted = assertIs<AgentSurfaceResponse.Submitted>(response)
+            val secret = submitted.values["token"] as AgentSurfaceFieldValue.SecretValue
+            assertEquals("supersecret", secret.value)
+            // The secret value must NOT appear in the rendered transcript.
+            assertTrue("Secret leaked into stdout") { !harness.stdout().contains("supersecret") }
+        }
+    }
+
+    @Test
+    fun `Form Number field rejects non-integer when integerOnly is set`() = runTest {
+        coroutineScope {
+            val harness = harness(
+                stdin = "2.5\n3\n1\n",
+                bus = EventSerialBus(scope = this),
+            )
+            val response = harness.driveTo(
+                AgentSurface.Form(
+                    correlationId = "form-int",
+                    title = "Count",
+                    fields = listOf(
+                        AgentSurfaceField.Number(
+                            id = "count",
+                            label = "Count",
+                            required = true,
+                            integerOnly = true,
+                            min = 1.0,
+                            max = 10.0,
+                        ),
+                    ),
+                ),
+            )
+            val submitted = assertIs<AgentSurfaceResponse.Submitted>(response)
+            val number = submitted.values["count"] as AgentSurfaceFieldValue.NumberValue
+            assertEquals(3.0, number.value)
+            assertTrue(harness.stdout().contains("must be a whole number"))
+        }
+    }
+
+    @Test
+    fun `Card with actions resolves chosenAction`() = runTest {
+        coroutineScope {
+            val harness = harness(stdin = "2\n", bus = EventSerialBus(scope = this))
+            val response = harness.driveTo(
+                AgentSurface.Card(
+                    correlationId = "card-1",
+                    title = "Pull request opened",
+                    slots = listOf(
+                        AgentSurface.Card.Slot.Body(text = "PR #42 is open."),
+                        AgentSurface.Card.Slot.KeyValue(key = "Author", value = "@alice"),
+                        AgentSurface.Card.Slot.Heading(text = "Diff", level = 3),
+                        AgentSurface.Card.Slot.Code(source = "+ 1\n- 2", language = "diff"),
+                    ),
+                    actions = listOf(
+                        AgentSurface.Card.Action(id = "open-in-browser", label = "Open in browser"),
+                        AgentSurface.Card.Action(
+                            id = "close-pr",
+                            label = "Close PR",
+                            severity = AgentSurface.Confirmation.Severity.Destructive,
+                        ),
+                    ),
+                ),
+            )
+            val submitted = assertIs<AgentSurfaceResponse.Submitted>(response)
+            assertEquals("close-pr", submitted.chosenAction)
+            assertTrue(harness.stdout().contains("Pull request opened"))
+            assertTrue(harness.stdout().contains("Author: @alice"))
+            assertTrue(harness.stdout().contains("[1] Open in browser"))
+        }
+    }
+
+    @Test
+    fun `Card without actions cancels on enter`() = runTest {
+        coroutineScope {
+            val harness = harness(stdin = "\n", bus = EventSerialBus(scope = this))
+            val response = harness.driveTo(
+                AgentSurface.Card(
+                    correlationId = "card-readonly",
+                    title = "Build complete",
+                    slots = listOf(AgentSurface.Card.Slot.Body(text = "All green.")),
+                ),
+            )
+            val cancelled = assertIs<AgentSurfaceResponse.Cancelled>(response)
+            assertEquals("dismissed", cancelled.reason)
+        }
+    }
+
+    @Test
+    fun `Card with actions dismisses on '0'`() = runTest {
+        coroutineScope {
+            val harness = harness(stdin = "0\n", bus = EventSerialBus(scope = this))
+            val response = harness.driveTo(
+                AgentSurface.Card(
+                    correlationId = "card-zero",
+                    title = "Result",
+                    slots = listOf(AgentSurface.Card.Slot.Body(text = "Done.")),
+                    actions = listOf(
+                        AgentSurface.Card.Action(id = "ok", label = "OK"),
+                    ),
+                ),
+            )
+            val cancelled = assertIs<AgentSurfaceResponse.Cancelled>(response)
+            assertEquals("dismissed", cancelled.reason)
+        }
+    }
+
+    @Test
+    fun `concurrent surface emits are serialised by the renderer`() = runTest {
+        coroutineScope {
+            val harness = harness(stdin = "1\n2\n", bus = EventSerialBus(scope = this))
+
+            val first = async {
+                harness.bus.awaitSurfaceResponse(
+                    awaiterAgentId = "plugin-a",
+                    correlationId = "first",
+                    timeout = 5.seconds,
+                )
+            }
+            val second = async {
+                harness.bus.awaitSurfaceResponse(
+                    awaiterAgentId = "plugin-b",
+                    correlationId = "second",
+                    timeout = 5.seconds,
+                )
+            }
+
+            harness.bus.emitSurfaceRequest(
+                surface = AgentSurface.Confirmation(correlationId = "first", prompt = "?"),
+                eventSource = EventSource.Agent("plugin-a"),
+            )
+            harness.bus.emitSurfaceRequest(
+                surface = AgentSurface.Confirmation(correlationId = "second", prompt = "?"),
+                eventSource = EventSource.Agent("plugin-b"),
+            )
+
+            val firstResponse = first.await()
+            val secondResponse = second.await()
+            assertIs<AgentSurfaceResponse.Submitted>(firstResponse)
+            assertIs<AgentSurfaceResponse.Cancelled>(secondResponse)
+        }
+    }
+
+    private fun harness(
+        bus: EventSerialBus,
+        stdin: String,
+        readSecret: () -> String? = { null },
+    ): RendererHarness {
+        val outBuffer = StringWriter()
+        val renderer = AgentSurfaceCliRenderer(
+            bus = bus,
+            agentId = "renderer-test",
+            input = BufferedReader(StringReader(stdin)),
+            output = PrintWriter(outBuffer, true),
+            ansi = false,
+            readSecret = readSecret,
+            now = { Instant.fromEpochMilliseconds(0L) },
+        )
+        renderer.start()
+        return RendererHarness(bus, outBuffer)
+    }
+
+    private class RendererHarness(
+        val bus: EventSerialBus,
+        private val outBuffer: StringWriter,
+    ) {
+        suspend fun driveTo(surface: AgentSurface): AgentSurfaceResponse = coroutineScope {
+            val plugin = "plugin-driver"
+            val deferred = async {
+                bus.awaitSurfaceResponse(
+                    awaiterAgentId = plugin,
+                    correlationId = surface.correlationId,
+                    timeout = 5.seconds,
+                )
+            }
+            bus.emitSurfaceRequest(
+                surface = surface,
+                eventSource = EventSource.Agent(plugin),
+            )
+            deferred.await()
+        }
+
+        fun stdout(): String = outBuffer.toString()
+    }
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/events/surface/AgentSurfaceDocSamplesTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/events/surface/AgentSurfaceDocSamplesTest.kt
@@ -1,0 +1,439 @@
+package link.socket.ampere.agents.events.surface
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import link.socket.ampere.agents.domain.event.AgentSurfaceEvent
+import link.socket.ampere.agents.domain.event.EventSource
+import link.socket.ampere.agents.events.bus.EventSerialBus
+import link.socket.ampere.agents.events.bus.subscribe
+import link.socket.ampere.agents.events.subscription.EventSubscription
+import link.socket.ampere.agents.events.utils.generateUUID
+
+/**
+ * Locks in that every code sample shipped in
+ * `docs/develop/agent-surface-getting-started.md`,
+ * `docs/develop/agent-surface/{form,choice,confirmation,card}.md`,
+ * and `docs/develop/agent-surface-design-patterns.md`
+ * type-checks against the public AgentSurface API as shipped.
+ *
+ * If any of these tests fail to compile or fail at runtime, the corresponding
+ * documentation sample is wrong; fix the doc, not the test.
+ */
+class AgentSurfaceDocSamplesTest {
+
+    @Test
+    fun `getting-started Confirmation sample compiles and round-trips`() = runTest {
+        coroutineScope {
+            val bus = EventSerialBus(scope = this)
+            val agentId = "plugin-agent"
+            val rendererAgent = "renderer-stub"
+            val correlationId = generateUUID(agentId, "delete-branch", "feature/old")
+
+            bus.subscribe<AgentSurfaceEvent.Requested, EventSubscription.ByEventClassType>(
+                agentId = rendererAgent,
+                eventType = AgentSurfaceEvent.Requested.EVENT_TYPE,
+            ) { event, _ ->
+                if (event.correlationId == correlationId) {
+                    bus.publish(
+                        AgentSurfaceEvent.Responded(
+                            eventId = generateUUID(correlationId, rendererAgent),
+                            timestamp = Clock.System.now(),
+                            eventSource = EventSource.Agent(rendererAgent),
+                            response = AgentSurfaceResponse.Submitted(
+                                correlationId = correlationId,
+                            ),
+                        ),
+                    )
+                }
+            }
+
+            val awaiter = async {
+                bus.awaitSurfaceResponse(
+                    awaiterAgentId = agentId,
+                    correlationId = correlationId,
+                    timeout = 30.seconds,
+                )
+            }
+
+            bus.emitSurfaceRequest(
+                surface = AgentSurface.Confirmation(
+                    correlationId = correlationId,
+                    prompt = "Delete the branch 'feature/old'? This cannot be undone.",
+                    severity = AgentSurface.Confirmation.Severity.Destructive,
+                    confirmLabel = "Delete",
+                    cancelLabel = "Keep",
+                ),
+                eventSource = EventSource.Agent(agentId),
+            )
+
+            val response = awaiter.await()
+            assertIs<AgentSurfaceResponse.Submitted>(response)
+            assertEquals(correlationId, response.correlationId)
+        }
+    }
+
+    @Test
+    fun `Form variant reference sample carries a typed value per field`() {
+        val correlationId = "create-pr"
+        val form = AgentSurface.Form(
+            correlationId = correlationId,
+            title = "Open a pull request",
+            description = "Describe the change. Reviewers see the title and body verbatim.",
+            fields = listOf(
+                AgentSurfaceField.Text(
+                    id = "title",
+                    label = "Title",
+                    required = true,
+                    minLength = 3,
+                    maxLength = 72,
+                    placeholder = "Short, imperative summary",
+                ),
+                AgentSurfaceField.Text(
+                    id = "body",
+                    label = "Description",
+                    multiline = true,
+                    helpText = "Markdown is fine.",
+                ),
+                AgentSurfaceField.Toggle(
+                    id = "draft",
+                    label = "Open as draft",
+                    default = false,
+                ),
+            ),
+            submitLabel = "Open PR",
+        )
+
+        assertEquals(3, form.fields.size)
+        val titleField = form.fields[0] as AgentSurfaceField.Text
+        assertEquals(
+            FieldValidationResult.Valid,
+            titleField.validate(AgentSurfaceFieldValue.TextValue("Open ticket browser")),
+        )
+        val tooShort = titleField.validate(AgentSurfaceFieldValue.TextValue("hi"))
+        assertIs<FieldValidationResult.Invalid>(tooShort)
+        assertTrue(tooShort.errors.any { it.contains("at least 3") })
+    }
+
+    @Test
+    fun `Choice single-select sample produces SelectionValue under SELECTION_KEY`() {
+        val correlationId = "pick-base-branch"
+        val choice = AgentSurface.Choice(
+            correlationId = correlationId,
+            title = "Pick a base branch",
+            description = "The PR will target this branch.",
+            options = listOf(
+                AgentSurface.Choice.Option(id = "main", label = "main"),
+                AgentSurface.Choice.Option(id = "develop", label = "develop"),
+                AgentSurface.Choice.Option(
+                    id = "release",
+                    label = "release",
+                    description = "Frozen during the release window.",
+                    enabled = false,
+                ),
+            ),
+        )
+
+        assertEquals(false, choice.multiSelect)
+        assertEquals(1, choice.minSelections)
+        assertEquals(1, choice.maxSelections)
+
+        val response = AgentSurfaceResponse.Submitted(
+            correlationId = correlationId,
+            values = mapOf(
+                AgentSurfaceResponse.SELECTION_KEY to AgentSurfaceFieldValue.SelectionValue(
+                    selectedIds = listOf("main"),
+                ),
+            ),
+        )
+        val selection = response.values[AgentSurfaceResponse.SELECTION_KEY]
+            as? AgentSurfaceFieldValue.SelectionValue
+        assertEquals(listOf("main"), selection?.selectedIds)
+    }
+
+    @Test
+    fun `Choice multi-select sample bounds selections by min and max`() {
+        val choice = AgentSurface.Choice(
+            correlationId = "pick-reviewers",
+            title = "Pick reviewers",
+            options = listOf(
+                AgentSurface.Choice.Option(id = "@alice", label = "Alice"),
+                AgentSurface.Choice.Option(id = "@bob", label = "Bob"),
+                AgentSurface.Choice.Option(id = "@carol", label = "Carol"),
+                AgentSurface.Choice.Option(id = "@dan", label = "Dan"),
+            ),
+            multiSelect = true,
+            minSelections = 1,
+            maxSelections = 3,
+        )
+
+        assertEquals(true, choice.multiSelect)
+        assertEquals(1, choice.minSelections)
+        assertEquals(3, choice.maxSelections)
+        assertEquals(4, choice.options.size)
+    }
+
+    @Test
+    fun `Confirmation reference sample preserves severity through the bus`() = runTest {
+        coroutineScope {
+            val bus = EventSerialBus(scope = this)
+            val agentId = "plugin-agent"
+            val rendererAgent = "renderer-stub"
+            val correlationId = generateUUID(agentId, "force-push", "feature/x")
+
+            bus.subscribe<AgentSurfaceEvent.Requested, EventSubscription.ByEventClassType>(
+                agentId = rendererAgent,
+                eventType = AgentSurfaceEvent.Requested.EVENT_TYPE,
+            ) { event, _ ->
+                val confirmation = event.surface as AgentSurface.Confirmation
+                assertEquals(
+                    AgentSurface.Confirmation.Severity.Destructive,
+                    confirmation.severity,
+                )
+                bus.publish(
+                    AgentSurfaceEvent.Responded(
+                        eventId = generateUUID(event.correlationId, rendererAgent),
+                        timestamp = Clock.System.now(),
+                        eventSource = EventSource.Agent(rendererAgent),
+                        response = AgentSurfaceResponse.Cancelled(
+                            correlationId = event.correlationId,
+                            reason = "user-dismissed",
+                        ),
+                    ),
+                )
+            }
+
+            val awaiter = async {
+                bus.awaitSurfaceResponse(
+                    awaiterAgentId = agentId,
+                    correlationId = correlationId,
+                    timeout = 60.seconds,
+                )
+            }
+
+            bus.emitSurfaceRequest(
+                surface = AgentSurface.Confirmation(
+                    correlationId = correlationId,
+                    prompt = "Force-push 'feature/x'? Anyone with this branch checked out " +
+                        "will need to reset to the new history.",
+                    severity = AgentSurface.Confirmation.Severity.Destructive,
+                    confirmLabel = "Force-push",
+                    cancelLabel = "Stop",
+                ),
+                eventSource = EventSource.Agent(agentId),
+            )
+
+            val response = awaiter.await()
+            val cancelled = assertIs<AgentSurfaceResponse.Cancelled>(response)
+            assertEquals("user-dismissed", cancelled.reason)
+        }
+    }
+
+    @Test
+    fun `Card reference sample dispatches by chosenAction`() {
+        val correlationId = "show-pr-result"
+        val card = AgentSurface.Card(
+            correlationId = correlationId,
+            title = "Pull request opened",
+            slots = listOf(
+                AgentSurface.Card.Slot.Body(text = "PR #42 is open against main."),
+                AgentSurface.Card.Slot.KeyValue(key = "Title", value = "Tighten branch rules"),
+                AgentSurface.Card.Slot.KeyValue(key = "Author", value = "@alice"),
+                AgentSurface.Card.Slot.KeyValue(key = "Reviewers", value = "@bob, @carol"),
+                AgentSurface.Card.Slot.Heading(text = "Diff summary", level = 3),
+                AgentSurface.Card.Slot.Code(
+                    source = "+ 12 -3 link/socket/ampere/agents/events/surface/AgentSurface.kt",
+                    language = "diff",
+                ),
+            ),
+            actions = listOf(
+                AgentSurface.Card.Action(id = "open-in-browser", label = "Open in browser"),
+                AgentSurface.Card.Action(
+                    id = "close-pr",
+                    label = "Close PR",
+                    severity = AgentSurface.Confirmation.Severity.Destructive,
+                ),
+            ),
+        )
+
+        assertEquals(6, card.slots.size)
+        assertEquals(2, card.actions.size)
+        assertEquals(
+            AgentSurface.Confirmation.Severity.Destructive,
+            card.actions[1].severity,
+        )
+
+        val submitted = AgentSurfaceResponse.Submitted(
+            correlationId = correlationId,
+            chosenAction = "open-in-browser",
+        )
+        assertEquals("open-in-browser", submitted.chosenAction)
+        assertTrue(submitted.values.isEmpty())
+    }
+
+    @Test
+    fun `every Card Slot kind constructs and is recognisable in a when`() {
+        val slots: List<AgentSurface.Card.Slot> = listOf(
+            AgentSurface.Card.Slot.Heading(text = "Section", level = 2),
+            AgentSurface.Card.Slot.Body(text = "Plain text only."),
+            AgentSurface.Card.Slot.KeyValue(key = "Status", value = "Open"),
+            AgentSurface.Card.Slot.Image(url = "https://example.test/img.png", altText = "diagram"),
+            AgentSurface.Card.Slot.Code(source = "val x = 1", language = "kotlin"),
+        )
+        val labels = slots.map {
+            when (it) {
+                is AgentSurface.Card.Slot.Heading -> "heading"
+                is AgentSurface.Card.Slot.Body -> "body"
+                is AgentSurface.Card.Slot.KeyValue -> "keyvalue"
+                is AgentSurface.Card.Slot.Image -> "image"
+                is AgentSurface.Card.Slot.Code -> "code"
+            }
+        }
+        assertEquals(listOf("heading", "body", "keyvalue", "image", "code"), labels)
+    }
+
+    @Test
+    fun `every AgentSurface variant is exhaustive in a when block`() {
+        val surfaces: List<AgentSurface> = listOf(
+            AgentSurface.Form(
+                correlationId = "f",
+                title = "f",
+                fields = listOf(
+                    AgentSurfaceField.Text(id = "x", label = "X"),
+                ),
+            ),
+            AgentSurface.Choice(
+                correlationId = "c",
+                title = "c",
+                options = listOf(AgentSurface.Choice.Option(id = "a", label = "A")),
+            ),
+            AgentSurface.Confirmation(correlationId = "k", prompt = "?"),
+            AgentSurface.Card(
+                correlationId = "d",
+                title = "d",
+                slots = listOf(AgentSurface.Card.Slot.Body(text = "hi")),
+            ),
+        )
+        val kinds = surfaces.map {
+            when (it) {
+                is AgentSurface.Form -> "form"
+                is AgentSurface.Choice -> "choice"
+                is AgentSurface.Confirmation -> "confirmation"
+                is AgentSurface.Card -> "card"
+            }
+        }
+        assertEquals(listOf("form", "choice", "confirmation", "card"), kinds)
+    }
+
+    @Test
+    fun `every AgentSurfaceResponse variant is exhaustive in a when block`() {
+        val responses: List<AgentSurfaceResponse> = listOf(
+            AgentSurfaceResponse.Submitted(correlationId = "s"),
+            AgentSurfaceResponse.Cancelled(correlationId = "c", reason = "user"),
+            AgentSurfaceResponse.TimedOut(correlationId = "t", timeoutMillis = 100L),
+        )
+        val kinds = responses.map {
+            when (it) {
+                is AgentSurfaceResponse.Submitted -> "submitted"
+                is AgentSurfaceResponse.Cancelled -> "cancelled"
+                is AgentSurfaceResponse.TimedOut -> "timed-out"
+            }
+        }
+        assertEquals(listOf("submitted", "cancelled", "timed-out"), kinds)
+    }
+
+    @Test
+    fun `getting-started end-to-end function returns true on Submitted`() = runTest {
+        coroutineScope {
+            val bus = EventSerialBus(scope = this)
+            val agentId = "plugin-agent"
+            val rendererAgent = "renderer-stub"
+            val branchName = "feature/old"
+
+            bus.subscribe<AgentSurfaceEvent.Requested, EventSubscription.ByEventClassType>(
+                agentId = rendererAgent,
+                eventType = AgentSurfaceEvent.Requested.EVENT_TYPE,
+            ) { event, _ ->
+                bus.publish(
+                    AgentSurfaceEvent.Responded(
+                        eventId = generateUUID(event.correlationId, rendererAgent),
+                        timestamp = Clock.System.now(),
+                        eventSource = EventSource.Agent(rendererAgent),
+                        response = AgentSurfaceResponse.Submitted(
+                            correlationId = event.correlationId,
+                        ),
+                    ),
+                )
+            }
+
+            val confirmed = confirmDeleteBranch(bus, agentId, branchName)
+            assertEquals(true, confirmed)
+        }
+    }
+
+    private suspend fun confirmDeleteBranch(
+        bus: EventSerialBus,
+        agentId: String,
+        branchName: String,
+    ): Boolean {
+        val correlationId = generateUUID(agentId, "delete-branch", branchName)
+
+        bus.emitSurfaceRequest(
+            surface = AgentSurface.Confirmation(
+                correlationId = correlationId,
+                prompt = "Delete the branch '$branchName'? This cannot be undone.",
+                severity = AgentSurface.Confirmation.Severity.Destructive,
+                confirmLabel = "Delete",
+                cancelLabel = "Keep",
+            ),
+            eventSource = EventSource.Agent(agentId),
+        )
+
+        return when (
+            bus.awaitSurfaceResponse(
+                awaiterAgentId = agentId,
+                correlationId = correlationId,
+                timeout = 30.seconds,
+            )
+        ) {
+            is AgentSurfaceResponse.Submitted -> true
+            is AgentSurfaceResponse.Cancelled,
+            is AgentSurfaceResponse.TimedOut,
+            -> false
+        }
+    }
+
+    @Test
+    fun `Form sample readback uses safe casts on optional fields`() {
+        val response = AgentSurfaceResponse.Submitted(
+            correlationId = "create-pr",
+            values = mapOf(
+                "title" to AgentSurfaceFieldValue.TextValue("Tighten branch rules"),
+                "draft" to AgentSurfaceFieldValue.ToggleValue(true),
+            ),
+        )
+        val title = (response.values["title"] as AgentSurfaceFieldValue.TextValue).value
+        val body = (response.values["body"] as? AgentSurfaceFieldValue.TextValue)?.value.orEmpty()
+        val draft = (response.values["draft"] as? AgentSurfaceFieldValue.ToggleValue)?.value ?: false
+
+        assertEquals("Tighten branch rules", title)
+        assertEquals("", body)
+        assertEquals(true, draft)
+    }
+
+    @Test
+    fun `unused timeout duration sample compiles`() {
+        // Doc samples reference 2.minutes and 5.minutes; ensure the import is wired up.
+        val twoMinutes = 2.minutes
+        val fiveMinutes = 5.minutes
+        assertTrue(twoMinutes.inWholeSeconds == 120L)
+        assertTrue(fiveMinutes.inWholeSeconds == 300L)
+    }
+}

--- a/docs/develop/agent-surface-design-patterns.md
+++ b/docs/develop/agent-surface-design-patterns.md
@@ -1,0 +1,213 @@
+# Designing for agents that render UI
+
+An agent that renders UI is in a strange position. It is making decisions
+under uncertainty, all the time, and every now and then it pauses and asks a
+person for help. The question is which moments deserve that pause — and what
+shape the pause should take when it happens.
+
+`AgentSurface` gives you four shapes: Form, Choice, Confirmation, Card. The
+contract enforces that the agent picks one. This essay is about *how* to pick
+— and how to write the words inside the shape so the person on the other end
+knows what they're being asked.
+
+## When to ask, when to act
+
+The cheapest way to fail is to ask too much. Every prompt is friction; every
+prompt is a context switch from whatever the user was doing. A surface
+should appear because the agent is genuinely uncertain or genuinely about to
+do something the user would want to know about — not because the agent
+wants reassurance.
+
+Three cases where a surface is the right answer:
+
+1. **The next step is irreversible.** A force-push, a delete, a
+   production deploy. The user needs to confirm, even if the agent is
+   confident.
+2. **The agent has multiple plausible paths and no signal to discriminate.**
+   "Which base branch should this PR target?" — the answer depends on
+   intent the agent can't see in the diff.
+3. **The agent has a result the user asked for and needs to surface it.**
+   "Here's the PR I opened" is the close of a loop the user started.
+
+Three cases where a surface is the wrong answer:
+
+1. **Asking for permission to do the thing the user just asked for.**
+   "I'm about to run the tests you told me to run — proceed?" is noise.
+   The user's instruction is the consent.
+2. **Re-asking when the answer is already in scope.** If the user's
+   request specified the base branch, don't show a `Choice` of branches.
+   Read the request.
+3. **Surfacing a status that nothing depends on.** "I started the build"
+   is a log line, not a card. Render the *result* of the build, not the
+   ignition.
+
+The shorthand: a surface should be either a *decision* or a *delivery*.
+If it's neither, it's interrupting the user for nothing.
+
+## Picking the right variant
+
+The variants form a small taxonomy. Match the shape of the question to the
+shape of the variant.
+
+| Question | Variant |
+| --- | --- |
+| "Should I do this irreversible thing?" | `Confirmation` |
+| "Which of these should I pick?" | `Choice` |
+| "Fill in the values I need to proceed." | `Form` |
+| "Here is the result; what (if anything) should I do next?" | `Card` |
+
+A few mismatches show up often enough to call out:
+
+- **A `Confirmation` with three buttons isn't a `Confirmation`.** It's a
+  `Choice`. `Confirmation` is yes-or-no; once you have a third path,
+  switch.
+- **A `Choice` with two options labelled "Yes" / "No" isn't a `Choice`.**
+  It's a `Confirmation` in disguise. Use the variant whose semantics
+  match — `Confirmation` carries severity and destructive-affordance
+  contracts that `Choice` does not.
+- **A `Form` with one optional `Toggle` isn't a `Form`.** It's a
+  `Confirmation` with extra steps. Either the toggle matters (in which
+  case make it a real branch) or it doesn't (in which case drop it).
+- **A `Card` with a "Continue" button isn't a `Card`.** It's a status
+  modal. Either the user has something meaningful to pick (make the
+  buttons describe outcomes) or the card is read-only (drop the button).
+
+## Urgency and severity
+
+Two knobs influence how prominent the surface feels: `Urgency` on the bus
+event itself (Low, Medium, High) and `Severity` on `Confirmation` (and on
+`Card.Action`). They do different jobs.
+
+**Urgency** is about *when* the user sees it. A high-urgency surface should
+interrupt; a low-urgency one can sit in a queue. The bus carries the urgency;
+the platform layer decides what to do with it. From the Plugin's side, the
+rule is: only emit `HIGH` for things that genuinely cannot wait.
+
+**Severity** is about *what the next click means*. `Destructive` says "this
+button takes the user down a one-way street." Renderers map it to whatever
+their platform's destructive affordance is. The button still confirms
+something — but the visual weight and the muscle memory ("red is forever")
+are doing the work of warning the user.
+
+The mapping in practice:
+
+- **Routine confirmation, recoverable outcome** — `severity = Info`,
+  `urgency = MEDIUM`. Default for "is this what you wanted?" prompts.
+- **Attention needed, recoverable outcome** — `severity = Warning`,
+  `urgency = MEDIUM`. The user might overwrite something; they can fix it.
+- **Irreversible outcome** — `severity = Destructive`,
+  `urgency = MEDIUM` or `HIGH`. The next click can't be taken back.
+- **Background information** — `Card`, `urgency = LOW`. The user can
+  read it on their own schedule.
+
+There is no `Severity = Trivial` and no `Urgency = NUCLEAR`. The agent's
+job is to make the call honestly inside the levels the contract gives.
+
+## Writing the prompt
+
+The prompt is the part the user actually reads. Treat it like writing
+documentation for a stranger.
+
+**State the action, not the state.** "Delete the branch 'feature/old'?" is a
+question with a verb and an object. "Confirm branch deletion?" is corporate
+ceremony. The user is deciding to *do something*; the prompt should name
+what.
+
+**Name the thing being acted on.** Specific quoted object names beat generic
+descriptions every time. `"Delete the branch 'feature/old'?"` beats `"Delete
+the selected branch?"`. The user is reading fast; concrete names anchor.
+
+**Include the consequence if it's not obvious.** `"Force-push 'main'?
+Anyone with this branch checked out will need to reset."` is the difference
+between an informed consent and a regret.
+
+**Don't ask twice in one prompt.** A prompt with "Continue?" tacked onto the
+end is teaching the user that the button was the question all along. Pick
+one.
+
+**Avoid hedge words.** "Are you sure you want to maybe delete this?" is the
+agent's anxiety leaking into the user's experience. Either ask the question
+or don't.
+
+## Writing labels
+
+Labels are the contract between the user's intent and the agent's action.
+
+**Use the verb of the outcome.** `"Delete"` and `"Keep"`. `"Force-push"` and
+`"Stop"`. The button is what the user is committing to — the label should
+describe that commitment in two or three words.
+
+**Don't use `"OK"` and `"Cancel"`.** Those are dialog labels, not action
+labels. They tell the user nothing about what's about to happen if they
+press the button. The contract's defaults are placeholders; replace them.
+
+**Symmetry helps.** `"Delete" / "Keep"` reads as a pair of choices. `"Yes,
+delete the branch" / "No"` reads as a confession.
+
+**Imperatives, not nouns.** `"Open PR"`, not `"Pull request"`. `"Schedule
+deploy"`, not `"Deployment"`. The label is what the user is *doing*.
+
+## Validation copy
+
+Validation messages live inside `FieldValidationResult.Invalid(errors)`. The
+contract gives you a `List<String>` and lets the renderer surface them
+inline. Same writing rules:
+
+**Lead with what's wrong.** `"Branch name must be at least 3 characters"`,
+not `"Please enter a longer branch name"`. The first three words tell the
+user the problem.
+
+**Name the field.** The default validators do this for you (`"$label is
+required"`). If you write a custom error string, keep the pattern — it's
+what makes errors readable when several fields fail at once.
+
+**Be specific about the rule.** `"at least 3 characters"` is testable;
+`"too short"` is editorial. The field already knows what `minLength` is
+because that's how the validator failed; pass it through.
+
+**Don't apologise for the rule.** `"This field is required, sorry!"`
+trains the user that the rule is arbitrary. It isn't. State the rule;
+trust the user to accept it.
+
+## Three rough patterns
+
+A few combinations come up enough to be worth naming.
+
+### Confirm-then-show
+
+A `Confirmation` followed by a `Card` carrying the result. The agent
+asks before the irreversible step; the agent shows the outcome after.
+The two surfaces share *no* state — the `correlationId` on each is
+independent, because they are separate decisions on the user's part.
+Cancel on the `Confirmation` short-circuits; the `Card` never emits.
+
+### Pick-then-form
+
+A `Choice` followed by a `Form`. The user picks the kind of thing they
+want to do; the form gathers the parameters for that kind. Don't try to
+collapse this into one giant form — the second surface only needs the
+fields that apply to the picked option, and you'd be hiding fields with
+runtime visibility logic that the contract can't see.
+
+### Form-with-confirm-on-submit
+
+A `Form` for the input, then a `Confirmation` on submit if the values are
+destructive. The form validates the inputs; the confirmation gates the
+irreversible step. This separation is what lets the user fix typos in
+the form without re-confirming each time.
+
+## What renderers will do
+
+The contract is `commonMain`-only by design — Plugins describe the surface,
+renderers translate it. That means you don't get pixel-level control, and
+that's the point. A `Confirmation` with `Destructive` severity will look
+*right* on Android, on iOS, in a desktop window, in a CLI — because each
+renderer maps the contract to the affordance the user already knows.
+
+If you find yourself reaching for renderer-specific styling, the surface
+contract is probably missing something. The right move is to extend the
+contract (a new severity? a new slot kind?) — not to encode the styling in
+the prompt text.
+
+<!-- platform-notes: pending W1.3 / W1.4 -->
+<!-- example: pending W2.1 -->

--- a/docs/develop/agent-surface-getting-started.md
+++ b/docs/develop/agent-surface-getting-started.md
@@ -1,0 +1,232 @@
+# Getting started with AgentSurface
+
+Plugins running on AMPERE never draw pixels. They describe what they want the
+user to see and let the platform decide how to render it. The piece of the SDK
+that carries that description from your Plugin to the platform is
+`AgentSurface`.
+
+This guide walks from an empty Plugin to one that asks a person to confirm a
+destructive action and then handles the reply. It takes about five minutes,
+and every code sample is valid against the `AgentSurface` contract that ships
+with `ampere-core`.
+
+> **Audience.** Third-party Plugin developers building on AMPERE. You should
+> already be comfortable with `commonMain`, suspending functions, and the
+> `EventSerialBus` (the same bus that carries every other typed event in the
+> system).
+
+## What you're going to build
+
+A Plugin that, before doing something irreversible, emits a typed
+`Confirmation` surface, suspends until the user responds, and decides what to
+do based on whether the user approved, rejected, or never replied.
+
+You're going to write four pieces of code:
+
+1. Generate a `correlationId` that pairs the request with its response.
+2. Build the `AgentSurface.Confirmation` value.
+3. Emit the surface and suspend until a response arrives.
+4. Branch on the typed response variant.
+
+That's the entire surface lifecycle. Everything else in `AgentSurface` is
+either a different variant (Form, Choice, Card) or a different field type
+inside Form — same shape, different payload.
+
+## Prerequisites
+
+Your Plugin module needs:
+
+- A reference to `EventSerialBus` (the bus you publish to and subscribe from).
+- An `AgentId` that identifies the Plugin's owning agent. This is what the
+  bus uses to scope subscriptions.
+
+Both are part of the standard Plugin runtime. If you can already publish an
+`Event`, you can already use `AgentSurface`.
+
+## Step 1 — Generate a correlation id
+
+A `correlationId` is what makes a surface request and its response a single
+transactional unit. The Plugin generates it; the renderer echoes it back
+verbatim. Without it, an asynchronous reply has no idea which request it
+belongs to.
+
+```kotlin
+import link.socket.ampere.agents.events.surface.CorrelationId
+import link.socket.ampere.agents.events.utils.generateUUID
+
+val correlationId: CorrelationId = generateUUID(agentId, "delete-branch")
+```
+
+`generateUUID` is deterministic given its inputs. Use a label that's unique to
+the *thing the user is deciding about* — not to the moment in time. If the
+Plugin retries the same decision, the same id pairs the new request with the
+new response.
+
+## Step 2 — Build the surface
+
+`AgentSurface.Confirmation` is the smallest variant: a prompt, a severity, and
+two button labels. Severity is the only intentional channel through which
+styling leaks from the contract into the renderer.
+
+```kotlin
+import link.socket.ampere.agents.events.surface.AgentSurface
+
+val surface = AgentSurface.Confirmation(
+    correlationId = correlationId,
+    prompt = "Delete the branch 'feature/old'? This cannot be undone.",
+    severity = AgentSurface.Confirmation.Severity.Destructive,
+    confirmLabel = "Delete",
+    cancelLabel = "Keep",
+)
+```
+
+Three things to notice:
+
+- **The prompt is a complete sentence.** Renderers treat it as the question
+  the user is being asked. Don't lead with "Are you sure" — it teaches the
+  reader nothing about *what* they're confirming.
+- **`Destructive` is not a styling hint.** It's the contract telling every
+  platform: this is the path where someone loses work. Renderers map it to
+  whatever destructive affordance the platform already has (a red button on
+  Android, system-red on iOS, a warning glyph on a CLI).
+- **Labels are imperatives, not "OK / Cancel".** The label is what the user
+  is committing to. "Delete" and "Keep" describe the outcomes; "OK" and
+  "Cancel" describe the dialog.
+
+## Step 3 — Emit and suspend
+
+`emitSurfaceRequest` publishes an `AgentSurfaceEvent.Requested` carrying the
+surface. `awaitSurfaceResponse` subscribes to the matching
+`AgentSurfaceEvent.Responded`, suspends the calling coroutine, and returns
+the typed response when one arrives.
+
+```kotlin
+import kotlin.time.Duration.Companion.seconds
+import link.socket.ampere.agents.domain.event.EventSource
+import link.socket.ampere.agents.events.surface.awaitSurfaceResponse
+import link.socket.ampere.agents.events.surface.emitSurfaceRequest
+
+bus.emitSurfaceRequest(
+    surface = surface,
+    eventSource = EventSource.Agent(agentId),
+)
+
+val response = bus.awaitSurfaceResponse(
+    awaiterAgentId = agentId,
+    correlationId = correlationId,
+    timeout = 30.seconds,
+)
+```
+
+The emit is fire-and-forget. The await is the suspending half: the coroutine
+parks until the renderer publishes a `Responded` event with the same
+`correlationId`. If `timeout` elapses first, you get an
+`AgentSurfaceResponse.TimedOut` rather than an exception — failure is part of
+the type, not a control-flow surprise.
+
+You can pass `timeout = null` to wait indefinitely. Only do that if you have
+some other deadline in scope; an unbounded await with no signal-of-life is a
+hang.
+
+## Step 4 — Handle the response
+
+`AgentSurfaceResponse` is a sealed interface with three variants. A `when`
+over them is exhaustive; the compiler tells you when you've forgotten one.
+
+```kotlin
+import link.socket.ampere.agents.events.surface.AgentSurfaceResponse
+
+when (response) {
+    is AgentSurfaceResponse.Submitted -> deleteBranch("feature/old")
+    is AgentSurfaceResponse.Cancelled -> log("User declined: ${response.reason}")
+    is AgentSurfaceResponse.TimedOut -> log("No reply within ${response.timeoutMillis}ms")
+}
+```
+
+For a `Confirmation`, `Submitted` means the user pressed the confirm button.
+The `chosenAction` field on `Submitted` is null for `Confirmation` (there's
+only one confirm path); it carries an action id only for `Card` variants.
+`Cancelled.reason` is optional context from the renderer — usually null.
+
+## The whole thing
+
+```kotlin
+import kotlin.time.Duration.Companion.seconds
+import link.socket.ampere.agents.definition.AgentId
+import link.socket.ampere.agents.domain.event.EventSource
+import link.socket.ampere.agents.events.bus.EventSerialBus
+import link.socket.ampere.agents.events.surface.AgentSurface
+import link.socket.ampere.agents.events.surface.AgentSurfaceResponse
+import link.socket.ampere.agents.events.surface.awaitSurfaceResponse
+import link.socket.ampere.agents.events.surface.emitSurfaceRequest
+import link.socket.ampere.agents.events.utils.generateUUID
+
+suspend fun confirmDeleteBranch(
+    bus: EventSerialBus,
+    agentId: AgentId,
+    branchName: String,
+): Boolean {
+    val correlationId = generateUUID(agentId, "delete-branch", branchName)
+
+    bus.emitSurfaceRequest(
+        surface = AgentSurface.Confirmation(
+            correlationId = correlationId,
+            prompt = "Delete the branch '$branchName'? This cannot be undone.",
+            severity = AgentSurface.Confirmation.Severity.Destructive,
+            confirmLabel = "Delete",
+            cancelLabel = "Keep",
+        ),
+        eventSource = EventSource.Agent(agentId),
+    )
+
+    return when (val response = bus.awaitSurfaceResponse(
+        awaiterAgentId = agentId,
+        correlationId = correlationId,
+        timeout = 30.seconds,
+    )) {
+        is AgentSurfaceResponse.Submitted -> true
+        is AgentSurfaceResponse.Cancelled,
+        is AgentSurfaceResponse.TimedOut -> false
+    }
+}
+```
+
+That function is the smallest meaningful Plugin↔user interaction. Substitute
+a different surface variant and a different response branch and you have the
+shape of every UI request a Plugin will ever make.
+
+## What you can rely on
+
+The `AgentSurface` contract is `commonMain` Kotlin. It carries no Compose,
+SwiftUI, UIKit, or terminal-rendering types. Your Plugin compiles on every
+target AMPERE supports without per-platform shims. When platform renderers
+ship, they translate the same typed values into whatever native UI the host
+provides.
+
+Two guarantees worth making explicit:
+
+- **Validation is a pure function.** `AgentSurfaceField.validate(value)`
+  returns `FieldValidationResult.Valid` or `Invalid(errors)` and runs
+  identically on every target. Renderers validate before submission; you
+  should validate again on receipt. The pure-Kotlin predicates make that
+  cheap.
+- **Responses are typed, not stringly-keyed.** A `Submitted` response from a
+  `Form` carries a `Map<String, AgentSurfaceFieldValue>` keyed by field id;
+  a `Submitted` from a `Choice` carries a `SelectionValue` under the
+  well-known key `AgentSurfaceResponse.SELECTION_KEY`; a `Submitted` from a
+  `Card` or `Confirmation` carries a `chosenAction` string. The shape per
+  variant is documented on each variant's reference page.
+
+## What's next
+
+- **One variant per page**: [Form](agent-surface/form.md),
+  [Choice](agent-surface/choice.md),
+  [Confirmation](agent-surface/confirmation.md),
+  [Card](agent-surface/card.md). Each page lists every prop, every
+  validation rule, and the exact response shape.
+- **[Designing for agents that render UI](agent-surface-design-patterns.md)**
+  — when to ask versus when to act, how urgency maps to variant choice, and
+  the writing rules for prompts and validation copy.
+
+<!-- platform-notes: pending W1.3 / W1.4 -->
+<!-- example: pending W2.1 -->

--- a/docs/develop/agent-surface/card.md
+++ b/docs/develop/agent-surface/card.md
@@ -1,0 +1,192 @@
+# AgentSurface.Card
+
+A **Card** is structured, slot-based content. Use it to *show* a result, an
+artifact, or a summary — and optionally let the user choose a follow-up
+action. Cards are the variant for "here's what I did" or "here's what I
+found"; they are not for asking the user to fill anything in.
+
+## Constructor
+
+```kotlin
+AgentSurface.Card(
+    correlationId: CorrelationId,
+    title: String,
+    slots: List<Slot>,
+    actions: List<Action> = emptyList(),
+)
+```
+
+| Prop | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `correlationId` | `CorrelationId` | required | Pairs request and response. |
+| `title` | `String` | required | Single-line heading shown above the slots. |
+| `slots` | `List<Slot>` | required | Rendered in the order given. |
+| `actions` | `List<Action>` | empty | Optional buttons. If empty, the card is read-only and the response is whatever the user does to dismiss it. |
+
+## Slots
+
+`Card.Slot` is a sealed interface. Five slot kinds cover the content space.
+New slot kinds extend the sealed hierarchy — there is no `Custom(any)`
+escape hatch by design.
+
+### `Heading`
+
+```kotlin
+Slot.Heading(text: String, level: Int = 2)
+```
+
+A subheading inside the card. `level` mirrors `<h2>`/`<h3>` — renderers map
+it to whatever heading scale they support.
+
+### `Body`
+
+```kotlin
+Slot.Body(text: String)
+```
+
+A paragraph of plain text. **Plain.** No HTML, no markdown that the
+renderer is expected to parse, no embedded `<script>`. Slots are typed for
+a reason — if you need bold, that's a future slot kind, not a workaround.
+
+### `KeyValue`
+
+```kotlin
+Slot.KeyValue(key: String, value: String)
+```
+
+A labelled field. Renderers typically display these as a two-column row.
+Use `KeyValue` for metadata like commit shas, ticket numbers, durations.
+
+### `Image`
+
+```kotlin
+Slot.Image(url: String, altText: String? = null)
+```
+
+A displayable image. `altText` is the accessibility caption — set it for
+every image that conveys information, leave it null only for purely
+decorative images.
+
+### `Code`
+
+```kotlin
+Slot.Code(source: String, language: String? = null)
+```
+
+A code block. `language` is a hint for syntax highlighting (`"kotlin"`,
+`"sql"`, `"diff"`). Renderers may choose not to highlight; the source must
+display verbatim regardless.
+
+## Actions
+
+```kotlin
+AgentSurface.Card.Action(
+    id: String,
+    label: String,
+    severity: AgentSurface.Confirmation.Severity = Severity.Info,
+)
+```
+
+| Prop | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `id` | `String` | required | Reported as `chosenAction` in the response. Stable. |
+| `label` | `String` | required | The visible button text. Imperative. |
+| `severity` | `Severity` | `Info` | Reuses `Confirmation.Severity` so destructive actions on cards style the same way. |
+
+Cards with no actions are read-only displays; the user can dismiss them and
+the response will be `Cancelled`. Cards with one or more actions let the
+user pick a follow-up; the response is `Submitted` with `chosenAction` set
+to the picked action's id.
+
+## Response shape
+
+A `Submitted` response from a `Card`:
+
+```kotlin
+AgentSurfaceResponse.Submitted(
+    correlationId = correlationId,
+    values = emptyMap(),
+    chosenAction = "open-pr",
+)
+```
+
+- `values` is empty. Cards don't collect input.
+- `chosenAction` is the id of the action the user picked, or null if the
+  card had no actions and was dismissed without input (in practice, that
+  outcome is usually delivered as `Cancelled` instead).
+
+`Cancelled` and `TimedOut` mean what they always mean.
+
+## Example
+
+```kotlin
+val correlationId = generateUUID(agentId, "show-pr-result", prNumber.toString())
+
+bus.emitSurfaceRequest(
+    surface = AgentSurface.Card(
+        correlationId = correlationId,
+        title = "Pull request opened",
+        slots = listOf(
+            AgentSurface.Card.Slot.Body(
+                text = "PR #$prNumber is open against main.",
+            ),
+            AgentSurface.Card.Slot.KeyValue(key = "Title", value = prTitle),
+            AgentSurface.Card.Slot.KeyValue(key = "Author", value = author),
+            AgentSurface.Card.Slot.KeyValue(key = "Reviewers", value = reviewers.joinToString()),
+            AgentSurface.Card.Slot.Heading(text = "Diff summary", level = 3),
+            AgentSurface.Card.Slot.Code(
+                source = diffSummary,
+                language = "diff",
+            ),
+        ),
+        actions = listOf(
+            AgentSurface.Card.Action(
+                id = "open-in-browser",
+                label = "Open in browser",
+            ),
+            AgentSurface.Card.Action(
+                id = "close-pr",
+                label = "Close PR",
+                severity = AgentSurface.Confirmation.Severity.Destructive,
+            ),
+        ),
+    ),
+    eventSource = EventSource.Agent(agentId),
+)
+
+val response = bus.awaitSurfaceResponse(
+    awaiterAgentId = agentId,
+    correlationId = correlationId,
+    timeout = 5.minutes,
+)
+
+when (response) {
+    is AgentSurfaceResponse.Submitted -> when (response.chosenAction) {
+        "open-in-browser" -> openBrowser(prUrl)
+        "close-pr" -> closePullRequest(prNumber)
+        else -> Unit
+    }
+    is AgentSurfaceResponse.Cancelled,
+    is AgentSurfaceResponse.TimedOut -> Unit
+}
+```
+
+## Constraints
+
+- **Slot order is the contract.** The order is the reading order; don't
+  reflow.
+- **Slot kinds are sealed.** A new kind of content needs a new variant in
+  the sealed hierarchy and a renderer update on every platform. There is
+  no `Body(text = "<html>...")` shortcut for embedding markup — the slot
+  taxonomy exists precisely so platforms can render natively.
+- **Actions are imperatives.** `"Open in browser"`, `"Close PR"`. Avoid
+  `"More..."` or `"Continue"` — they teach the user nothing about what
+  they're picking.
+- **Use `Destructive` severity sparingly on cards.** If a card has a
+  destructive action, the renderer's destructive affordance fires every
+  time the user sees the card. Reserve it for cases where confirming the
+  destructive button means *don't ask again, do it now*; otherwise emit a
+  follow-up `Confirmation` to gate the destructive path.
+
+<!-- platform-notes: pending W1.3 / W1.4 -->
+<!-- example: pending W2.1 -->

--- a/docs/develop/agent-surface/choice.md
+++ b/docs/develop/agent-surface/choice.md
@@ -1,0 +1,155 @@
+# AgentSurface.Choice
+
+A **Choice** is a single- or multi-select picker over a fixed set of options.
+Use it when the answer is "one of these" — never when the answer is open
+text. Picking from a list is easier for the user and tighter for the trace
+than parsing free-form input.
+
+## Constructor
+
+```kotlin
+AgentSurface.Choice(
+    correlationId: CorrelationId,
+    title: String,
+    description: String? = null,
+    options: List<AgentSurface.Choice.Option>,
+    multiSelect: Boolean = false,
+    minSelections: Int = if (multiSelect) 0 else 1,
+    maxSelections: Int = if (multiSelect) options.size else 1,
+)
+```
+
+| Prop | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `correlationId` | `CorrelationId` | required | Pairs request and response. |
+| `title` | `String` | required | Single-line heading shown above the options. |
+| `description` | `String?` | `null` | Optional context shown below the title. |
+| `options` | `List<Option>` | required | Rendered in the order given. |
+| `multiSelect` | `Boolean` | `false` | If `false`, exactly one option may be chosen. |
+| `minSelections` | `Int` | `0` (multi) / `1` (single) | Lower bound on selections. |
+| `maxSelections` | `Int` | `options.size` (multi) / `1` (single) | Upper bound on selections. |
+
+### `Option`
+
+```kotlin
+AgentSurface.Choice.Option(
+    id: String,
+    label: String,
+    description: String? = null,
+    enabled: Boolean = true,
+)
+```
+
+| Prop | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `id` | `String` | required | The id reported back in the response. Stable across renderers. |
+| `label` | `String` | required | The visible label. |
+| `description` | `String?` | `null` | Optional helper text per option. |
+| `enabled` | `Boolean` | `true` | If `false`, the option renders but cannot be selected. |
+
+## Validation
+
+The renderer enforces selection counts before publishing `Submitted`:
+
+| Rule | Triggers when |
+| --- | --- |
+| required-when-single | single-select with no selection |
+| minSelections | `selections.size < minSelections` |
+| maxSelections | `selections.size > maxSelections` |
+| unknown ids | a selected id isn't present in `options` |
+
+Disabled options are not selectable; if a renderer somehow submits one, treat
+the response as malformed and reject it on the Plugin side.
+
+## Response shape
+
+A `Submitted` response from a `Choice` is **always** encoded as a
+`SelectionValue` under the well-known key
+`AgentSurfaceResponse.SELECTION_KEY` (`"selection"`):
+
+```kotlin
+AgentSurfaceResponse.Submitted(
+    correlationId = correlationId,
+    values = mapOf(
+        AgentSurfaceResponse.SELECTION_KEY to AgentSurfaceFieldValue.SelectionValue(
+            selectedIds = listOf("main"),
+        ),
+    ),
+)
+```
+
+For single-select, `selectedIds` has exactly one element. For multi-select,
+it has between `minSelections` and `maxSelections` elements. Read it like
+any other typed value:
+
+```kotlin
+val selection = response.values[AgentSurfaceResponse.SELECTION_KEY]
+    as? AgentSurfaceFieldValue.SelectionValue
+val picked: List<String> = selection?.selectedIds.orEmpty()
+```
+
+`Cancelled` and `TimedOut` carry no selection — they signal that no choice
+was made.
+
+## Examples
+
+### Single-select
+
+```kotlin
+val correlationId = generateUUID(agentId, "pick-base-branch")
+
+bus.emitSurfaceRequest(
+    surface = AgentSurface.Choice(
+        correlationId = correlationId,
+        title = "Pick a base branch",
+        description = "The PR will target this branch.",
+        options = listOf(
+            AgentSurface.Choice.Option(id = "main", label = "main"),
+            AgentSurface.Choice.Option(id = "develop", label = "develop"),
+            AgentSurface.Choice.Option(
+                id = "release",
+                label = "release",
+                description = "Frozen during the release window.",
+                enabled = false,
+            ),
+        ),
+    ),
+    eventSource = EventSource.Agent(agentId),
+)
+```
+
+### Multi-select
+
+```kotlin
+val correlationId = generateUUID(agentId, "pick-reviewers")
+
+bus.emitSurfaceRequest(
+    surface = AgentSurface.Choice(
+        correlationId = correlationId,
+        title = "Pick reviewers",
+        options = teamMembers.map { member ->
+            AgentSurface.Choice.Option(id = member.handle, label = member.name)
+        },
+        multiSelect = true,
+        minSelections = 1,
+        maxSelections = 3,
+    ),
+    eventSource = EventSource.Agent(agentId),
+)
+```
+
+## Constraints
+
+- **Option order is the contract.** Don't sort by label in the renderer.
+  The Plugin chose the order; if there's a "primary" option, it's first.
+- **Option ids are stable.** They appear in `selectedIds` and in tests.
+  Renaming is a breaking change.
+- **Disabled is not the same as absent.** A disabled option still renders;
+  use it to *show* a path the user can't take right now and *why*. To hide
+  an option, leave it out of the list.
+- **`Choice` is for "one of these," not "yes / no".** A `Choice` with two
+  options labelled "Yes" and "No" is a `Confirmation` in disguise. Use the
+  variant that matches the question's shape.
+
+<!-- platform-notes: pending W1.3 / W1.4 -->
+<!-- example: pending W2.1 -->

--- a/docs/develop/agent-surface/confirmation.md
+++ b/docs/develop/agent-surface/confirmation.md
@@ -1,0 +1,109 @@
+# AgentSurface.Confirmation
+
+A **Confirmation** is the smallest variant: a single prompt with an accept
+and reject affordance. Use it when the question is binary and the user is
+making a real decision — usually because the next step is irreversible,
+expensive, or visible to other people.
+
+## Constructor
+
+```kotlin
+AgentSurface.Confirmation(
+    correlationId: CorrelationId,
+    prompt: String,
+    severity: Severity = Severity.Info,
+    confirmLabel: String = "Confirm",
+    cancelLabel: String = "Cancel",
+)
+```
+
+| Prop | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `correlationId` | `CorrelationId` | required | Pairs request and response. |
+| `prompt` | `String` | required | The complete question the user is being asked. Sentence form. |
+| `severity` | `Severity` | `Info` | The contract's signal that the path is destructive, attention-needed, or routine. |
+| `confirmLabel` | `String` | `"Confirm"` | Imperative for the accept action. Replace with the verb of the outcome. |
+| `cancelLabel` | `String` | `"Cancel"` | Imperative for the reject action. |
+
+### `Severity`
+
+```kotlin
+enum class Severity { Info, Warning, Destructive }
+```
+
+| Value | When to use | Renderer mapping |
+| --- | --- | --- |
+| `Info` | Routine confirmation — sending an email, scheduling a meeting. | Neutral default. |
+| `Warning` | Attention-needed but recoverable — overwriting an unsaved draft. | Platform's elevated/warning affordance. |
+| `Destructive` | Cannot be undone — deleting data, force-pushing, sending production traffic. | Platform's destructive affordance (red action button on Android, system-red on iOS, etc.). |
+
+Severity is **the only intentional channel** through which styling leaks
+from the contract into the renderer. Don't try to push styling through
+prompt text or labels (`"⚠️ Are you sure? ⚠️"` is a contract violation by
+spirit, even if not by compile-time check).
+
+## Validation
+
+There is no field-level validation. The user accepts or rejects.
+
+## Response shape
+
+`Confirmation` produces:
+
+- `AgentSurfaceResponse.Submitted` — the user pressed the confirm action.
+  `chosenAction` is `null`; `values` is empty.
+- `AgentSurfaceResponse.Cancelled` — the user pressed cancel or dismissed
+  the prompt. `reason` is optional context from the renderer.
+- `AgentSurfaceResponse.TimedOut` — the renderer didn't reply within the
+  awaiter's timeout window.
+
+In practice, the Plugin treats `Cancelled` and `TimedOut` the same way:
+*don't proceed*. They differ only in what you can tell the user about why
+the next step didn't happen.
+
+## Example
+
+```kotlin
+val correlationId = generateUUID(agentId, "force-push", branchName)
+
+bus.emitSurfaceRequest(
+    surface = AgentSurface.Confirmation(
+        correlationId = correlationId,
+        prompt = "Force-push '$branchName'? Anyone with this branch checked out " +
+            "will need to reset to the new history.",
+        severity = AgentSurface.Confirmation.Severity.Destructive,
+        confirmLabel = "Force-push",
+        cancelLabel = "Stop",
+    ),
+    eventSource = EventSource.Agent(agentId),
+)
+
+val response = bus.awaitSurfaceResponse(
+    awaiterAgentId = agentId,
+    correlationId = correlationId,
+    timeout = 60.seconds,
+)
+
+if (response is AgentSurfaceResponse.Submitted) {
+    forcePush(branchName)
+}
+```
+
+## Constraints
+
+- **Prompts are complete sentences.** A renderer surfaces the prompt
+  verbatim; a fragment like `"Confirm?"` is uninformative no matter what
+  the title above it says.
+- **Labels describe the outcome.** `"Delete"` and `"Keep"`, not `"OK"` and
+  `"Cancel"`. The user is committing to the verb on the button — make sure
+  it matches what's about to happen.
+- **`Destructive` means irreversible.** Don't use it for "this is mildly
+  important." If `Cmd+Z` would undo the next step, severity is `Info` or
+  `Warning`. The renderer's destructive affordance should mean the same
+  thing every time the user sees it.
+- **A `Confirmation` is not a notification.** If the user has nothing to
+  decide, don't ask. Render a `Card` (or, eventually, surface the result
+  through whatever notification primitive the platform provides).
+
+<!-- platform-notes: pending W1.3 / W1.4 -->
+<!-- example: pending W2.1 -->

--- a/docs/develop/agent-surface/form.md
+++ b/docs/develop/agent-surface/form.md
@@ -1,0 +1,255 @@
+# AgentSurface.Form
+
+A **Form** is a multi-field input. The Plugin describes the fields it needs;
+the renderer presents them in order; the response carries a typed value per
+field. Use it whenever you need more than a single yes/no, a single pick from
+a list, or a static piece of content.
+
+## Constructor
+
+```kotlin
+AgentSurface.Form(
+    correlationId: CorrelationId,
+    title: String,
+    description: String? = null,
+    fields: List<AgentSurfaceField>,
+    submitLabel: String = "Submit",
+    cancelLabel: String = "Cancel",
+)
+```
+
+| Prop | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `correlationId` | `CorrelationId` (`String`) | required | Pairs request and response. Generate per-decision, not per-attempt. |
+| `title` | `String` | required | The single-line heading the renderer shows above the fields. |
+| `description` | `String?` | `null` | Optional one-paragraph context shown below the title. |
+| `fields` | `List<AgentSurfaceField>` | required | Rendered in order. Order is part of the contract. |
+| `submitLabel` | `String` | `"Submit"` | Imperative for the confirm action. Replace with the verb that matches the outcome. |
+| `cancelLabel` | `String` | `"Cancel"` | Imperative for the dismiss action. |
+
+## Field types
+
+`AgentSurfaceField` is sealed. Six variants cover the input space; they all
+share the four common props on the interface (`id`, `label`, `helpText`,
+`required`) and add type-specific props.
+
+### Common to every field
+
+| Prop | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `id` | `String` | required | The key under which the field's value appears in `Submitted.values`. |
+| `label` | `String` | required | The visible field label. |
+| `helpText` | `String?` | `null` | Optional helper text below the field. |
+| `required` | `Boolean` | `false` | If `true`, validation fails when the value is missing. |
+
+### `Text`
+
+Free-form single- or multi-line text. The `pattern` is a Kotlin `Regex` source.
+
+| Prop | Type | Default |
+| --- | --- | --- |
+| `placeholder` | `String?` | `null` |
+| `multiline` | `Boolean` | `false` |
+| `minLength` | `Int` | `0` |
+| `maxLength` | `Int?` | `null` |
+| `pattern` | `String?` | `null` |
+
+| Validation | Triggers when |
+| --- | --- |
+| required | value is null or empty |
+| minLength | `text.length < minLength` |
+| maxLength | `text.length > maxLength` |
+| pattern | `Regex(pattern).matches(text)` is false |
+
+### `Number`
+
+Numeric input. `integerOnly` rejects non-integral doubles.
+
+| Prop | Type | Default |
+| --- | --- | --- |
+| `min` | `Double?` | `null` |
+| `max` | `Double?` | `null` |
+| `integerOnly` | `Boolean` | `false` |
+
+| Validation | Triggers when |
+| --- | --- |
+| required | value is null |
+| integerOnly | the number has a non-zero fractional part |
+| min | `number < min` |
+| max | `number > max` |
+
+### `Toggle`
+
+Boolean switch. `required` here means *the toggle must be on* — the same
+shape as a "I accept the terms" checkbox.
+
+| Prop | Type | Default |
+| --- | --- | --- |
+| `default` | `Boolean` | `false` |
+
+| Validation | Triggers when |
+| --- | --- |
+| required | value is `false` or null |
+
+### `DateTime`
+
+A point in time, expressed as `kotlinx.datetime.Instant`. `includeTime = false`
+hints to the renderer that a date picker is enough.
+
+| Prop | Type | Default |
+| --- | --- | --- |
+| `notBefore` | `Instant?` | `null` |
+| `notAfter` | `Instant?` | `null` |
+| `includeTime` | `Boolean` | `true` |
+
+| Validation | Triggers when |
+| --- | --- |
+| required | value is null |
+| notBefore | `instant < notBefore` |
+| notAfter | `instant > notAfter` |
+
+### `Selection`
+
+A single- or multi-pick from a fixed set of options, rendered inline within
+the form (as opposed to `AgentSurface.Choice`, which is a top-level surface).
+Reuses `AgentSurface.Choice.Option`.
+
+| Prop | Type | Default |
+| --- | --- | --- |
+| `options` | `List<AgentSurface.Choice.Option>` | required |
+| `multiSelect` | `Boolean` | `false` |
+| `minSelections` | `Int` | `1` (single-select) / `0` (multi-select) |
+| `maxSelections` | `Int` | `1` (single-select) / `options.size` (multi-select) |
+
+| Validation | Triggers when |
+| --- | --- |
+| required | no options selected |
+| minSelections | fewer selections than the floor |
+| maxSelections | more selections than the ceiling |
+| unknown ids | a selected id isn't present in `options` |
+
+### `Secret`
+
+A masked input. Same length validations as `Text`. Renderers must not log,
+echo, or persist the value beyond the originating Plugin's scope.
+
+| Prop | Type | Default |
+| --- | --- | --- |
+| `minLength` | `Int` | `0` |
+| `maxLength` | `Int?` | `null` |
+
+| Validation | Triggers when |
+| --- | --- |
+| required | value is null or empty |
+| minLength | `text.length < minLength` |
+| maxLength | `text.length > maxLength` |
+
+## Validation contract
+
+`AgentSurfaceField.validate(value: AgentSurfaceFieldValue?)` returns:
+
+- `FieldValidationResult.Valid` — the value passes every constraint on the
+  field.
+- `FieldValidationResult.Invalid(errors: List<String>)` — one or more
+  human-readable error messages, suitable to surface inline in the renderer.
+
+The predicate runs in pure Kotlin, identically on every target. That gives
+you three things:
+
+1. Renderers can validate before publishing `Submitted`. The contract says
+   they **must** — submission with invalid values is a contract violation.
+2. The Plugin can re-validate on receipt without trusting the wire. Don't
+   skip this. Validation runs twice by design.
+3. Tests share the predicates with the production path. There's no "test
+   helper" copy of the rules to drift.
+
+A value of the wrong variant — passing a `NumberValue` to a `Text` field,
+say — is treated as missing. `validate(NumberValue(1.0))` on a required
+`Text` field returns `Invalid` with the "is required" error.
+
+## Response shape
+
+A `Submitted` response from a `Form` carries:
+
+```kotlin
+AgentSurfaceResponse.Submitted(
+    correlationId: CorrelationId,
+    values: Map<String, AgentSurfaceFieldValue>,
+    chosenAction: String? = null,
+)
+```
+
+- `values` is keyed by `AgentSurfaceField.id`. The `AgentSurfaceFieldValue`
+  variant matches the field variant (`Text` ↔ `TextValue`, `Number` ↔
+  `NumberValue`, etc.).
+- `chosenAction` is null for forms. It's used by `Card`.
+
+`Cancelled` and `TimedOut` are the same as for any other surface.
+
+## Example
+
+```kotlin
+val correlationId = generateUUID(agentId, "create-pr")
+
+bus.emitSurfaceRequest(
+    surface = AgentSurface.Form(
+        correlationId = correlationId,
+        title = "Open a pull request",
+        description = "Describe the change. Reviewers see the title and body verbatim.",
+        fields = listOf(
+            AgentSurfaceField.Text(
+                id = "title",
+                label = "Title",
+                required = true,
+                minLength = 3,
+                maxLength = 72,
+                placeholder = "Short, imperative summary",
+            ),
+            AgentSurfaceField.Text(
+                id = "body",
+                label = "Description",
+                multiline = true,
+                helpText = "Markdown is fine.",
+            ),
+            AgentSurfaceField.Toggle(
+                id = "draft",
+                label = "Open as draft",
+                default = false,
+            ),
+        ),
+        submitLabel = "Open PR",
+    ),
+    eventSource = EventSource.Agent(agentId),
+)
+
+val response = bus.awaitSurfaceResponse(
+    awaiterAgentId = agentId,
+    correlationId = correlationId,
+    timeout = 2.minutes,
+)
+
+when (response) {
+    is AgentSurfaceResponse.Submitted -> {
+        val title = (response.values["title"] as AgentSurfaceFieldValue.TextValue).value
+        val body = (response.values["body"] as? AgentSurfaceFieldValue.TextValue)?.value.orEmpty()
+        val draft = (response.values["draft"] as? AgentSurfaceFieldValue.ToggleValue)?.value ?: false
+        openPullRequest(title = title, body = body, draft = draft)
+    }
+    is AgentSurfaceResponse.Cancelled -> Unit
+    is AgentSurfaceResponse.TimedOut -> log("PR form timed out at ${response.timeoutMillis}ms")
+}
+```
+
+## Constraints
+
+- **Field order is the contract.** Don't sort, group, or reorder fields in
+  the renderer. The Plugin chose the order for a reason.
+- **Field ids are stable.** They appear in `Submitted.values` and they
+  appear in tests. Treat them like serialised wire keys: you can add new
+  ones, but renaming is a breaking change.
+- **A field with no value still has a key on the response.** Optional fields
+  the user left blank either have no entry in `values` or have an entry
+  whose `String`/`Boolean`/etc. is empty/false. Read defensively; don't `!!`.
+
+<!-- platform-notes: pending W1.3 / W1.4 -->
+<!-- example: pending W2.1 -->


### PR DESCRIPTION
Closes #466.

Adds developer docs for the AgentSurface UI primitive under `docs/develop/` (getting-started, four variant references, design-patterns essay) with machine-greppable forward markers for the W1.3 / W1.4 renderer tickets and W2.1 reference-Plugin tickets. Adds `AgentSurfaceCliRenderer` in `ampere-cli` — the first generic renderer that closes the loop end-to-end on the JVM without pulling in Compose / SwiftUI / UIKit, with field-level validation re-prompts, secret masking via the JVM console, `Confirmation.Severity.Destructive` → red ANSI, and a `Mutex` that serialises concurrent emits. Tests cover every doc code sample (12) and the renderer driven through the real `EventSerialBus` with piped I/O (17) — all green.

Authored by Claude Opus 4.7 in collaboration with Miley.