### PR TITLE
AMPR-173 #502 Add EscalationFired cognitive event

### DIFF
--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/watch/presentation/EventCategorizer.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/watch/presentation/EventCategorizer.kt
@@ -1,6 +1,7 @@
 package link.socket.ampere.cli.watch.presentation
 
 import link.socket.ampere.agents.domain.event.AgentSurfaceEvent
+import link.socket.ampere.agents.domain.event.CognitiveEvent
 import link.socket.ampere.agents.domain.event.Event
 import link.socket.ampere.agents.domain.event.FileSystemEvent
 import link.socket.ampere.agents.domain.event.GitEvent
@@ -52,6 +53,7 @@ object EventCategorizer {
     private fun categorizeInternal(event: Event): EventSignificance = when (event) {
         // Critical events require immediate human awareness
         is Event.QuestionRaised,
+        is CognitiveEvent.EscalationFired,
         is TicketEvent.TicketBlocked,
         is MessageEvent.EscalationRequested,
         is HumanInteractionEvent.InputRequested,

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/watch/presentation/WatchPresenter.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/watch/presentation/WatchPresenter.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
+import link.socket.ampere.agents.domain.event.CognitiveEvent
 import link.socket.ampere.agents.domain.event.CognitiveStateSnapshot
 import link.socket.ampere.agents.domain.event.Event
 import link.socket.ampere.agents.domain.event.EventSource
@@ -371,6 +372,9 @@ class WatchPresenter(
                 "\"$content\""
             }
             is MessageEvent.EscalationRequested -> "⚠️ Escalation: ${event.reason.take(50)}"
+            is CognitiveEvent.EscalationFired -> {
+                "Uncertainty escalation: ${event.uncertaintyValue} >= ${event.threshold}"
+            }
             is MemoryEvent.KnowledgeRecalled -> {
                 val count = event.resultsFound
                 if (count > 0) "Recalled $count items (relevance: ${String.format("%.0f%%", event.averageRelevance * 100)})"

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/renderer/EventRenderer.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/renderer/EventRenderer.kt
@@ -13,6 +13,7 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import link.socket.ampere.agents.domain.Urgency
 import link.socket.ampere.agents.domain.event.AgentSurfaceEvent
+import link.socket.ampere.agents.domain.event.CognitiveEvent
 import link.socket.ampere.agents.domain.event.Event
 import link.socket.ampere.agents.domain.event.EventSource
 import link.socket.ampere.agents.domain.event.FileSystemEvent
@@ -134,6 +135,7 @@ class EventRenderer(
             is Event.CodeSubmitted -> "💻" to cyan
             is Event.QuestionRaised -> "❓" to magenta
             is Event.TaskCreated -> "📋" to green
+            is CognitiveEvent.EscalationFired -> "❓" to red
             is TaskEvent -> "📋" to green
             is FileSystemEvent -> "📄" to cyan
             is GitEvent -> "🪾" to cyan

--- a/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/cli/watch/presentation/EventCategorizerTest.kt
+++ b/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/cli/watch/presentation/EventCategorizerTest.kt
@@ -4,6 +4,7 @@ import kotlinx.datetime.Clock
 import link.socket.ampere.agents.domain.Urgency
 import link.socket.ampere.agents.domain.knowledge.KnowledgeType
 import link.socket.ampere.agents.domain.status.TicketStatus
+import link.socket.ampere.agents.domain.event.CognitiveEvent
 import link.socket.ampere.agents.domain.event.Event
 import link.socket.ampere.agents.domain.event.EventSource
 import link.socket.ampere.agents.domain.event.MemoryEvent
@@ -61,6 +62,24 @@ class EventCategorizerTest {
             urgency = Urgency.HIGH,
             threadId = "thread-1",
             reason = "Need human input on critical decision"
+        )
+
+        val significance = EventCategorizer.categorize(event)
+        assertEquals(EventSignificance.CRITICAL, significance)
+    }
+
+    @Test
+    fun `CRITICAL - EscalationFired events are critical`() {
+        val event = CognitiveEvent.EscalationFired(
+            eventId = "evt-escalation-fired",
+            timestamp = Clock.System.now(),
+            eventSource = EventSource.Agent("agent-test"),
+            urgency = Urgency.HIGH,
+            agentId = "agent-test",
+            uncertaintyValue = 0.9,
+            threshold = 0.7,
+            prompt = "Need confidence threshold escalation",
+            cognitivePhase = null,
         )
 
         val significance = EventCategorizer.categorize(event)

--- a/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/renderer/EventRendererTest.kt
+++ b/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/renderer/EventRendererTest.kt
@@ -5,6 +5,7 @@ import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
+import link.socket.ampere.agents.domain.event.CognitiveEvent
 import link.socket.ampere.agents.domain.event.Event
 import link.socket.ampere.agents.domain.event.CognitiveStateSnapshot
 import link.socket.ampere.agents.domain.event.EventSource
@@ -209,6 +210,23 @@ class EventRendererTest {
         success = success,
     )
 
+    private fun escalationFiredEvent(
+        eventId: String = "evt-escalation-fired-1",
+        timestamp: Instant = Clock.System.now(),
+        source: EventSource = EventSource.Agent("agent-test"),
+        urgency: Urgency = Urgency.HIGH,
+    ): CognitiveEvent.EscalationFired = CognitiveEvent.EscalationFired(
+        eventId = eventId,
+        timestamp = timestamp,
+        eventSource = source,
+        urgency = urgency,
+        agentId = "agent-test",
+        uncertaintyValue = 0.9,
+        threshold = 0.7,
+        prompt = "Need human decision",
+        cognitivePhase = null,
+    )
+
     @Test
     fun `render TaskCreated event shows task ID, description, and assignment`() {
         val output = captureTerminalOutput { _, renderer ->
@@ -403,6 +421,12 @@ class EventRendererTest {
             renderer.render(codeEvent())
         }
         assertContains(codeOutput, "💻")
+
+        val escalationOutput = captureTerminalOutput { _, renderer ->
+            renderer.render(escalationFiredEvent())
+        }
+        assertContains(escalationOutput, "❓")
+        assertContains(escalationOutput, "EscalationFired")
     }
 
     @Test

--- a/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/util/EventTypeParserTest.kt
+++ b/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/util/EventTypeParserTest.kt
@@ -5,6 +5,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import link.socket.ampere.agents.domain.event.Event
+import link.socket.ampere.agents.domain.event.CognitiveEvent
 import link.socket.ampere.agents.domain.event.MeetingEvent
 import link.socket.ampere.agents.domain.event.MessageEvent
 import link.socket.ampere.agents.domain.event.NotificationEvent
@@ -44,6 +45,11 @@ class EventTypeParserTest {
         assertNotNull(EventTypeParser.parse("TaskCreated"))
         assertNotNull(EventTypeParser.parse("QuestionRaised"))
         assertNotNull(EventTypeParser.parse("CodeSubmitted"))
+    }
+
+    @Test
+    fun `parse handles CognitiveEvent types`() {
+        assertNotNull(EventTypeParser.parse("EscalationFired"))
     }
 
     @Test
@@ -149,6 +155,7 @@ class EventTypeParserTest {
         assertTrue(allTypes.contains(Event.TaskCreated.EVENT_TYPE))
         assertTrue(allTypes.contains(Event.QuestionRaised.EVENT_TYPE))
         assertTrue(allTypes.contains(Event.CodeSubmitted.EVENT_TYPE))
+        assertTrue(allTypes.contains(CognitiveEvent.EscalationFired.EVENT_TYPE))
 
         // Should have meeting events
         assertTrue(allTypes.contains(MeetingEvent.MeetingScheduled.EVENT_TYPE))

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/CognitiveEvent.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/CognitiveEvent.kt
@@ -1,0 +1,63 @@
+package link.socket.ampere.agents.domain.event
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import link.socket.ampere.agents.definition.AgentId
+import link.socket.ampere.agents.domain.Urgency
+import link.socket.ampere.agents.domain.cognition.sparks.CognitivePhase
+
+/**
+ * Events emitted by cognitive evaluators outside normal phase transitions.
+ */
+@Serializable
+sealed interface CognitiveEvent : Event {
+
+    val agentId: AgentId
+
+    /**
+     * Emitted when an agent's uncertainty meets or exceeds its configured escalation threshold.
+     */
+    @Serializable
+    @SerialName("CognitiveEvent.EscalationFired")
+    data class EscalationFired(
+        override val eventId: EventId,
+        override val timestamp: Instant,
+        override val eventSource: EventSource,
+        override val urgency: Urgency = Urgency.HIGH,
+        override val agentId: AgentId,
+        val uncertaintyValue: Double,
+        val threshold: Double,
+        val prompt: String,
+        val cognitivePhase: CognitivePhase?,
+    ) : CognitiveEvent {
+
+        override val eventType: EventType = EVENT_TYPE
+
+        override fun getSummary(
+            formatUrgency: (Urgency) -> String,
+            formatSource: (EventSource) -> String,
+        ): String = buildString {
+            append("Escalation fired for $agentId: uncertainty ")
+            append(uncertaintyValue.formatRatio())
+            append(" >= threshold ")
+            append(threshold.formatRatio())
+            cognitivePhase?.let { append(" [${it.name}]") }
+            if (prompt.isNotBlank()) {
+                append(" - ${prompt.take(80)}")
+                if (prompt.length > 80) append("...")
+            }
+            append(" ${formatUrgency(urgency)}")
+            append(" from ${formatSource(eventSource)}")
+        }
+
+        companion object {
+            const val EVENT_TYPE: EventType = "EscalationFired"
+        }
+    }
+}
+
+private fun Double.formatRatio(): String {
+    val rounded = (this * 1000.0).toInt() / 1000.0
+    return rounded.toString()
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/EventRegistry.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/EventRegistry.kt
@@ -30,6 +30,9 @@ object EventRegistry {
         Event.QuestionRaised.EVENT_TYPE,
         Event.CodeSubmitted.EVENT_TYPE,
 
+        // CognitiveEvent types
+        CognitiveEvent.EscalationFired.EVENT_TYPE,
+
         // MeetingEvent types
         MeetingEvent.MeetingScheduled.EVENT_TYPE,
         MeetingEvent.MeetingStarted.EVENT_TYPE,

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/api/AgentEventApi.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/api/AgentEventApi.kt
@@ -5,6 +5,7 @@ import kotlinx.datetime.Instant
 import link.socket.ampere.agents.config.AgentActionAutonomy
 import link.socket.ampere.agents.definition.AgentId
 import link.socket.ampere.agents.domain.Urgency
+import link.socket.ampere.agents.domain.event.CognitiveEvent
 import link.socket.ampere.agents.domain.event.Event
 import link.socket.ampere.agents.domain.event.EventSource
 import link.socket.ampere.agents.domain.event.EventType
@@ -192,6 +193,20 @@ class AgentEventApi(
         eventSerialBus.subscribe<Event.CodeSubmitted, EventSubscription.ByEventClassType>(
             agentId = agentId,
             eventType = Event.CodeSubmitted.EVENT_TYPE,
+        ) { event, subscription ->
+            if (filter.execute(event)) {
+                handler(event, subscription)
+            }
+        }
+
+    /** Subscribe to threshold-driven cognitive escalation events. */
+    fun onEscalationFired(
+        filter: EventFilter<CognitiveEvent.EscalationFired> = EventFilter.noFilter(),
+        handler: suspend (CognitiveEvent.EscalationFired, Subscription?) -> Unit,
+    ): Subscription =
+        eventSerialBus.subscribe<CognitiveEvent.EscalationFired, EventSubscription.ByEventClassType>(
+            agentId = agentId,
+            eventType = CognitiveEvent.EscalationFired.EVENT_TYPE,
         ) { event, subscription ->
             if (filter.execute(event)) {
                 handler(event, subscription)

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/escalation/UncertaintyEscalationEvaluator.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/escalation/UncertaintyEscalationEvaluator.kt
@@ -1,0 +1,71 @@
+package link.socket.ampere.agents.events.escalation
+
+import kotlinx.datetime.Clock
+import link.socket.ampere.agents.definition.AgentId
+import link.socket.ampere.agents.domain.Urgency
+import link.socket.ampere.agents.domain.cognition.sparks.CognitivePhase
+import link.socket.ampere.agents.domain.event.CognitiveEvent
+import link.socket.ampere.agents.domain.event.EventSource
+import link.socket.ampere.agents.events.api.AgentEventApi
+import link.socket.ampere.agents.events.utils.generateUUID
+
+/**
+ * Evaluates uncertainty against an escalation threshold and publishes the threshold-fired signal.
+ */
+class UncertaintyEscalationEvaluator(
+    private val agentId: AgentId,
+    private val publishEscalationFired: suspend (CognitiveEvent.EscalationFired) -> Unit,
+    private val clock: Clock = Clock.System,
+) {
+
+    constructor(
+        agentEventApi: AgentEventApi,
+        clock: Clock = Clock.System,
+    ) : this(
+        agentId = agentEventApi.agentId,
+        publishEscalationFired = { event -> agentEventApi.publish(event) },
+        clock = clock,
+    )
+
+    /**
+     * @return true when the threshold fired and an [CognitiveEvent.EscalationFired] was published.
+     */
+    suspend fun evaluate(
+        uncertaintyValue: Double,
+        threshold: Double,
+        prompt: String,
+        cognitivePhase: CognitivePhase? = null,
+        urgency: Urgency = Urgency.HIGH,
+    ): Boolean {
+        require(uncertaintyValue in UNCERTAINTY_RANGE) {
+            "uncertaintyValue must be in [0.0, 1.0], was $uncertaintyValue"
+        }
+        require(threshold in UNCERTAINTY_RANGE) {
+            "threshold must be in [0.0, 1.0], was $threshold"
+        }
+
+        if (uncertaintyValue < threshold) {
+            return false
+        }
+
+        publishEscalationFired(
+            CognitiveEvent.EscalationFired(
+                eventId = generateUUID(agentId),
+                timestamp = clock.now(),
+                eventSource = EventSource.Agent(agentId),
+                urgency = urgency,
+                agentId = agentId,
+                uncertaintyValue = uncertaintyValue,
+                threshold = threshold,
+                prompt = prompt,
+                cognitivePhase = cognitivePhase,
+            ),
+        )
+
+        return true
+    }
+
+    private companion object {
+        val UNCERTAINTY_RANGE = 0.0..1.0
+    }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/utils/SignificanceAwareEventLogger.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/utils/SignificanceAwareEventLogger.kt
@@ -3,6 +3,7 @@ package link.socket.ampere.agents.events.utils
 import co.touchlab.kermit.Logger
 import link.socket.ampere.agents.domain.Urgency
 import link.socket.ampere.agents.domain.event.AgentSurfaceEvent
+import link.socket.ampere.agents.domain.event.CognitiveEvent
 import link.socket.ampere.agents.domain.event.Event
 import link.socket.ampere.agents.domain.event.EventSource
 import link.socket.ampere.agents.domain.event.EventType
@@ -95,6 +96,7 @@ class SignificanceAwareEventLogger(
     private fun categorizeEvent(event: Event): EventSignificance = when (event) {
         // Critical events require immediate human awareness
         is Event.QuestionRaised -> EventSignificance.CRITICAL
+        is CognitiveEvent.EscalationFired -> EventSignificance.CRITICAL
         is TicketEvent.TicketBlocked -> EventSignificance.CRITICAL
         is MessageEvent.EscalationRequested -> EventSignificance.CRITICAL
         is PermissionDeniedEvent -> EventSignificance.CRITICAL

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/api/service/EventService.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/api/service/EventService.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.datetime.Instant
+import link.socket.ampere.agents.domain.event.CognitiveEvent
 import link.socket.ampere.agents.domain.event.Event
 import link.socket.ampere.agents.domain.event.FileSystemEvent
 import link.socket.ampere.agents.domain.event.GitEvent
@@ -156,6 +157,11 @@ fun EventService.completionEvents(
 ): Flow<ProviderCallCompletedEvent> = observe(filters).filterIsInstance<ProviderCallCompletedEvent>()
 
 @link.socket.ampere.api.AmpereStableApi
+fun EventService.escalationFiredEvents(
+    filters: EventRelayFilters = EventRelayFilters(),
+): Flow<CognitiveEvent.EscalationFired> = observe(filters).filterIsInstance<CognitiveEvent.EscalationFired>()
+
+@link.socket.ampere.api.AmpereStableApi
 enum class EventStreamFilter {
     ALL,
     TELEMETRY,
@@ -195,6 +201,7 @@ enum class EventStreamFilter {
             is ProductEvent,
             is RoutingEvent,
             is SparkEvent,
+            is CognitiveEvent,
             -> true
             else -> false
         }

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/events/escalation/UncertaintyEscalationEvaluatorTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/events/escalation/UncertaintyEscalationEvaluatorTest.kt
@@ -1,0 +1,125 @@
+package link.socket.ampere.agents.events.escalation
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import link.socket.ampere.agents.domain.Urgency
+import link.socket.ampere.agents.domain.cognition.sparks.CognitivePhase
+import link.socket.ampere.agents.domain.event.CognitiveEvent
+import link.socket.ampere.agents.domain.event.EventSource
+import link.socket.ampere.agents.events.bus.EventSerialBus
+import link.socket.ampere.agents.events.bus.subscribe
+import link.socket.ampere.agents.events.subscription.EventSubscription
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class UncertaintyEscalationEvaluatorTest {
+
+    private val fixedClock = object : Clock {
+        override fun now(): Instant = Instant.parse("2026-05-31T12:00:00Z")
+    }
+
+    @Test
+    fun `uncertainty at threshold publishes EscalationFired with payload through bus`() = runTest {
+        val bus = EventSerialBus(scope = this)
+        val received = mutableListOf<CognitiveEvent.EscalationFired>()
+        val evaluator = evaluatorPublishingTo(bus)
+
+        bus.subscribe<CognitiveEvent.EscalationFired, EventSubscription.ByEventClassType>(
+            agentId = "subscriber",
+            eventType = CognitiveEvent.EscalationFired.EVENT_TYPE,
+        ) { event, _ ->
+            received += event
+        }
+
+        val fired = evaluator.evaluate(
+            uncertaintyValue = 0.7,
+            threshold = 0.7,
+            prompt = "Choose between migration plans",
+            cognitivePhase = CognitivePhase.PLAN,
+        )
+        advanceUntilIdle()
+
+        assertTrue(fired)
+        assertEquals(1, received.size)
+        val event = received.single()
+        assertEquals("agent-threshold", event.agentId)
+        assertEquals(0.7, event.uncertaintyValue)
+        assertEquals(0.7, event.threshold)
+        assertEquals("Choose between migration plans", event.prompt)
+        assertEquals(CognitivePhase.PLAN, event.cognitivePhase)
+        assertEquals(EventSource.Agent("agent-threshold"), event.eventSource)
+        assertEquals(Urgency.HIGH, event.urgency)
+        assertEquals(fixedClock.now(), event.timestamp)
+    }
+
+    @Test
+    fun `uncertainty below threshold does not publish EscalationFired`() = runTest {
+        val bus = EventSerialBus(scope = this)
+        val received = mutableListOf<CognitiveEvent.EscalationFired>()
+        val evaluator = evaluatorPublishingTo(bus)
+
+        bus.subscribe<CognitiveEvent.EscalationFired, EventSubscription.ByEventClassType>(
+            agentId = "subscriber",
+            eventType = CognitiveEvent.EscalationFired.EVENT_TYPE,
+        ) { event, _ ->
+            received += event
+        }
+
+        val fired = evaluator.evaluate(
+            uncertaintyValue = 0.69,
+            threshold = 0.7,
+            prompt = "Choose between migration plans",
+        )
+        advanceUntilIdle()
+
+        assertFalse(fired)
+        assertEquals(emptyList(), received)
+    }
+
+    @Test
+    fun `multiple rapid threshold fires publish multiple events`() = runTest {
+        val bus = EventSerialBus(scope = this)
+        val received = mutableListOf<CognitiveEvent.EscalationFired>()
+        val evaluator = evaluatorPublishingTo(bus)
+
+        bus.subscribe<CognitiveEvent.EscalationFired, EventSubscription.ByEventClassType>(
+            agentId = "subscriber",
+            eventType = CognitiveEvent.EscalationFired.EVENT_TYPE,
+        ) { event, _ ->
+            received += event
+        }
+
+        evaluator.evaluate(uncertaintyValue = 0.8, threshold = 0.7, prompt = "First prompt")
+        evaluator.evaluate(uncertaintyValue = 0.9, threshold = 0.7, prompt = "Second prompt")
+        advanceUntilIdle()
+
+        assertEquals(2, received.size)
+        assertEquals(listOf("First prompt", "Second prompt"), received.map { it.prompt })
+    }
+
+    @Test
+    fun `uncertainty values must be normalized`() = runTest {
+        val evaluator = evaluatorPublishingTo(EventSerialBus(scope = this))
+
+        assertFailsWith<IllegalArgumentException> {
+            evaluator.evaluate(uncertaintyValue = 1.1, threshold = 0.7, prompt = "invalid")
+        }
+        assertFailsWith<IllegalArgumentException> {
+            evaluator.evaluate(uncertaintyValue = 0.5, threshold = -0.1, prompt = "invalid")
+        }
+    }
+
+    private fun evaluatorPublishingTo(bus: EventSerialBus): UncertaintyEscalationEvaluator =
+        UncertaintyEscalationEvaluator(
+            agentId = "agent-threshold",
+            publishEscalationFired = { event -> bus.publish(event) },
+            clock = fixedClock,
+        )
+}

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/events/EventSerializationTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/events/EventSerializationTest.kt
@@ -6,6 +6,8 @@ import kotlin.test.assertIs
 import kotlinx.datetime.Clock
 import kotlinx.serialization.json.Json
 import link.socket.ampere.agents.domain.Urgency
+import link.socket.ampere.agents.domain.cognition.sparks.CognitivePhase
+import link.socket.ampere.agents.domain.event.CognitiveEvent
 import link.socket.ampere.agents.domain.event.Event
 import link.socket.ampere.agents.domain.event.EventSource
 import link.socket.ampere.agents.domain.event.PermissionDeniedEvent
@@ -92,6 +94,27 @@ class EventSerializationTest {
         val decoded = json.decodeFromString(Event.serializer(), text)
 
         assertIs<PermissionDeniedEvent>(decoded)
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun `serialize and deserialize escalation fired event polymorphic`() {
+        val original: Event = CognitiveEvent.EscalationFired(
+            eventId = "55555555-5555-5555-5555-555555555555",
+            timestamp = stubTimestamp,
+            eventSource = stubEventSource,
+            urgency = Urgency.HIGH,
+            agentId = "agent-X",
+            uncertaintyValue = 0.82,
+            threshold = 0.7,
+            prompt = "Which migration path should we use?",
+            cognitivePhase = CognitivePhase.PLAN,
+        )
+
+        val text = json.encodeToString(Event.serializer(), original)
+        val decoded = json.decodeFromString(Event.serializer(), text)
+
+        assertIs<CognitiveEvent.EscalationFired>(decoded)
         assertEquals(original, decoded)
     }
 }

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/events/messages/AgentMessageApiTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/events/messages/AgentMessageApiTest.kt
@@ -212,6 +212,38 @@ class AgentMessageApiTest {
     }
 
     @Test
+    fun `discretionary escalateToHuman still publishes EscalationRequested`() {
+        runBlocking {
+            val api = agentMessageApiFactory.create(stubAgentId)
+            val received = mutableListOf<MessageEvent.EscalationRequested>()
+
+            api.onEscalationRequested { event, _ ->
+                received += event
+            }
+
+            val thread = api.createThread(
+                participants = emptySet(),
+                channel = MessageChannel.Public.Engineering,
+                initialMessageContent = "Need a decision",
+            )
+
+            api.escalateToHuman(
+                threadId = thread.id,
+                reason = "Need human input on release timing",
+                context = mapOf("release" to "v1"),
+            )
+
+            delay(200)
+
+            assertEquals(1, received.size)
+            val event = received.single()
+            assertEquals(thread.id, event.threadId)
+            assertEquals("Need human input on release timing", event.reason)
+            assertEquals(mapOf("release" to "v1"), event.context)
+        }
+    }
+
+    @Test
     fun `reopen thread fails when not in WAITING_FOR_HUMAN state`() {
         runBlocking {
             val api = agentMessageApiFactory.create(stubAgentId)

--- a/docs/ampere/events.md
+++ b/docs/ampere/events.md
@@ -1,0 +1,51 @@
+# AMPERE Events
+
+AMPERE exposes cognitive and coordination state changes as typed `Event` values on
+`EventSerialBus`. Publishers should use `AgentEventApi` when they are emitting
+from an agent-owned workflow so events are persisted and source attribution stays
+consistent.
+
+## Threshold-driven cognitive escalation
+
+`CognitiveEvent.EscalationFired` is emitted when an agent's normalized
+uncertainty value meets or exceeds the configured escalation threshold.
+
+```kotlin
+val evaluator = UncertaintyEscalationEvaluator(agentEventApi)
+
+evaluator.evaluate(
+    uncertaintyValue = 0.82,
+    threshold = 0.70,
+    prompt = "Which migration path should we use?",
+    cognitivePhase = CognitivePhase.PLAN,
+)
+```
+
+The event payload includes:
+
+| Field | Meaning |
+| --- | --- |
+| `agentId` | Agent whose uncertainty was evaluated. |
+| `uncertaintyValue` | Normalized uncertainty in `0.0..1.0`; `1.0` means maximum uncertainty. |
+| `threshold` | Normalized configured trip point in `0.0..1.0`. |
+| `prompt` | Human-readable question or context that triggered evaluation. |
+| `cognitivePhase` | PROPEL phase active when the threshold fired, if known. |
+
+Subscribe through the normal event bus:
+
+```kotlin
+agentEventApi.onEscalationFired { event, _ ->
+    println(
+        "Uncertainty ${event.uncertaintyValue} crossed " +
+            "${event.threshold} for ${event.agentId}",
+    )
+}
+```
+
+`EscalationFired` is distinct from `MessageEvent.EscalationRequested`.
+`EscalationRequested` is discretionary thread escalation: an agent or workflow
+chooses to put a message thread into `WaitingForHuman`. `EscalationFired` is
+threshold-driven cognitive telemetry: it fires because uncertainty crossed a
+configured trip point. Consumers that need confidence-specific UI behavior should
+subscribe to `EscalationFired` rather than treating all human escalations as
+uncertainty events.

--- a/docs/concepts/event-serial-bus.md
+++ b/docs/concepts/event-serial-bus.md
@@ -11,7 +11,7 @@ tracked_sources:
   - ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/**
   - ampere-core/src/commonMain/sqldelight/link/socket/ampere/db/events/**
 related: [PropelLoop, AgentSurface, CognitionTrace, MemoryProvenance]
-last_verified: 2026-04-29
+last_verified: 2026-05-31
 ---
 
 # EventSerialBus


### PR DESCRIPTION
Closes #502 (AMPR-173).

This PR adds `CognitiveEvent.EscalationFired` and `UncertaintyEscalationEvaluator` so threshold-driven uncertainty escalation publishes a first-class event with prompt, phase, uncertainty, and threshold payload. It wires subscriptions, event registry, EventService filtering, CLI presentation/significance, docs, and tests while preserving `MessageEvent.EscalationRequested` as the discretionary thread escalation path. Validation: `./gradlew ktlintFormat`, `./gradlew ktlintCheck`, and `git diff --check` passed; `./gradlew jvmTest` is blocked in this workspace because `local.properties` is missing and repo rules forbid creating it.