### PR TITLE
Release 0.6.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,4 +26,4 @@ sqldelight.version=2.2.1
 mosaic.version=0.18.0
 
 #Ampere
-ampereVersion=0.5.0
+ampereVersion=0.6.0


### PR DESCRIPTION
## Summary
Bumps `ampereVersion` from `0.5.0` → `0.6.0` in `gradle.properties` ahead of the Maven Central publish.

## What's in this release
Six merged PRs since v0.5.0:
- AMPR-167 #494: Ampere client-runtime readiness (MemoryStore + UpstreamLlmClient) (#495)
- Dashboard render perf: batch diff runs, async goal activation, 20 FPS (#493)
- AMPR-165 #489: Finish declarative spark migration (#491)
- AMPR-165 #489: JSON frontmatter for .spark.md + role spark registry (#490)
- AMPR-163 #486: complete spark-based agent migration (#488)
- AMPR-161 #482: declarative PhaseSpark surface + spark composition scaffolding (#485)
- [codex] Fix Ampere CLI build warnings (#483)

## Release procedure
After merge, tag the squashed/merge commit on `main` as `v0.6.0` and push the tag — the `publish.yml` workflow will validate the tag against `gradle.properties`, run tests, and publish to Maven Central. Then bump `gradle.properties` to `0.7.0-SNAPSHOT` per `docs/RELEASING.md`.

## Test plan
- [x] `./gradlew jvmTest` passes locally
- [x] `./gradlew :ampere-core:compileCommonMainKotlinMetadata` passes locally
- [x] `./gradlew ktlintFormat` clean
- [ ] CI green on this PR
- [ ] After tag push: `publish.yml` succeeds and artifacts appear at https://search.maven.org/search?q=g:link.socket within ~30 minutes

---

_PR drafted and committed by Claude Opus 4.7 on Miley's behalf._