### PR TITLE
Fix HybridQueryRanker commonMain compile (unblocks v0.5.0 publish)

### DIFF
--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/knowledge/HybridQueryRanker.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/knowledge/HybridQueryRanker.kt
@@ -61,7 +61,7 @@ class HybridQueryRanker(
         // semantic hit so its enrichment wins ties (semantic queries usually
         // walk the document table; keyword search may not).
         val canonicalById = mutableMapOf<String, KnowledgeQueryResult>()
-        keywordResults.forEach { canonicalById.putIfAbsent(it.chunk.id, it) }
+        keywordResults.forEach { canonicalById.getOrPut(it.chunk.id) { it } }
         semanticResults.forEach { canonicalById[it.chunk.id] = it }
 
         return canonicalById.values


### PR DESCRIPTION
## Summary
The `v0.5.0` tag pushed by #478 triggered `publish.yml`, which failed at `:ampere-core:compileCommonMainKotlinMetadata` because `HybridQueryRanker.kt:64` used `MutableMap.putIfAbsent` — a JVM-only method not available in `commonMain`. The regular PR CI doesn't run the metadata-compile task, so the issue slipped through when AMPR-156 (#476) merged.

This swaps `putIfAbsent` for `getOrPut`, which exists in commonMain and is semantically identical when the return value is discarded inside `forEach`.

## Verification
- `./gradlew :ampere-core:compileCommonMainKotlinMetadata` — passes locally (was the failing task in the publish run)
- `./gradlew :ampere-core:jvmTest --tests "*HybridQueryRanker*"` — passes
- `./gradlew ktlintFormat` — clean

## Release recovery (after merge)
Maven Central never received `0.5.0` (publish failed before the upload step), so the `v0.5.0` tag can be safely moved to the merge commit and re-pushed to retrigger `publish.yml`:
```bash
git tag -f v0.5.0 <merge-commit>
git push origin v0.5.0 --force
```

---

_Fix authored and committed by Claude Opus 4.7 on Miley's behalf._