### PR TITLE
AMPR-178/#507: Populate memory run IDs

### DIFF
--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/Agent.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/Agent.kt
@@ -9,6 +9,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 import link.socket.ampere.agents.config.AgentConfiguration
 import link.socket.ampere.agents.domain.AgentError
+import link.socket.ampere.agents.domain.RunId
 import link.socket.ampere.agents.domain.knowledge.Knowledge
 import link.socket.ampere.agents.domain.memory.AgentMemoryService
 import link.socket.ampere.agents.domain.memory.KnowledgeWithScore
@@ -183,12 +184,14 @@ sealed interface Agent<S : AgentState> {
      * @param knowledge The knowledge to persist
      * @param tags Optional tags for categorization
      * @param taskType Optional task type for context-based retrieval
+     * @param runId Optional Arc run correlation ID for trace projection
      * @return Result containing the stored knowledge entry or an error
      */
     suspend fun storeKnowledge(
         knowledge: Knowledge,
         tags: List<String> = emptyList(),
         taskType: String? = null,
+        runId: RunId? = null,
     ): Result<Unit> {
         val service = memoryService
         if (service == null) {
@@ -206,6 +209,7 @@ sealed interface Agent<S : AgentState> {
                 knowledge = knowledge,
                 tags = tags,
                 taskType = taskType,
+                runId = runId,
             ).fold(
                 onSuccess = { entry ->
                     logger.i { "Stored knowledge entry ${entry.id} of type ${entry.knowledgeType}" }

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/AutonomousAgent.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/AutonomousAgent.kt
@@ -412,7 +412,12 @@ abstract class AutonomousAgent<S : AgentState> : Agent<S>, NeuralAgent<S> {
             }
 
             // Store in long-term memory
-            storeKnowledge(knowledge, tags = tags, taskType = taskType)
+            storeKnowledge(
+                knowledge = knowledge,
+                tags = tags,
+                taskType = taskType,
+                runId = task.id.takeUnless { it.isBlank() },
+            )
         } catch (e: Exception) {
             // Logging is handled in storeKnowledge, just catch to prevent loop crash
         }

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/Identifiers.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/Identifiers.kt
@@ -3,3 +3,4 @@ package link.socket.ampere.agents.domain
 typealias TeamId = String
 typealias SprintId = String
 typealias PRId = String
+typealias RunId = String

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/knowledge/KnowledgeRepository.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/knowledge/KnowledgeRepository.kt
@@ -1,6 +1,7 @@
 package link.socket.ampere.agents.domain.knowledge
 
 import kotlinx.datetime.Instant
+import link.socket.ampere.agents.domain.RunId
 
 /**
  * Repository for storing and retrieving Knowledge entries to enable agent learning.
@@ -31,6 +32,7 @@ interface KnowledgeRepository {
      * @param tags Optional tags for categorization (e.g., "testing", "database", "validation")
      * @param taskType Optional task type for contextual filtering
      * @param complexityLevel Optional complexity indicator
+     * @param runId Optional Arc run correlation ID for trace projection
      * @return Result with the stored KnowledgeEntry or an error
      */
     suspend fun storeKnowledge(
@@ -38,6 +40,7 @@ interface KnowledgeRepository {
         tags: List<String> = emptyList(),
         taskType: String? = null,
         complexityLevel: String? = null,
+        runId: RunId? = null,
     ): Result<KnowledgeEntry>
 
     /**

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/knowledge/KnowledgeRepositoryImpl.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/knowledge/KnowledgeRepositoryImpl.kt
@@ -2,6 +2,7 @@ package link.socket.ampere.agents.domain.knowledge
 
 import kotlinx.coroutines.withContext
 import kotlinx.datetime.Instant
+import link.socket.ampere.agents.domain.RunId
 import link.socket.ampere.agents.events.utils.generateUUID
 import link.socket.ampere.db.Database
 import link.socket.ampere.db.memory.KnowledgeStore
@@ -30,6 +31,7 @@ class KnowledgeRepositoryImpl(
         tags: List<String>,
         taskType: String?,
         complexityLevel: String?,
+        runId: RunId?,
     ): Result<KnowledgeEntry> = withContext(ioDispatcher) {
         runCatching {
             // Generate ID based on knowledge type and source ID
@@ -59,20 +61,38 @@ class KnowledgeRepositoryImpl(
             }
 
             // Insert knowledge entry
-            queries.insertKnowledge(
-                id = id,
-                knowledge_type = knowledgeType.name,
-                approach = knowledge.approach,
-                learnings = knowledge.learnings,
-                timestamp = knowledge.timestamp.toEpochMilliseconds(),
-                idea_id = ideaId,
-                outcome_id = outcomeId,
-                perception_id = perceptionId,
-                plan_id = planId,
-                task_id = taskId,
-                task_type = taskType,
-                complexity_level = complexityLevel,
-            )
+            if (runId != null) {
+                queries.insertKnowledgeWithRunId(
+                    id = id,
+                    knowledge_type = knowledgeType.name,
+                    approach = knowledge.approach,
+                    learnings = knowledge.learnings,
+                    timestamp = knowledge.timestamp.toEpochMilliseconds(),
+                    run_id = runId,
+                    idea_id = ideaId,
+                    outcome_id = outcomeId,
+                    perception_id = perceptionId,
+                    plan_id = planId,
+                    task_id = taskId,
+                    task_type = taskType,
+                    complexity_level = complexityLevel,
+                )
+            } else {
+                queries.insertKnowledge(
+                    id = id,
+                    knowledge_type = knowledgeType.name,
+                    approach = knowledge.approach,
+                    learnings = knowledge.learnings,
+                    timestamp = knowledge.timestamp.toEpochMilliseconds(),
+                    idea_id = ideaId,
+                    outcome_id = outcomeId,
+                    perception_id = perceptionId,
+                    plan_id = planId,
+                    task_id = taskId,
+                    task_type = taskType,
+                    complexity_level = complexityLevel,
+                )
+            }
 
             // Insert tags
             tags.forEach { tag ->

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/memory/AgentMemoryService.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/memory/AgentMemoryService.kt
@@ -3,6 +3,7 @@ package link.socket.ampere.agents.domain.memory
 import kotlinx.coroutines.withContext
 import kotlinx.datetime.Clock
 import link.socket.ampere.agents.definition.AgentId
+import link.socket.ampere.agents.domain.RunId
 import link.socket.ampere.agents.domain.event.EventSource
 import link.socket.ampere.agents.domain.event.MemoryEvent
 import link.socket.ampere.agents.domain.knowledge.Knowledge
@@ -41,6 +42,7 @@ class AgentMemoryService(
      * @param tags Optional tags for categorization and filtering
      * @param taskType Optional task type for context-based retrieval
      * @param complexityLevel Optional complexity level for similarity matching
+     * @param runId Optional Arc run correlation ID for trace projection
      * @return Result containing the stored KnowledgeEntry or an error
      */
     suspend fun storeKnowledge(
@@ -48,6 +50,7 @@ class AgentMemoryService(
         tags: List<String> = emptyList(),
         taskType: String? = null,
         complexityLevel: ComplexityLevel? = null,
+        runId: RunId? = null,
     ): Result<KnowledgeEntry> = withContext(ioDispatcher) {
         // Store knowledge using the repository
         val result = knowledgeRepository.storeKnowledge(
@@ -55,6 +58,7 @@ class AgentMemoryService(
             tags = tags,
             taskType = taskType,
             complexityLevel = complexityLevel?.name,
+            runId = runId,
         )
 
         // Emit event on success
@@ -79,6 +83,7 @@ class AgentMemoryService(
                 approach = knowledge.approach,
                 learnings = knowledge.learnings,
                 sourceId = sourceId,
+                runId = runId,
             )
 
             eventBus.publish(event)

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/outcome/OutcomeMemoryRepository.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/outcome/OutcomeMemoryRepository.kt
@@ -1,6 +1,7 @@
 package link.socket.ampere.agents.domain.outcome
 
 import kotlinx.datetime.Instant
+import link.socket.ampere.agents.domain.RunId
 import link.socket.ampere.agents.events.tickets.TicketId
 import link.socket.ampere.agents.execution.executor.ExecutorId
 
@@ -28,6 +29,7 @@ interface OutcomeMemoryRepository {
      * @param approach Description of what was tried (from ticket + context)
      * @param outcome The execution outcome (success or failure)
      * @param timestamp When this execution completed
+     * @param runId Optional Arc run correlation ID for trace projection
      * @return Result with the created OutcomeMemory or an error
      */
     suspend fun recordOutcome(
@@ -36,6 +38,7 @@ interface OutcomeMemoryRepository {
         approach: String,
         outcome: ExecutionOutcome,
         timestamp: Instant,
+        runId: RunId? = null,
     ): Result<OutcomeMemory>
 
     /**

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/outcome/OutcomeMemoryRepositoryImpl.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/outcome/OutcomeMemoryRepositoryImpl.kt
@@ -2,6 +2,7 @@ package link.socket.ampere.agents.domain.outcome
 
 import kotlinx.coroutines.withContext
 import kotlinx.datetime.Instant
+import link.socket.ampere.agents.domain.RunId
 import link.socket.ampere.agents.events.tickets.TicketId
 import link.socket.ampere.agents.events.utils.generateUUID
 import link.socket.ampere.agents.execution.executor.ExecutorId
@@ -29,6 +30,7 @@ class OutcomeMemoryRepositoryImpl(
         approach: String,
         outcome: ExecutionOutcome,
         timestamp: Instant,
+        runId: RunId?,
     ): Result<OutcomeMemory> = withContext(ioDispatcher) {
         runCatching {
             val id = generateUUID(ticketId, executorId)
@@ -86,17 +88,32 @@ class OutcomeMemoryRepositoryImpl(
                 }
             }
 
-            queries.insertOutcome(
-                id = id,
-                ticket_id = ticketId,
-                executor_id = executorId,
-                approach = approach,
-                success = if (success) 1L else 0L,
-                execution_duration_ms = executionDurationMs,
-                files_changed = filesChanged.toLong(),
-                error_message = errorMessage,
-                timestamp = timestamp.toEpochMilliseconds(),
-            )
+            if (runId != null) {
+                queries.insertOutcomeWithRunId(
+                    id = id,
+                    ticket_id = ticketId,
+                    executor_id = executorId,
+                    approach = approach,
+                    success = if (success) 1L else 0L,
+                    execution_duration_ms = executionDurationMs,
+                    files_changed = filesChanged.toLong(),
+                    error_message = errorMessage,
+                    timestamp = timestamp.toEpochMilliseconds(),
+                    run_id = runId,
+                )
+            } else {
+                queries.insertOutcome(
+                    id = id,
+                    ticket_id = ticketId,
+                    executor_id = executorId,
+                    approach = approach,
+                    success = if (success) 1L else 0L,
+                    execution_duration_ms = executionDurationMs,
+                    files_changed = filesChanged.toLong(),
+                    error_message = errorMessage,
+                    timestamp = timestamp.toEpochMilliseconds(),
+                )
+            }
 
             OutcomeMemory(
                 id = id,

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/reasoning/AgentReasoning.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/reasoning/AgentReasoning.kt
@@ -2,6 +2,7 @@ package link.socket.ampere.agents.domain.reasoning
 
 import kotlinx.datetime.Clock
 import link.socket.ampere.agents.config.AgentConfiguration
+import link.socket.ampere.agents.domain.RunId
 import link.socket.ampere.agents.domain.knowledge.Knowledge
 import link.socket.ampere.agents.domain.memory.AgentMemoryService
 import link.socket.ampere.agents.domain.memory.KnowledgeWithScore
@@ -181,22 +182,25 @@ class AgentReasoning private constructor(
     suspend fun evaluateOutcomes(
         outcomes: List<Outcome>,
         memoryService: AgentMemoryService? = null,
+        runId: RunId? = null,
     ): EvaluationResult {
         // Use mock response if available
         mockResponses?.outcomeEvaluator?.let { evaluator ->
             return evaluator(outcomes)
         }
 
+        val effectiveRunId = runId ?: outcomes.firstRunIdOrNull()
         val result = outcomeEvaluator?.evaluate(
             outcomes = outcomes,
             agentRole = settings.agentRole,
             contextBuilder = null,
+            runId = effectiveRunId,
         ) ?: throw IllegalStateException("No outcome evaluator configured")
 
         // Store learnings in memory if available
         if (result.knowledge.isNotEmpty() && memoryService != null) {
             result.knowledge.forEach { knowledge ->
-                memoryService.storeKnowledge(knowledge)
+                memoryService.storeKnowledge(knowledge, runId = effectiveRunId)
             }
         }
 
@@ -317,6 +321,15 @@ class AgentReasoning private constructor(
         }
     }
 }
+
+private fun List<Outcome>.firstRunIdOrNull(): RunId? =
+    filterIsInstance<ExecutionOutcome>()
+        .firstOrNull()
+        ?.taskId
+        ?.takeUnless { it.isBlank() }
+        ?: firstOrNull()
+            ?.id
+            ?.takeUnless { it.isBlank() }
 
 /**
  * Mock responses container for testing AgentReasoning.

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/reasoning/OutcomeEvaluator.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/reasoning/OutcomeEvaluator.kt
@@ -3,6 +3,7 @@ package link.socket.ampere.agents.domain.reasoning
 import kotlinx.datetime.Clock
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import link.socket.ampere.agents.domain.RunId
 import link.socket.ampere.agents.domain.cognition.sparks.CognitivePhase
 import link.socket.ampere.agents.domain.knowledge.Knowledge
 import link.socket.ampere.agents.domain.outcome.ExecutionOutcome
@@ -47,12 +48,14 @@ class OutcomeEvaluator(
      * @param outcomes List of outcomes from recent executions
      * @param agentRole Description of the agent's role
      * @param contextBuilder Optional custom context builder for outcomes
+     * @param runId Optional Arc run correlation ID for trace projection
      * @return EvaluationResult containing knowledge and summary idea
      */
     suspend fun evaluate(
         outcomes: List<Outcome>,
         agentRole: String,
         contextBuilder: ((List<Outcome>) -> String)? = null,
+        runId: RunId? = null,
     ): EvaluationResult {
         // Handle empty or blank outcomes
         if (outcomes.isEmpty()) {
@@ -89,7 +92,8 @@ class OutcomeEvaluator(
                     phase = CognitivePhase.LEARN,
                     agentId = llmService.agentId,
                     agentRole = agentRole,
-                    workflowId = outcomes.filterIsInstance<ExecutionOutcome>().firstOrNull()?.taskId
+                    workflowId = runId
+                        ?: outcomes.filterIsInstance<ExecutionOutcome>().firstOrNull()?.taskId
                         ?: outcomes.firstOrNull()?.id,
                 ),
             )

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/api/internal/DefaultKnowledgeService.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/api/internal/DefaultKnowledgeService.kt
@@ -1,5 +1,6 @@
 package link.socket.ampere.api.internal
 
+import link.socket.ampere.agents.domain.RunId
 import link.socket.ampere.agents.domain.knowledge.Knowledge
 import link.socket.ampere.agents.domain.knowledge.KnowledgeEntry
 import link.socket.ampere.agents.domain.knowledge.KnowledgeRepository
@@ -15,11 +16,13 @@ internal class DefaultKnowledgeService(
         tags: List<String>,
         taskType: String?,
         complexityLevel: String?,
+        runId: RunId?,
     ): Result<KnowledgeEntry> = knowledgeRepository.storeKnowledge(
         knowledge = knowledge,
         tags = tags,
         taskType = taskType,
         complexityLevel = complexityLevel,
+        runId = runId,
     )
 
     override suspend fun get(id: String): Result<KnowledgeEntry?> =

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/api/service/KnowledgeService.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/api/service/KnowledgeService.kt
@@ -1,5 +1,6 @@
 package link.socket.ampere.api.service
 
+import link.socket.ampere.agents.domain.RunId
 import link.socket.ampere.agents.domain.knowledge.Knowledge
 import link.socket.ampere.agents.domain.knowledge.KnowledgeEntry
 import link.socket.ampere.agents.domain.knowledge.KnowledgeType
@@ -31,12 +32,14 @@ interface KnowledgeService {
      * @param tags Optional tags for categorization
      * @param taskType Optional task type for context
      * @param complexityLevel Optional complexity annotation
+     * @param runId Optional Arc run correlation ID for trace projection
      */
     suspend fun store(
         knowledge: Knowledge,
         tags: List<String> = emptyList(),
         taskType: String? = null,
         complexityLevel: String? = null,
+        runId: RunId? = null,
     ): Result<KnowledgeEntry>
 
     /**

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/api/service/stub/StubKnowledgeService.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/api/service/stub/StubKnowledgeService.kt
@@ -1,6 +1,7 @@
 package link.socket.ampere.api.service.stub
 
 import kotlinx.datetime.Clock
+import link.socket.ampere.agents.domain.RunId
 import link.socket.ampere.agents.domain.knowledge.Knowledge
 import link.socket.ampere.agents.domain.knowledge.KnowledgeEntry
 import link.socket.ampere.agents.domain.knowledge.KnowledgeType
@@ -20,6 +21,7 @@ class StubKnowledgeService : KnowledgeService {
         tags: List<String>,
         taskType: String?,
         complexityLevel: String?,
+        runId: RunId?,
     ): Result<KnowledgeEntry> {
         knowledgeCounter++
         return Result.success(

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/memory/MemoryStoreTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/memory/MemoryStoreTest.kt
@@ -6,6 +6,7 @@ import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
+import link.socket.ampere.agents.domain.RunId
 import link.socket.ampere.agents.domain.knowledge.Knowledge
 import link.socket.ampere.agents.domain.knowledge.KnowledgeEntry
 import link.socket.ampere.agents.domain.knowledge.KnowledgeRepository
@@ -94,6 +95,7 @@ private class RecordingKnowledgeRepository : KnowledgeRepository {
         tags: List<String>,
         taskType: String?,
         complexityLevel: String?,
+        runId: RunId?,
     ): Result<KnowledgeEntry> {
         stored += knowledge
         return Result.success(
@@ -167,6 +169,7 @@ private class RecordingOutcomeRepository : OutcomeMemoryRepository {
         approach: String,
         outcome: ExecutionOutcome,
         timestamp: kotlinx.datetime.Instant,
+        runId: RunId?,
     ): Result<OutcomeMemory> {
         val memory = OutcomeMemory(
             id = "memory-${recorded.size}",

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/domain/memory/KnowledgeRepositoryTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/domain/memory/KnowledgeRepositoryTest.kt
@@ -30,13 +30,14 @@ import link.socket.ampere.db.Database
 class KnowledgeRepositoryTest {
 
     private lateinit var driver: JdbcSqliteDriver
+    private lateinit var database: Database
     private lateinit var repo: KnowledgeRepository
 
     @BeforeTest
     fun setUp() {
         driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
         Database.Schema.create(driver)
-        val database = Database(driver)
+        database = Database(driver)
         repo = KnowledgeRepositoryImpl(database)
     }
 
@@ -122,6 +123,46 @@ class KnowledgeRepositoryTest {
     // =============================================================================
     // REQUIREMENT 1: Insert and retrieve all five Knowledge subtypes by ID
     // =============================================================================
+
+    @Test
+    fun `storeKnowledge with runId populates run_id column`() = runBlocking {
+        val runId = "run-knowledge-1"
+        val knowledge = createKnowledgeFromOutcome()
+
+        val result = repo.storeKnowledge(
+            knowledge = knowledge,
+            tags = listOf("trace"),
+            taskType = "trace",
+            runId = runId,
+        )
+
+        assertTrue(result.isSuccess)
+        val stored = assertNotNull(result.getOrNull())
+        val row = database.knowledgeStoreQueries
+            .getKnowledgeById(stored.id)
+            .executeAsOne()
+
+        assertEquals(runId, row.run_id)
+    }
+
+    @Test
+    fun `storeKnowledge without runId leaves run_id column null`() = runBlocking {
+        val knowledge = createKnowledgeFromOutcome(outcomeId = "outcome-without-run")
+
+        val result = repo.storeKnowledge(
+            knowledge = knowledge,
+            tags = listOf("trace"),
+            taskType = "trace",
+        )
+
+        assertTrue(result.isSuccess)
+        val stored = assertNotNull(result.getOrNull())
+        val row = database.knowledgeStoreQueries
+            .getKnowledgeById(stored.id)
+            .executeAsOne()
+
+        assertNull(row.run_id)
+    }
 
     @Test
     fun `storeKnowledge successfully stores and retrieves FromIdea knowledge`() = runBlocking {

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/domain/memory/OutcomeMemoryRepositoryTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/domain/memory/OutcomeMemoryRepositoryTest.kt
@@ -32,13 +32,14 @@ import link.socket.ampere.db.Database
 class OutcomeMemoryRepositoryTest {
 
     private lateinit var driver: JdbcSqliteDriver
+    private lateinit var database: Database
     private lateinit var repo: OutcomeMemoryRepository
 
     @BeforeTest
     fun setUp() {
         driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
         Database.Schema.create(driver)
-        val database = Database(driver)
+        database = Database(driver)
         repo = OutcomeMemoryRepositoryImpl(database)
     }
 
@@ -99,6 +100,50 @@ class OutcomeMemoryRepositoryTest {
     // =============================================================================
     // RECORD OUTCOME TESTS
     // =============================================================================
+
+    @Test
+    fun `recordOutcome with runId populates run_id column`() = runBlocking {
+        val runId = "run-outcome-1"
+        val outcome = createSuccessfulOutcome()
+
+        val result = repo.recordOutcome(
+            ticketId = ticketId1,
+            executorId = executorId1,
+            approach = "Traceable execution",
+            outcome = outcome,
+            timestamp = outcome.executionEndTimestamp,
+            runId = runId,
+        )
+
+        assertTrue(result.isSuccess)
+        val stored = assertNotNull(result.getOrNull())
+        val row = database.outcomeMemoryStoreQueries
+            .getOutcomeById(stored.id)
+            .executeAsOne()
+
+        assertEquals(runId, row.run_id)
+    }
+
+    @Test
+    fun `recordOutcome without runId leaves run_id column null`() = runBlocking {
+        val outcome = createSuccessfulOutcome()
+
+        val result = repo.recordOutcome(
+            ticketId = ticketId1,
+            executorId = executorId1,
+            approach = "Unattributed execution",
+            outcome = outcome,
+            timestamp = outcome.executionEndTimestamp,
+        )
+
+        assertTrue(result.isSuccess)
+        val stored = assertNotNull(result.getOrNull())
+        val row = database.outcomeMemoryStoreQueries
+            .getOutcomeById(stored.id)
+            .executeAsOne()
+
+        assertNull(row.run_id)
+    }
 
     @Test
     fun `recordOutcome successfully stores and retrieves successful outcome`() = runBlocking {

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/api/ConsumerSimulationTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/api/ConsumerSimulationTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import link.socket.ampere.agents.definition.AgentId
+import link.socket.ampere.agents.domain.RunId
 import link.socket.ampere.agents.domain.event.Event
 import link.socket.ampere.agents.domain.knowledge.Knowledge
 import link.socket.ampere.agents.domain.knowledge.KnowledgeEntry
@@ -212,6 +213,7 @@ class ConsumerSimulationTest {
             tags: List<String>,
             taskType: String?,
             complexityLevel: String?,
+            runId: RunId?,
         ) =
             Result.success(
                 KnowledgeEntry(

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/trace/ArcTraceProjectionTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/trace/ArcTraceProjectionTest.kt
@@ -20,8 +20,13 @@ import link.socket.ampere.agents.domain.event.MemoryEvent
 import link.socket.ampere.agents.domain.event.ProviderCallCompletedEvent
 import link.socket.ampere.agents.domain.event.ProviderCallStartedEvent
 import link.socket.ampere.agents.domain.event.ToolEvent
+import link.socket.ampere.agents.domain.knowledge.Knowledge
+import link.socket.ampere.agents.domain.knowledge.KnowledgeRepositoryImpl
 import link.socket.ampere.agents.domain.knowledge.KnowledgeType
+import link.socket.ampere.agents.domain.outcome.ExecutionOutcome
+import link.socket.ampere.agents.domain.outcome.OutcomeMemoryRepositoryImpl
 import link.socket.ampere.agents.events.EventRepository
+import link.socket.ampere.agents.execution.results.ExecutionResult
 import link.socket.ampere.api.model.TokenUsage
 import link.socket.ampere.data.DEFAULT_JSON
 import link.socket.ampere.db.Database
@@ -113,6 +118,62 @@ class ArcTraceProjectionTest {
             elapsed.inWholeMilliseconds < 50,
             "Projection took ${elapsed.inWholeMilliseconds}ms",
         )
+    }
+
+    @Test
+    fun `projects memory rows written through repositories with runId`() = runTest {
+        val runId = "run-memory-repository"
+        val timestamp = Instant.fromEpochMilliseconds(2_000)
+        val knowledgeRepository = KnowledgeRepositoryImpl(database)
+        val outcomeRepository = OutcomeMemoryRepositoryImpl(database)
+
+        val storedKnowledge = knowledgeRepository.storeKnowledge(
+            knowledge = Knowledge.FromOutcome(
+                outcomeId = "outcome-memory-repository",
+                approach = "Write through repository",
+                learnings = "Run-attributed rows project into the trace",
+                timestamp = timestamp,
+            ),
+            tags = listOf("trace"),
+            taskType = "trace",
+            runId = runId,
+        ).getOrThrow()
+
+        val executionOutcome = ExecutionOutcome.CodeChanged.Success(
+            executorId = "agent-memory-repository",
+            ticketId = "ticket-memory-repository",
+            taskId = runId,
+            executionStartTimestamp = timestamp,
+            executionEndTimestamp = Instant.fromEpochMilliseconds(2_500),
+            changedFiles = listOf("Trace.kt"),
+            validation = ExecutionResult(
+                codeChanges = null,
+                compilation = null,
+                linting = null,
+                tests = null,
+            ),
+        )
+
+        val storedOutcome = outcomeRepository.recordOutcome(
+            ticketId = executionOutcome.ticketId,
+            executorId = executionOutcome.executorId,
+            approach = "Run tests after writing trace code",
+            outcome = executionOutcome,
+            timestamp = executionOutcome.executionEndTimestamp,
+            runId = runId,
+        ).getOrThrow()
+
+        val trace = projection.project(runId).getOrThrow()
+        val memoryWrites = trace.phases.flatMap { it.memoryWrites }
+
+        val projectedKnowledge = assertNotNull(memoryWrites.firstOrNull { it.id == storedKnowledge.id })
+        assertEquals("LEARN", projectedKnowledge.phaseName)
+        assertEquals("Write through repository", projectedKnowledge.approach)
+        assertEquals(listOf("trace"), projectedKnowledge.tags)
+
+        val projectedOutcome = assertNotNull(memoryWrites.firstOrNull { it.id == storedOutcome.id })
+        assertEquals("EXECUTE", projectedOutcome.phaseName)
+        assertEquals("Run tests after writing trace code", projectedOutcome.approach)
     }
 
     private suspend fun seedTrace(runId: String) {

--- a/docs/concepts/memory-provenance.md
+++ b/docs/concepts/memory-provenance.md
@@ -8,7 +8,7 @@ tracked_sources:
   - ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/MemoryEvent.kt
   - ampere-core/src/commonMain/sqldelight/link/socket/ampere/db/memory/**
 related: [PropelLoop, CognitionTrace, EventSerialBus, DreamCycle]
-last_verified: 2026-04-29
+last_verified: 2026-05-27
 ---
 
 # Memory Provenance

--- a/docs/concepts/propel-loop.md
+++ b/docs/concepts/propel-loop.md
@@ -8,7 +8,7 @@ tracked_sources:
   - ampere-core/src/commonMain/kotlin/link/socket/ampere/trace/ArcRunTrace.kt
   - docs/AGENT_LIFECYCLE.md
 related: [CognitiveRelay, MemoryProvenance, SparkSystem, CognitionTrace, EventSerialBus]
-last_verified: 2026-04-29
+last_verified: 2026-05-27
 ---
 
 # PROPEL Loop


### PR DESCRIPTION
Codex-authored change for Linear AMPR-178 / GitHub #507.

Closes #507.

This adds optional runId propagation through Knowledge and Outcome memory writers, using the existing WithRunId SQL inserts while preserving null fallbacks.

It threads available run context through memory service/reasoning APIs and verifies ArcTraceProjection returns repository-written memory rows by run.

Validation: `./gradlew :ampere-core:compileCommonMainKotlinMetadata`, `./gradlew ktlintFormat`, `./gradlew jvmTest`.