### PR TITLE
Release 0.5.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,4 +26,4 @@ sqldelight.version=2.2.1
 mosaic.version=0.18.0
 
 #Ampere
-ampereVersion=0.4.0
+ampereVersion=0.5.0


### PR DESCRIPTION
## Summary
Bumps `ampereVersion` from `0.4.0` → `0.5.0` in `gradle.properties` ahead of the Maven Central publish.

## What's in this release
Ten merged feature PRs since v0.4.0 (AMPR-148 through AMPR-157): plugin permission schema, AgentSurface + AgentPause primitive type systems, cognition trace read model, plugin MCP manifest extension, plugin bundle format spec, on-device knowledge embeddings schema, concept cells, knowledge query primitive, and AgentSurface developer docs.

## Release procedure
After merge, tag the squashed/merge commit on `main` as `v0.5.0` and push the tag — the `publish.yml` workflow will validate the tag against `gradle.properties`, run tests, and publish to Maven Central. Then bump `gradle.properties` to `0.6.0-SNAPSHOT` per `docs/RELEASING.md`.

## Test plan
- [x] `./gradlew jvmTest` passes locally on this branch
- [ ] CI green on this PR
- [ ] After tag push: `publish.yml` succeeds and artifacts appear at https://search.maven.org/search?q=g:link.socket within ~30 minutes

---

_PR drafted and committed by Claude Opus 4.7 on Miley's behalf._