### PR TITLE
Dashboard render perf: batch diff runs, async goal activation, 20 FPS

### DIFF
--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/AmpereCommand.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/AmpereCommand.kt
@@ -239,10 +239,24 @@ class AmpereCommand(
                         ) { status -> systemStatus = status }
                     } else {
                         val effectiveGoal = goal!!
-                        val activationResult = goalHandler.activateGoal(effectiveGoal)
-                        if (activationResult.isFailure) {
-                            jazzPane.setFailed("Failed to activate goal: ${activationResult.exceptionOrNull()?.message}")
-                            systemStatus = StatusBar.SystemStatus.ATTENTION_NEEDED
+                        // Run activation asynchronously so the dashboard renders
+                        // while the agent factory and ticket orchestrator initialize.
+                        // Awaiting it here blocked the launch of the render and
+                        // input jobs below, so --goal showed a completely empty
+                        // terminal until activation completed.
+                        agentScope.launch {
+                            try {
+                                val activationResult = goalHandler.activateGoal(effectiveGoal)
+                                if (activationResult.isFailure) {
+                                    jazzPane.setFailed(
+                                        "Failed to activate goal: ${activationResult.exceptionOrNull()?.message}"
+                                    )
+                                    systemStatus = StatusBar.SystemStatus.ATTENTION_NEEDED
+                                }
+                            } catch (e: Exception) {
+                                jazzPane.setFailed("Goal activation crashed: ${e.message}")
+                                systemStatus = StatusBar.SystemStatus.ATTENTION_NEEDED
+                            }
                         }
                     }
                 }
@@ -280,7 +294,14 @@ class AmpereCommand(
                     if (configGoal != null) {
                         jazzPane.startDemo()
                         systemStatus = StatusBar.SystemStatus.WORKING
-                        goalHandler.activateGoal(configGoal)
+                        agentScope.launch {
+                            try {
+                                goalHandler.activateGoal(configGoal)
+                            } catch (e: Exception) {
+                                jazzPane.setFailed("Goal activation crashed: ${e.message}")
+                                systemStatus = StatusBar.SystemStatus.ATTENTION_NEEDED
+                            }
+                        }
                     }
                     // Otherwise: idle TUI dashboard
                 }
@@ -422,7 +443,7 @@ class AmpereCommand(
                             rightPane = rightPane,
                             statusBar = statusBarStr,
                             viewState = watchState,
-                            deltaSeconds = 0.25f
+                            deltaSeconds = 0.05f
                         )
                     }
 
@@ -431,7 +452,7 @@ class AmpereCommand(
                     out.print(output)
                     out.flush()
 
-                    delay(250) // Render at 4 FPS
+                    delay(50) // Render at 20 FPS
                 }
             }
 

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/hybrid/HybridCellBuffer.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/hybrid/HybridCellBuffer.kt
@@ -11,7 +11,7 @@ data class HybridCell(
     val layer: Int = 0
 )
 
-private const val ANSI_RESET = "\u001B[0m"
+private const val ANSI_RESET = "[0m"
 
 /**
  * Double-buffered cell buffer that supports layer compositing and differential rendering.
@@ -102,7 +102,7 @@ class HybridCellBuffer(
         return buildString {
             for (y in 0 until height) {
                 // Position cursor at start of row (1-based)
-                append("\u001B[${y + 1};1H")
+                append("[${y + 1};1H")
                 var lastColor: String? = null
 
                 for (x in 0 until width) {
@@ -121,15 +121,24 @@ class HybridCellBuffer(
                 if (lastColor != null) {
                     append(ANSI_RESET)
                 }
-                append("\u001B[K") // Clear rest of line
+                append("[K") // Clear rest of line
             }
         }
     }
 
     /**
      * Generate differential ANSI output.
-     * Compares current buffer against previous buffer,
-     * emits cursor-positioned writes only for changed cells.
+     *
+     * Walks the buffer row-by-row, detects contiguous runs of changed cells,
+     * and emits ONE cursor positioning escape per run. Within a run the
+     * current ANSI color is carried across cells — a reset is emitted only
+     * when the color actually changes or the run ends.
+     *
+     * Replaces a per-cell loop that emitted N cursor jumps + N color codes +
+     * N resets for N changed cells. Most terminals (notably macOS
+     * Terminal.app) flush internal state on every cursor positioning escape,
+     * so batching dramatically reduces terminal-side load on
+     * frequently-changing scenes.
      *
      * Falls back to renderFull on first frame or if no previous buffer exists.
      */
@@ -138,20 +147,29 @@ class HybridCellBuffer(
 
         return buildString {
             for (y in 0 until height) {
-                for (x in 0 until width) {
-                    val newCell = currentBuffer[y][x]
-                    val oldCell = prev[y][x]
-
-                    if (newCell != oldCell) {
-                        append("\u001B[${y + 1};${x + 1}H")
-                        if (newCell.ansiColor != null) {
-                            append(newCell.ansiColor)
-                            append(newCell.char)
-                            append(ANSI_RESET)
-                        } else {
-                            append(newCell.char)
-                        }
+                var x = 0
+                while (x < width) {
+                    if (currentBuffer[y][x] == prev[y][x]) {
+                        x++
+                        continue
                     }
+
+                    // Run start: emit one cursor positioning escape, then
+                    // walk forward emitting cells until we hit an unchanged
+                    // cell or the row ends. Color is carried across cells.
+                    append("[${y + 1};${x + 1}H")
+                    var lastColor: String? = null
+                    while (x < width && currentBuffer[y][x] != prev[y][x]) {
+                        val cell = currentBuffer[y][x]
+                        if (cell.ansiColor != lastColor) {
+                            if (lastColor != null) append(ANSI_RESET)
+                            if (cell.ansiColor != null) append(cell.ansiColor)
+                            lastColor = cell.ansiColor
+                        }
+                        append(cell.char)
+                        x++
+                    }
+                    if (lastColor != null) append(ANSI_RESET)
                 }
             }
         }


### PR DESCRIPTION
## Summary

Three independent improvements to the interactive dashboard. None of them change visible content; they improve responsiveness and unblock the dashboard from rendering on `--goal` startup.

- **Batch contiguous diff runs in `HybridCellBuffer.renderDiff`** — one cursor positioning escape per changed run, ANSI color carried across cells. Previously every changed cell emitted its own `ESC[r;cH` + color + reset. Most terminals (notably macOS Terminal.app) flush internal state on every cursor positioning escape, so batching dramatically reduces terminal-side load on frequently-changing scenes.
- **Async `goalHandler.activateGoal`** — was being awaited inline before the render and input jobs launched, so `--goal` showed a completely empty terminal until activation finished (often several seconds). Now launched on `agentScope` with try/catch that still routes failures to `setFailed` + `ATTENTION_NEEDED`. Same treatment for the `configGoal` fallback.
- **Render loop 4 FPS → 20 FPS** — `delay(250) → delay(50)` and `deltaSeconds 0.25f → 0.05f`. Camera orbit and pane updates read as motion rather than discrete jumps.

## Test plan

- [x] `./gradlew :ampere-cli:jvmTest` (all 657 tests pass)
- [x] `./gradlew ktlintFormat`
- [x] `./gradlew :ampere-core:compileCommonMainKotlinMetadata`
- [ ] Run `./ampere-cli/ampere` interactively and confirm the dashboard renders at a smooth 20 FPS
- [ ] Run `./ampere-cli/ampere --goal "..."` interactively and confirm the dashboard renders immediately (instead of staying blank until activation finishes)
- [ ] Sanity check that no rendering regressions appear (status bar, dividers, pane content all draw correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)