### PR TITLE
AMPR-171 #500: Publish cognitive phase events

### DIFF
--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/watch/presentation/EventCategorizer.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/watch/presentation/EventCategorizer.kt
@@ -1,6 +1,7 @@
 package link.socket.ampere.cli.watch.presentation
 
 import link.socket.ampere.agents.domain.event.AgentSurfaceEvent
+import link.socket.ampere.agents.domain.event.CognitivePhaseEvent
 import link.socket.ampere.agents.domain.event.Event
 import link.socket.ampere.agents.domain.event.FileSystemEvent
 import link.socket.ampere.agents.domain.event.GitEvent
@@ -111,6 +112,7 @@ object EventCategorizer {
         is ToolEvent.ToolExecutionCompleted,
         is ProviderCallStartedEvent,
         is RoutingEvent.RouteSelected,
+        is CognitivePhaseEvent,
         is SparkEvent -> EventSignificance.ROUTINE
 
         is RoutingEvent.RouteFallback -> EventSignificance.SIGNIFICANT

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/renderer/EventRenderer.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/renderer/EventRenderer.kt
@@ -13,6 +13,7 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import link.socket.ampere.agents.domain.Urgency
 import link.socket.ampere.agents.domain.event.AgentSurfaceEvent
+import link.socket.ampere.agents.domain.event.CognitivePhaseEvent
 import link.socket.ampere.agents.domain.event.Event
 import link.socket.ampere.agents.domain.event.EventSource
 import link.socket.ampere.agents.domain.event.FileSystemEvent
@@ -72,6 +73,8 @@ class EventRenderer(
 
         // Get the event type name
         val eventTypeName = when (event) {
+            is CognitivePhaseEvent.PhaseEntered -> "PhaseEntered"
+            is CognitivePhaseEvent.PhaseExited -> "PhaseExited"
             is SparkAppliedEvent -> "StackApplied"
             is SparkRemovedEvent -> "StackRemoved"
             is CognitiveStateSnapshot -> "StackSnapshot"
@@ -149,6 +152,8 @@ class EventRenderer(
             is ProductEvent -> "💡" to green
             is TicketEvent -> "🎫" to green
             is ToolEvent -> "🔧" to yellow
+            is CognitivePhaseEvent.PhaseEntered -> "↦" to cyan
+            is CognitivePhaseEvent.PhaseExited -> "↤" to gray
             // Routing events
             is RoutingEvent.RouteSelected -> "🔀" to cyan
             is RoutingEvent.RouteFallback -> "🔀" to yellow
@@ -171,6 +176,21 @@ class EventRenderer(
      */
     private fun extractSummary(event: Event): String {
         return when (event) {
+            is CognitivePhaseEvent.PhaseEntered -> buildString {
+                append("Phase enter: ")
+                event.oldPhase?.let { append("${it.name} -> ") }
+                append(event.newPhase.name)
+                append(" (depth: ${event.nestingDepth})")
+                append(" ${formatUrgency(event.urgency)}")
+                append(" from ${formatSource(event.eventSource)}")
+            }
+            is CognitivePhaseEvent.PhaseExited -> buildString {
+                append("Phase exit: ${event.exitedPhase.name}")
+                event.restoredToPhase?.let { append(" -> ${it.name}") }
+                append(" (depth: ${event.nestingDepth})")
+                append(" ${formatUrgency(event.urgency)}")
+                append(" from ${formatSource(event.eventSource)}")
+            }
             is SparkAppliedEvent -> buildString {
                 append("Stack push: ${event.sparkName}")
                 append(" (depth: ${event.stackDepth})")

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/SparkBasedAgent.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/SparkBasedAgent.kt
@@ -103,6 +103,7 @@ open class SparkBasedAgent<S : AgentState>(
             agent = this,
             phaseConfig = agentConfiguration.cognitiveConfig.phaseSparks,
             library = _phaseSparkLibrary,
+            eventBus = _eventApi?.eventSerialBus,
         )
 
     override val id: AgentId = agentId

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/cognition/sparks/PhaseSparkManager.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/cognition/sparks/PhaseSparkManager.kt
@@ -2,9 +2,14 @@ package link.socket.ampere.agents.domain.cognition.sparks
 
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.withContext
+import kotlinx.datetime.Clock
 import link.socket.ampere.agents.config.PhaseSparkConfig
 import link.socket.ampere.agents.definition.AutonomousAgent
+import link.socket.ampere.agents.domain.event.CognitivePhaseEvent
+import link.socket.ampere.agents.domain.event.EventSource
 import link.socket.ampere.agents.domain.state.AgentState
+import link.socket.ampere.agents.events.bus.EventSerialBus
+import link.socket.ampere.agents.events.utils.generateUUID
 import link.socket.ampere.util.getEnvironmentVariable
 
 /**
@@ -24,20 +29,25 @@ class PhaseSparkManager<S : AgentState> private constructor(
     val enabled: Boolean,
     private val activePhases: Set<CognitivePhase>,
     private val library: PhaseSparkLibrary?,
+    private val eventBus: EventSerialBus?,
 ) {
     constructor(
         agent: AutonomousAgent<S>,
         enabled: Boolean = isPhaseSparkEnabled(),
         activePhases: Set<CognitivePhase> = DEFAULT_PHASES,
+        eventBus: EventSerialBus? = null,
     ) : this(
         agent = agent,
         enabled = enabled,
         activePhases = activePhases,
         library = null,
+        eventBus = eventBus,
     )
 
     private var appliedSparks: MutableList<PhaseSpark> = mutableListOf()
     private var currentPhase: CognitivePhase? = null
+    private var currentPhaseNestingDepth: Int = 0
+    private var withPhaseNestingDepth: Int = 0
 
     fun enterPhase(phase: CognitivePhase) {
         enterPhaseInternal(phase, selectionContext = null)
@@ -47,9 +57,15 @@ class PhaseSparkManager<S : AgentState> private constructor(
         enterPhaseInternal(phase, selectionContext)
     }
 
-    private fun enterPhaseInternal(phase: CognitivePhase, selectionContext: SparkSelectionContext?) {
+    private fun enterPhaseInternal(
+        phase: CognitivePhase,
+        selectionContext: SparkSelectionContext?,
+        nestingDepth: Int = 0,
+        oldPhaseOverride: CognitivePhase? = null,
+    ) {
         if (!enabled) return
 
+        val oldPhase = oldPhaseOverride ?: currentPhase
         if (appliedSparks.isNotEmpty() && currentPhase != phase) {
             removeAppliedSparks()
         }
@@ -67,11 +83,13 @@ class PhaseSparkManager<S : AgentState> private constructor(
         }
 
         agent.currentCognitivePhase = phase
+        publishPhaseEntered(oldPhase = oldPhase, newPhase = phase, nestingDepth = nestingDepth)
         for (spark in sparksToApply) {
             agent.spark<AutonomousAgent<S>>(spark)
             appliedSparks += spark
         }
         currentPhase = phase
+        currentPhaseNestingDepth = nestingDepth
     }
 
     suspend fun <R> withPhase(phase: CognitivePhase, block: suspend () -> R): R =
@@ -89,26 +107,41 @@ class PhaseSparkManager<S : AgentState> private constructor(
         block: suspend () -> R,
     ): R {
         if (!enabled) return block()
+        if (!isPhaseEnabled(phase)) return block()
 
+        val nestingDepth = withPhaseNestingDepth
         val previousPhase = currentPhase
         val previousSparks = appliedSparks.toList()
+        val previousPhaseNestingDepth = currentPhaseNestingDepth
         appliedSparks = mutableListOf()
         currentPhase = null
-        enterPhaseInternal(phase, selectionContext)
+        enterPhaseInternal(
+            phase = phase,
+            selectionContext = selectionContext,
+            nestingDepth = nestingDepth,
+            oldPhaseOverride = previousPhase,
+        )
+        withPhaseNestingDepth = nestingDepth + 1
 
         return try {
             block()
         } finally {
             withContext(NonCancellable) {
-                removeAppliedSparks()
+                withPhaseNestingDepth = nestingDepth
+                removeAppliedSparks(
+                    restoredToPhase = previousPhase,
+                    nestingDepth = nestingDepth,
+                )
 
                 if (previousPhase != null && previousSparks.isNotEmpty()) {
-                    agent.currentCognitivePhase = previousPhase
-                    for (spark in previousSparks) {
-                        agent.spark<AutonomousAgent<S>>(spark)
-                        appliedSparks += spark
-                    }
+                    appliedSparks = previousSparks.toMutableList()
                     currentPhase = previousPhase
+                    currentPhaseNestingDepth = previousPhaseNestingDepth
+                    publishPhaseEntered(
+                        oldPhase = phase,
+                        newPhase = previousPhase,
+                        nestingDepth = previousPhaseNestingDepth,
+                    )
                 }
             }
         }
@@ -126,14 +159,64 @@ class PhaseSparkManager<S : AgentState> private constructor(
 
     private fun isPhaseEnabled(phase: CognitivePhase): Boolean = activePhases.contains(phase)
 
-    private fun removeAppliedSparks() {
+    private fun removeAppliedSparks(
+        restoredToPhase: CognitivePhase? = null,
+        nestingDepth: Int = currentPhaseNestingDepth,
+    ) {
         if (appliedSparks.isEmpty()) return
+        val exitedPhase = currentPhase ?: return
         repeat(appliedSparks.size) {
             agent.unspark()
         }
         appliedSparks.clear()
         currentPhase = null
-        agent.currentCognitivePhase = null
+        currentPhaseNestingDepth = 0
+        agent.currentCognitivePhase = restoredToPhase
+        publishPhaseExited(
+            exitedPhase = exitedPhase,
+            restoredToPhase = restoredToPhase,
+            nestingDepth = nestingDepth,
+        )
+    }
+
+    private fun publishPhaseEntered(
+        oldPhase: CognitivePhase?,
+        newPhase: CognitivePhase,
+        nestingDepth: Int,
+    ) {
+        eventBus?.let { bus ->
+            bus.publishAsync(
+                CognitivePhaseEvent.PhaseEntered(
+                    eventId = generateUUID(agent.id, newPhase.name, nestingDepth.toString()),
+                    timestamp = Clock.System.now(),
+                    eventSource = EventSource.Agent(agent.id),
+                    agentId = agent.id,
+                    oldPhase = oldPhase,
+                    newPhase = newPhase,
+                    nestingDepth = nestingDepth,
+                ),
+            )
+        }
+    }
+
+    private fun publishPhaseExited(
+        exitedPhase: CognitivePhase,
+        restoredToPhase: CognitivePhase?,
+        nestingDepth: Int,
+    ) {
+        eventBus?.let { bus ->
+            bus.publishAsync(
+                CognitivePhaseEvent.PhaseExited(
+                    eventId = generateUUID(agent.id, exitedPhase.name, nestingDepth.toString()),
+                    timestamp = Clock.System.now(),
+                    eventSource = EventSource.Agent(agent.id),
+                    agentId = agent.id,
+                    exitedPhase = exitedPhase,
+                    restoredToPhase = restoredToPhase,
+                    nestingDepth = nestingDepth,
+                ),
+            )
+        }
     }
 
     companion object {
@@ -159,30 +242,35 @@ class PhaseSparkManager<S : AgentState> private constructor(
         fun <S : AgentState> create(
             agent: AutonomousAgent<S>,
             phaseConfig: PhaseSparkConfig? = null,
-        ): PhaseSparkManager<S> = createInternal(agent, phaseConfig, library = null)
+            eventBus: EventSerialBus? = null,
+        ): PhaseSparkManager<S> = createInternal(agent, phaseConfig, library = null, eventBus = eventBus)
 
         internal fun <S : AgentState> createWithLibrary(
             agent: AutonomousAgent<S>,
             phaseConfig: PhaseSparkConfig? = null,
             library: PhaseSparkLibrary? = null,
-        ): PhaseSparkManager<S> = createInternal(agent, phaseConfig, library)
+            eventBus: EventSerialBus? = null,
+        ): PhaseSparkManager<S> = createInternal(agent, phaseConfig, library, eventBus)
 
         internal fun <S : AgentState> internalCreate(
             agent: AutonomousAgent<S>,
             enabled: Boolean,
             activePhases: Set<CognitivePhase> = DEFAULT_PHASES,
             library: PhaseSparkLibrary? = null,
+            eventBus: EventSerialBus? = null,
         ): PhaseSparkManager<S> = PhaseSparkManager(
             agent = agent,
             enabled = enabled,
             activePhases = activePhases,
             library = library,
+            eventBus = eventBus,
         )
 
         private fun <S : AgentState> createInternal(
             agent: AutonomousAgent<S>,
             phaseConfig: PhaseSparkConfig?,
             library: PhaseSparkLibrary?,
+            eventBus: EventSerialBus?,
         ): PhaseSparkManager<S> {
             val enabledFromConfig = phaseConfig?.enabled ?: false
             val enabled = enabledFromConfig || isPhaseSparkEnabled()
@@ -192,6 +280,7 @@ class PhaseSparkManager<S : AgentState> private constructor(
                 enabled = enabled,
                 activePhases = phases,
                 library = library,
+                eventBus = eventBus,
             )
         }
     }

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/CognitivePhaseEvent.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/CognitivePhaseEvent.kt
@@ -1,0 +1,84 @@
+package link.socket.ampere.agents.domain.event
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import link.socket.ampere.agents.definition.AgentId
+import link.socket.ampere.agents.domain.Urgency
+import link.socket.ampere.agents.domain.cognition.sparks.CognitivePhase
+
+/**
+ * Events emitted when an agent enters or exits a cognitive phase.
+ *
+ * These events make phase transitions directly observable on the EventSerialBus
+ * without requiring consumers to poll agent state or infer phases from Spark
+ * application events.
+ */
+@Serializable
+sealed interface CognitivePhaseEvent : Event {
+    val agentId: AgentId
+    val nestingDepth: Int
+
+    @Serializable
+    @SerialName("PhaseEntered")
+    data class PhaseEntered(
+        override val eventId: EventId,
+        override val timestamp: Instant,
+        override val eventSource: EventSource,
+        override val agentId: AgentId,
+        val oldPhase: CognitivePhase?,
+        val newPhase: CognitivePhase,
+        override val nestingDepth: Int,
+        override val urgency: Urgency = Urgency.LOW,
+    ) : CognitivePhaseEvent {
+
+        override val eventType: EventType = EVENT_TYPE
+
+        override fun getSummary(
+            formatUrgency: (Urgency) -> String,
+            formatSource: (EventSource) -> String,
+        ): String = buildString {
+            append("Phase entered: ")
+            oldPhase?.let { append("${it.name} -> ") }
+            append(newPhase.name)
+            append(" (depth: $nestingDepth)")
+            append(" ${formatUrgency(urgency)}")
+            append(" from ${formatSource(eventSource)}")
+        }
+
+        companion object {
+            const val EVENT_TYPE: EventType = "PhaseEntered"
+        }
+    }
+
+    @Serializable
+    @SerialName("PhaseExited")
+    data class PhaseExited(
+        override val eventId: EventId,
+        override val timestamp: Instant,
+        override val eventSource: EventSource,
+        override val agentId: AgentId,
+        val exitedPhase: CognitivePhase,
+        val restoredToPhase: CognitivePhase?,
+        override val nestingDepth: Int,
+        override val urgency: Urgency = Urgency.LOW,
+    ) : CognitivePhaseEvent {
+
+        override val eventType: EventType = EVENT_TYPE
+
+        override fun getSummary(
+            formatUrgency: (Urgency) -> String,
+            formatSource: (EventSource) -> String,
+        ): String = buildString {
+            append("Phase exited: ${exitedPhase.name}")
+            restoredToPhase?.let { append(" -> ${it.name}") }
+            append(" (depth: $nestingDepth)")
+            append(" ${formatUrgency(urgency)}")
+            append(" from ${formatSource(eventSource)}")
+        }
+
+        companion object {
+            const val EVENT_TYPE: EventType = "PhaseExited"
+        }
+    }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/EventRegistry.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/EventRegistry.kt
@@ -82,6 +82,10 @@ object EventRegistry {
         SparkRemovedEvent.EVENT_TYPE,
         CognitiveStateSnapshot.EVENT_TYPE,
 
+        // CognitivePhaseEvent types
+        CognitivePhaseEvent.PhaseEntered.EVENT_TYPE,
+        CognitivePhaseEvent.PhaseExited.EVENT_TYPE,
+
         // TaskEvent lifecycle types
         TaskEvent.TaskStarted.EVENT_TYPE,
         TaskEvent.TaskProgressed.EVENT_TYPE,

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/api/AgentEventApi.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/api/AgentEventApi.kt
@@ -54,7 +54,7 @@ class EventFilter<E : Event>(
 class AgentEventApi(
     val agentId: AgentId,
     private val eventRepository: EventRepository,
-    private val eventSerialBus: EventSerialBus,
+    internal val eventSerialBus: EventSerialBus,
     private val logger: EventLogger = ConsoleEventLogger(),
 ) {
 

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/bus/EventSerialBus.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/bus/EventSerialBus.kt
@@ -1,6 +1,7 @@
 package link.socket.ampere.agents.events.bus
 
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -69,6 +70,17 @@ class EventSerialBus(
                     )
                 }
             }
+        }
+    }
+
+    /**
+     * Publish an [event] from a synchronous call site without blocking the
+     * caller. The event is still routed through [publish], so handler snapshot
+     * and dispatch semantics stay centralized.
+     */
+    fun publishAsync(event: Event) {
+        scope.launch(start = CoroutineStart.UNDISPATCHED) {
+            publish(event)
         }
     }
 

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/utils/SignificanceAwareEventLogger.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/utils/SignificanceAwareEventLogger.kt
@@ -3,6 +3,7 @@ package link.socket.ampere.agents.events.utils
 import co.touchlab.kermit.Logger
 import link.socket.ampere.agents.domain.Urgency
 import link.socket.ampere.agents.domain.event.AgentSurfaceEvent
+import link.socket.ampere.agents.domain.event.CognitivePhaseEvent
 import link.socket.ampere.agents.domain.event.Event
 import link.socket.ampere.agents.domain.event.EventSource
 import link.socket.ampere.agents.domain.event.EventType
@@ -155,6 +156,7 @@ class SignificanceAwareEventLogger(
         is HumanInteractionEvent.RequestTimedOut -> EventSignificance.SIGNIFICANT
 
         // Spark cognitive state events - routine cognitive operations
+        is CognitivePhaseEvent -> EventSignificance.ROUTINE
         is SparkEvent -> EventSignificance.ROUTINE
 
         // Routing events - routine for selection, significant for fallbacks

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/api/service/EventService.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/api/service/EventService.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.datetime.Instant
+import link.socket.ampere.agents.domain.event.CognitivePhaseEvent
 import link.socket.ampere.agents.domain.event.Event
 import link.socket.ampere.agents.domain.event.FileSystemEvent
 import link.socket.ampere.agents.domain.event.GitEvent
@@ -194,6 +195,7 @@ enum class EventStreamFilter {
             is PlanEvent,
             is ProductEvent,
             is RoutingEvent,
+            is CognitivePhaseEvent,
             is SparkEvent,
             -> true
             else -> false

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/trace/ArcTraceProjection.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/trace/ArcTraceProjection.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.datetime.Instant
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
+import link.socket.ampere.agents.domain.event.CognitivePhaseEvent
 import link.socket.ampere.agents.domain.event.Event
 import link.socket.ampere.agents.domain.event.MemoryEvent
 import link.socket.ampere.agents.domain.event.ProviderCallCompletedEvent
@@ -262,6 +263,8 @@ class ArcTraceProjection(
                 .add(decoded.toTraceEvent())
 
             activePhase = when (event) {
+                is CognitivePhaseEvent.PhaseEntered -> event.newPhase.name
+                is CognitivePhaseEvent.PhaseExited -> event.restoredToPhase?.name
                 is SparkAppliedEvent -> event.phaseSparkName() ?: activePhase
                 is SparkRemovedEvent -> null
                 else -> explicitPhase ?: activePhase
@@ -327,6 +330,8 @@ class ArcTraceProjection(
         is ProviderCallCompletedEvent -> event.cognitivePhase?.name
         is RoutingEvent.RouteSelected -> event.phase?.name
         is RoutingEvent.RouteFallback -> event.phase?.name
+        is CognitivePhaseEvent.PhaseEntered -> event.newPhase.name
+        is CognitivePhaseEvent.PhaseExited -> event.exitedPhase.name
         is MemoryEvent.KnowledgeRecalled -> RECALL_PHASE
         is MemoryEvent.KnowledgeStored -> LEARN_PHASE
         is ToolEvent.ToolExecutionStarted -> default ?: EXECUTE_PHASE

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/domain/cognition/sparks/PhaseSparkManagerTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/domain/cognition/sparks/PhaseSparkManagerTest.kt
@@ -4,13 +4,16 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import kotlinx.datetime.Clock
 import link.socket.ampere.agents.config.AgentConfiguration
 import link.socket.ampere.agents.config.CognitiveConfig
 import link.socket.ampere.agents.config.PhaseSparkConfig
 import link.socket.ampere.agents.definition.AgentId
 import link.socket.ampere.agents.definition.AutonomousAgent
+import link.socket.ampere.agents.domain.event.CognitivePhaseEvent
 import link.socket.ampere.agents.domain.knowledge.Knowledge
 import link.socket.ampere.agents.domain.outcome.ExecutionOutcome
 import link.socket.ampere.agents.domain.outcome.Outcome
@@ -19,6 +22,9 @@ import link.socket.ampere.agents.domain.reasoning.Perception
 import link.socket.ampere.agents.domain.reasoning.Plan
 import link.socket.ampere.agents.domain.state.AgentState
 import link.socket.ampere.agents.domain.task.Task
+import link.socket.ampere.agents.events.bus.EventSerialBus
+import link.socket.ampere.agents.events.bus.subscribe
+import link.socket.ampere.agents.events.subscription.EventSubscription
 import link.socket.ampere.agents.execution.request.ExecutionRequest
 import link.socket.ampere.agents.execution.tools.Tool
 import link.socket.ampere.stubAgentConfiguration
@@ -56,6 +62,33 @@ class PhaseSparkManagerTest {
         }
     }
 
+    private suspend fun MutableList<CognitivePhaseEvent>.awaitCount(count: Int): List<CognitivePhaseEvent> {
+        withTimeout(1000) {
+            while (size < count) {
+                delay(10)
+            }
+        }
+        return toList()
+    }
+
+    private fun EventSerialBus.collectPhaseEvents(
+        agentId: AgentId,
+        events: MutableList<CognitivePhaseEvent>,
+    ) {
+        subscribe<CognitivePhaseEvent.PhaseEntered, EventSubscription.ByEventClassType>(
+            agentId = agentId,
+            eventType = CognitivePhaseEvent.PhaseEntered.EVENT_TYPE,
+        ) { event, _ ->
+            events += event
+        }
+        subscribe<CognitivePhaseEvent.PhaseExited, EventSubscription.ByEventClassType>(
+            agentId = agentId,
+            eventType = CognitivePhaseEvent.PhaseExited.EVENT_TYPE,
+        ) { event, _ ->
+            events += event
+        }
+    }
+
     @Test
     fun `enterPhase applies and switches phase sparks`() {
         val agent = TestAgent()
@@ -72,6 +105,53 @@ class PhaseSparkManagerTest {
     }
 
     @Test
+    fun `enterPhase publishes PhaseEntered after current phase is assigned`() = runBlocking {
+        val agent = TestAgent()
+        val bus = EventSerialBus(this)
+        val events = mutableListOf<CognitivePhaseEvent>()
+        bus.collectPhaseEvents(agent.id, events)
+        val manager = PhaseSparkManager(agent, enabled = true, eventBus = bus)
+
+        manager.enterPhase(CognitivePhase.PERCEIVE)
+
+        val event = events.awaitCount(1).single()
+        assertEquals(
+            CognitivePhaseEvent.PhaseEntered(
+                eventId = event.eventId,
+                timestamp = event.timestamp,
+                eventSource = event.eventSource,
+                agentId = agent.id,
+                oldPhase = null,
+                newPhase = CognitivePhase.PERCEIVE,
+                nestingDepth = 0,
+            ),
+            event,
+        )
+    }
+
+    @Test
+    fun `sequential transitions publish exit before enter`() = runBlocking {
+        val agent = TestAgent()
+        val bus = EventSerialBus(this)
+        val events = mutableListOf<CognitivePhaseEvent>()
+        bus.collectPhaseEvents(agent.id, events)
+        val manager = PhaseSparkManager(agent, enabled = true, eventBus = bus)
+
+        manager.enterPhase(CognitivePhase.PERCEIVE)
+        manager.enterPhase(CognitivePhase.PLAN)
+
+        val sequence = events.awaitCount(3)
+        assertEquals(CognitivePhaseEvent.PhaseEntered.EVENT_TYPE, sequence[0].eventType)
+        assertEquals(CognitivePhase.PERCEIVE, (sequence[0] as CognitivePhaseEvent.PhaseEntered).newPhase)
+        assertEquals(CognitivePhaseEvent.PhaseExited.EVENT_TYPE, sequence[1].eventType)
+        assertEquals(CognitivePhase.PERCEIVE, (sequence[1] as CognitivePhaseEvent.PhaseExited).exitedPhase)
+        assertEquals(null, (sequence[1] as CognitivePhaseEvent.PhaseExited).restoredToPhase)
+        assertEquals(CognitivePhaseEvent.PhaseEntered.EVENT_TYPE, sequence[2].eventType)
+        assertEquals(CognitivePhase.PERCEIVE, (sequence[2] as CognitivePhaseEvent.PhaseEntered).oldPhase)
+        assertEquals(CognitivePhase.PLAN, (sequence[2] as CognitivePhaseEvent.PhaseEntered).newPhase)
+    }
+
+    @Test
     fun `withPhase restores previous phase spark`() = runBlocking {
         val agent = TestAgent()
         val manager = PhaseSparkManager(agent, enabled = true)
@@ -82,6 +162,46 @@ class PhaseSparkManagerTest {
         }
 
         assertTrue(agent.cognitiveState.contains("[Phase:Perceive]"))
+    }
+
+    @Test
+    fun `nested withPhase publishes depth-aware bracket events`() = runBlocking {
+        val agent = TestAgent()
+        val bus = EventSerialBus(this)
+        val events = mutableListOf<CognitivePhaseEvent>()
+        bus.collectPhaseEvents(agent.id, events)
+        val manager = PhaseSparkManager(agent, enabled = true, eventBus = bus)
+
+        manager.withPhase(CognitivePhase.PERCEIVE) {
+            assertEquals(1, agent.sparkDepth)
+            manager.withPhase(CognitivePhase.PLAN) {
+                assertEquals(2, agent.sparkDepth)
+                assertTrue(agent.cognitiveState.contains("[Phase:Perceive]"))
+                assertTrue(agent.cognitiveState.contains("[Phase:Plan]"))
+            }
+            assertEquals(1, agent.sparkDepth)
+            assertTrue(agent.cognitiveState.contains("[Phase:Perceive]"))
+        }
+
+        assertEquals(0, agent.sparkDepth)
+        val sequence = events.awaitCount(5)
+        assertEquals(
+            listOf(
+                "PhaseEntered:PERCEIVE:null:0",
+                "PhaseEntered:PLAN:PERCEIVE:1",
+                "PhaseExited:PLAN:PERCEIVE:1",
+                "PhaseEntered:PERCEIVE:PLAN:0",
+                "PhaseExited:PERCEIVE:null:0",
+            ),
+            sequence.map { event ->
+                when (event) {
+                    is CognitivePhaseEvent.PhaseEntered ->
+                        "PhaseEntered:${event.newPhase}:${event.oldPhase}:${event.nestingDepth}"
+                    is CognitivePhaseEvent.PhaseExited ->
+                        "PhaseExited:${event.exitedPhase}:${event.restoredToPhase}:${event.nestingDepth}"
+                }
+            },
+        )
     }
 
     @Test
@@ -112,6 +232,21 @@ class PhaseSparkManagerTest {
 
         manager.enterPhase(CognitivePhase.PERCEIVE)
         assertEquals(0, agent.sparkDepth)
+    }
+
+    @Test
+    fun `disabled manager does not publish phase events`() = runBlocking {
+        val agent = TestAgent()
+        val bus = EventSerialBus(this)
+        val events = mutableListOf<CognitivePhaseEvent>()
+        bus.collectPhaseEvents(agent.id, events)
+        val manager = PhaseSparkManager(agent, enabled = false, eventBus = bus)
+
+        manager.enterPhase(CognitivePhase.PERCEIVE)
+        manager.cleanup()
+        delay(100)
+
+        assertEquals(emptyList(), events)
     }
 
     @Test

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/events/EventSerializationTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/events/EventSerializationTest.kt
@@ -6,6 +6,8 @@ import kotlin.test.assertIs
 import kotlinx.datetime.Clock
 import kotlinx.serialization.json.Json
 import link.socket.ampere.agents.domain.Urgency
+import link.socket.ampere.agents.domain.cognition.sparks.CognitivePhase
+import link.socket.ampere.agents.domain.event.CognitivePhaseEvent
 import link.socket.ampere.agents.domain.event.Event
 import link.socket.ampere.agents.domain.event.EventSource
 import link.socket.ampere.agents.domain.event.PermissionDeniedEvent
@@ -92,6 +94,25 @@ class EventSerializationTest {
         val decoded = json.decodeFromString(Event.serializer(), text)
 
         assertIs<PermissionDeniedEvent>(decoded)
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun `serialize and deserialize phase entered event polymorphic`() {
+        val original: Event = CognitivePhaseEvent.PhaseEntered(
+            eventId = "55555555-5555-5555-5555-555555555555",
+            timestamp = stubTimestamp,
+            eventSource = stubEventSource,
+            agentId = "agent-X",
+            oldPhase = null,
+            newPhase = CognitivePhase.PERCEIVE,
+            nestingDepth = 0,
+        )
+
+        val text = json.encodeToString(Event.serializer(), original)
+        val decoded = json.decodeFromString(Event.serializer(), text)
+
+        assertIs<CognitivePhaseEvent.PhaseEntered>(decoded)
         assertEquals(original, decoded)
     }
 }

--- a/docs/concepts/cognition-trace.md
+++ b/docs/concepts/cognition-trace.md
@@ -12,7 +12,7 @@ tracked_sources:
   - ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/MemoryEvent.kt
   - ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/RoutingEvent.kt
 related: [PropelLoop, EventSerialBus, MemoryProvenance, CognitiveRelay, SparkSystem]
-last_verified: 2026-04-29
+last_verified: 2026-05-31
 ---
 
 # Cognition Trace
@@ -23,7 +23,7 @@ The cognition trace is AMPERE's read model for reconstructing one Arc run.
 `ArcTraceProjection.project(runId)` queries `EventStore`, `KnowledgeStore`,
 and `OutcomeMemoryStore` by `run_id` and assembles an `ArcRunTrace`:
 
-- One `PropelPhase` per phase (Perceive / Recall / Observe / Plan / Execute / Learn) plus a synthetic `Run` row for the overall envelope.
+- One `PropelPhase` per phase (Perceive / Recall / Observe / Plan / Execute / Learn) plus a synthetic `Run` row for the overall envelope. `CognitivePhaseEvent` phase boundaries are used directly when present.
 - `ModelInvocationTrace`s joining `ProviderCallStartedEvent` ↔ `ProviderCallCompletedEvent` with `routingReason`, latency, tokens, and estimated cost.
 - `ToolCallTrace`s joining `ToolEvent.ToolExecutionStarted` ↔ `ToolExecutionCompleted` with duration and success.
 - `MemoryWriteTrace`s for `KnowledgeStored` / `OutcomeRecorded`.
@@ -69,7 +69,7 @@ the projection that makes the run *legible*:
 - **The projection never writes.** It is a read model. A change that has the projection update an event row or a memory row is a layering violation; corrections happen by writing new rows.
 - **Provider call events come in pairs.** `ProviderCallStartedEvent` ↔ `ProviderCallCompletedEvent` keyed by `(workflowId, agentId, providerId, modelId, cognitivePhase)`. A start without a completion appears as a half-trace; a completion without a start is reconstructed from `latencyMs` (lossy — keep both).
 - **Tool events come in pairs by `invocationId`.** `ToolExecutionStarted` ↔ `ToolExecutionCompleted`. The projection retains starts that lack a completion as `pendingCalls` so in-flight work is visible.
-- **Phase names are derived from the event, not assigned by the projector.** `phaseNameFor(event)` reads `cognitivePhase` (or, for spark events, the `Phase:` prefix). The projector does not invent phase membership — events declare it. New event types that should be phase-aware must populate `cognitivePhase` themselves.
+- **Phase names are derived from the event, not assigned by the projector.** `phaseNameFor(event)` reads explicit phase fields (`CognitivePhaseEvent`, telemetry `cognitivePhase`, routing `phase`) or, for spark events, the `Phase:` prefix. The projector does not invent phase membership — events declare it. New event types that should be phase-aware must carry their own phase signal.
 - **`WattCost` is monotone-additive.** `WattCost.plus` only adds; entries are never subtracted. A change that subtracts cost (e.g., to "correct" a previous estimate) breaks the running aggregate.
 - **The schema migration that introduced `run_id` is not reversible without losing trace fidelity.** If the migration is renumbered or dropped, every persisted run before the change becomes opaque.
 

--- a/docs/concepts/event-serial-bus.md
+++ b/docs/concepts/event-serial-bus.md
@@ -11,7 +11,7 @@ tracked_sources:
   - ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/**
   - ampere-core/src/commonMain/sqldelight/link/socket/ampere/db/events/**
 related: [PropelLoop, AgentSurface, CognitionTrace, MemoryProvenance]
-last_verified: 2026-04-29
+last_verified: 2026-05-31
 ---
 
 # EventSerialBus
@@ -51,13 +51,14 @@ properties for free:
 
 ## Where it lives
 
-- `ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/bus/EventSerialBus.kt` — the bus itself; `publish`, `subscribe`, `unsubscribe`.
+- `ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/bus/EventSerialBus.kt` — the bus itself; `publish`, `publishAsync`, `subscribe`, `unsubscribe`.
 - `agents/events/bus/EventSerialBusFactory.kt` — wiring the bus into the application graph.
 - `agents/events/api/AgentEventApi.kt` — the agent-facing facade for emitting events without touching the bus directly.
 - `agents/events/relay/EventRelayService.kt` — out-of-process bridging (e.g., CLI streaming).
 - `agents/events/utils/EventLogger.kt`, `SignificanceAwareEventLogger.kt` — pluggable logging implementations. `Console`, significance-filtered.
 - `agents/events/subscription/EventSubscription.kt`, `Subscription.kt` — the handle returned to subscribers.
 - `agents/domain/event/Event.kt` and the `event/` package — the sealed `Event` hierarchy.
+- `agents/domain/event/CognitivePhaseEvent.kt` — phase transition events emitted by `PhaseSparkManager` when a bus is wired.
 - `ampere-core/src/commonMain/sqldelight/link/socket/ampere/db/events/EventStore.sq` — persistence schema (with `run_id` indexes for trace queries).
 
 ## Invariants
@@ -72,8 +73,10 @@ properties for free:
 ## Common operations
 
 - **Publish an event** — `agentEventApi.publish(SomeEvent(...))`. The api wraps the bus and is the agent-facing entry point.
+- **Publish from a synchronous boundary hook** — use `EventSerialBus.publishAsync(event)` only when the caller cannot suspend, such as phase boundary hooks. Prefer `AgentEventApi.publish` elsewhere.
 - **Subscribe** — `bus.subscribe(eventType, scope) { event, subscription -> ... }`. Hold onto the returned `EventSubscription` so you can `unsubscribe` on shutdown.
 - **Add a new event type** — extend `Event` (or the appropriate sub-sealed family in `agents/domain/event/`), register a `@Serializable` subclass with a stable `@SerialName`, add a CLI display handler, and add a logger summary in `Event.getSummary` if relevant.
+- **Observe phase transitions** — subscribe to `CognitivePhaseEvent.PhaseEntered.EVENT_TYPE` and/or `PhaseExited.EVENT_TYPE`; use `nestingDepth == 0` for outermost phase changes only.
 - **Persist for trace** — events flow into `EventStore` via the configured logger. New event types are picked up automatically; just verify `run_id` is set on the emitter.
 
 ## Anti-patterns

--- a/docs/concepts/propel-loop.md
+++ b/docs/concepts/propel-loop.md
@@ -8,7 +8,7 @@ tracked_sources:
   - ampere-core/src/commonMain/kotlin/link/socket/ampere/trace/ArcRunTrace.kt
   - docs/AGENT_LIFECYCLE.md
 related: [CognitiveRelay, MemoryProvenance, SparkSystem, CognitionTrace, EventSerialBus]
-last_verified: 2026-05-30
+last_verified: 2026-05-31
 ---
 
 # PROPEL Loop
@@ -65,7 +65,7 @@ single point at which we emit telemetry.
 ## Invariants
 
 - **Recall precedes Plan.** No `Plan` may be generated without first calling `AgentMemoryService.recallRelevantKnowledge` and feeding the result into `PlanGenerator`. Skipping Recall when context "feels obvious" is the canonical failure mode.
-- **Each phase emits its own boundary events.** `ProviderCallStartedEvent` / `ProviderCallCompletedEvent` carry a `cognitivePhase`; memory writes carry the phase that produced them; tool calls are tagged via the active phase. `ArcTraceProjection` relies on this to bucket activity per phase. A phase that runs without emitting boundary events is invisible to the trace, which is equivalent to it not having run.
+- **Each phase emits its own boundary events.** `CognitivePhaseEvent.PhaseEntered` / `PhaseExited` mark phase transitions when the phase manager has a bus; `ProviderCallStartedEvent` / `ProviderCallCompletedEvent` carry a `cognitivePhase`; memory writes carry the phase that produced them; tool calls are tagged via the active phase. `ArcTraceProjection` relies on this to bucket activity per phase. A phase that runs without emitting boundary events is invisible to the trace, which is equivalent to it not having run.
 - **The loop closes through `Knowledge`.** Every successful Arc run ends with `KnowledgeExtractor` writing at least one `Knowledge` entry tagged with the `run_id`. An Arc run that produced outcomes but no Knowledge entry has not closed the loop and will not contribute to future Recall.
 - **Phase order is fixed.** Perceive → Recall → Observe → Plan → Execute → Learn. The declaration order in `CognitivePhase` matches the PROPEL acronym; `enumValues<CognitivePhase>()` yields the cycle. New phases are added by extending the enum and updating every service that switches on it; phases are never reordered or skipped per call site.
 - **Observe is not a side-effect of Plan.** When recalled `Knowledge` contradicts an `Idea` or current state has drifted since the last run, that contradiction must be resolved in Observe and recorded in the Plan's rationale, not silently dropped during Plan generation.
@@ -73,7 +73,7 @@ single point at which we emit telemetry.
 ## Common operations
 
 - **Add a phase** — extend `CognitivePhase` (in `PhaseSpark.kt`), add a corresponding `PhaseSpark` data object with prompt contribution, update `PhaseSpark.forPhase`, add a service implementing the phase transform, wire it through `AgentReasoning`, and update `ArcTraceProjection.phaseNameFor` so the trace knows about the new phase.
-- **Hook into a phase** — subscribe to `SparkAppliedEvent` filtering on `phaseSparkName()`; this tells you exactly when the agent enters/exits a phase. Do not assume `PhaseSpark`s are always enabled — they're gated on `AgentConfiguration.cognitiveConfig.phaseSparks.enabled` or `AMPERE_PHASE_SPARKS=true`.
+- **Hook into a phase** — prefer `CognitivePhaseEvent.PhaseEntered` / `PhaseExited` when an event bus is wired. For older spark-stack consumers, subscribe to `SparkAppliedEvent` filtering on `phaseSparkName()`. Do not assume `PhaseSpark`s are always enabled — they're gated on `AgentConfiguration.cognitiveConfig.phaseSparks.enabled` or `AMPERE_PHASE_SPARKS=true`.
 - **Read what one Arc run did** — `ArcTraceProjection.project(runId)` returns an `ArcRunTrace` with one `PropelPhase` per phase. This is the "playback" of a cognitive cycle. Use this for debugging, not for orchestration.
 - **Validate a change to the loop** — run `./gradlew jvmTest` (the primary gate) and verify the loop still produces a `Knowledge` entry tagged with the run id.
 

--- a/docs/concepts/spark-system.md
+++ b/docs/concepts/spark-system.md
@@ -7,7 +7,7 @@ tracked_sources:
   - ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/SparkRemovedEvent.kt
   - ampere-core/src/commonMain/composeResources/files/sparks/**
 related: [PropelLoop, CognitiveRelay, PluginPermissions, CognitionTrace]
-last_verified: 2026-05-17
+last_verified: 2026-05-31
 ---
 
 > **2026-05-17 (AMPR-165):** Declarative `.spark.md` documents now use JSON
@@ -107,6 +107,10 @@ by eligibility, tag intersection, and keyword match against `whenToUse`;
 `AmpereSpikeFlags.declarativeSparksEnabled` is on; the `SparkBasedAgent`
 role factories consult the role surface at construction time and fail fast
 if the bundled role fixture is missing.
+When an `EventSerialBus` is provided, `PhaseSparkManager` also emits
+`CognitivePhaseEvent.PhaseEntered` / `PhaseExited` at phase boundaries so
+phase changes are observable even when consumers do not inspect Spark stack
+events.
 
 ## Why it exists
 
@@ -152,12 +156,14 @@ exceed parent permissions, so adding a Spark is monotone safe.
 - `agents/domain/cognition/sparks/AmpereSpikeFlags.kt` — `declarativeSparksEnabled: Boolean = false`; gates declarative spark application.
 - `composeResources/files/sparks/*.spark.md` — bundled declarative spark fixtures.
 - `agents/domain/event/SparkAppliedEvent.kt`, `SparkRemovedEvent.kt` — observability.
+- `agents/domain/event/CognitivePhaseEvent.kt` — first-class phase boundary events.
 
 ## Invariants
 
 - **Sparks can only narrow, never expand.** A Spark may set `allowedTools` to a strict subset of the parent context; setting a wider set than the parent is a violation and breaks the recursive safety guarantee.
 - **The system prompt is rebuilt from the live stack on every LLM call.** No caching of the rendered prompt is allowed unless invalidated on every push/pop. Stale prompts cause the active Spark stack to drift from observed prompt content.
 - **Apply/remove are paired and observed.** Every `SparkAppliedEvent` has a matching `SparkRemovedEvent` (or end-of-run cleanup). `ArcTraceProjection` uses these events to reconstruct phase context.
+- **Phase boundaries are explicit when a bus is wired.** `PhaseSparkManager` publishes `PhaseEntered` after `currentCognitivePhase` is assigned and before phase sparks are applied, and publishes `PhaseExited` after phase sparks are removed and the previous phase is restored.
 - **Tool-set composition is intersection.** When two Sparks both specify `allowedTools`, the effective set is `A ∩ B`, not `A ∪ B`. A change that switches to union is a permission expansion and violates the narrowing invariant.
 - **PhaseSparks add context only.** They do not narrow tools (`allowedTools = null`) or file access (`fileAccessScope = null`). Their job is prompt augmentation, not capability gating.
 - **Spark `name` follows `Type:Subtype`.** `Role:Code`, `Phase:Perceive`, `Project:ampere`, `PhaseSpark:cooking-domain`. The trace projection extracts subtype from this prefix; ad-hoc names break trace bucketing. Declarative sparks use `PhaseSpark:<id>` so trace bucketing that keys on `Phase:` still treats built-in phases distinctly.


### PR DESCRIPTION
Implemented by Codex for AMPR-171 / #500.

Adds first-class `CognitivePhaseEvent.PhaseEntered` and `PhaseExited` events and wires `PhaseSparkManager` to publish them with nesting depth through `EventSerialBus`.

Updates event registration, trace projection, CLI/watch presentation, concept docs, and tests for single, sequential, nested, disabled, and serialization behavior.

Validation: `./gradlew ktlintFormat` and `git diff --check` passed; `./gradlew jvmTest` is blocked because `local.properties` is missing and repo instructions forbid creating it.

Closes #500