### PR TITLE
AMPR-175 (#504): Add milestone memory events

### DIFF
--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/watch/presentation/EventCategorizer.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/watch/presentation/EventCategorizer.kt
@@ -85,6 +85,7 @@ object EventCategorizer {
         is ProductEvent.FeatureRequested,
         is ProductEvent.EpicDefined,
         is ProductEvent.PhaseDefined,
+        is MemoryEvent.MilestoneReached,
         is ProviderCallCompletedEvent,
         is TicketEvent.TicketCreated,
         is TicketEvent.TicketStatusChanged,

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/watch/presentation/WatchPresenter.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/watch/presentation/WatchPresenter.kt
@@ -381,6 +381,9 @@ class WatchPresenter(
                 val tags = event.tags.take(3).joinToString(", ")
                 if (tags.isNotEmpty()) "Stored $type: $tags" else "Stored $type knowledge"
             }
+            is MemoryEvent.MilestoneReached -> {
+                "Milestone ${event.category.name.lowercase()}: ${event.description.take(50)}"
+            }
             is Event.QuestionRaised -> "Question: ${event.questionText.take(50)}"
             is MeetingEvent.MeetingScheduled -> "Meeting: ${event.meeting.invitation.title.take(50)}"
             is MeetingEvent.MeetingStarted -> "Meeting started (${event.meetingId.takeLast(8)})"

--- a/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/cli/watch/presentation/EventCategorizerTest.kt
+++ b/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/cli/watch/presentation/EventCategorizerTest.kt
@@ -8,6 +8,7 @@ import link.socket.ampere.agents.domain.event.Event
 import link.socket.ampere.agents.domain.event.EventSource
 import link.socket.ampere.agents.domain.event.MemoryEvent
 import link.socket.ampere.agents.domain.event.MessageEvent
+import link.socket.ampere.agents.domain.event.MilestoneCategory
 import link.socket.ampere.agents.domain.event.SparkAppliedEvent
 import link.socket.ampere.agents.domain.event.TicketEvent
 import link.socket.ampere.agents.domain.memory.MemoryContext
@@ -171,6 +172,26 @@ class EventCategorizerTest {
 
         val significance = EventCategorizer.categorize(event)
         assertEquals(EventSignificance.ROUTINE, significance)
+    }
+
+    @Test
+    fun `SIGNIFICANT - MilestoneReached events are significant`() {
+        val event = MemoryEvent.MilestoneReached(
+            eventId = "evt-milestone-1",
+            timestamp = Clock.System.now(),
+            eventSource = EventSource.Agent("agent-test"),
+            urgency = Urgency.MEDIUM,
+            agentId = "agent-test",
+            milestoneId = "milestone-1",
+            description = "First successful code change",
+            knowledgeId = null,
+            taskId = "task-1",
+            runId = "run-1",
+            category = MilestoneCategory.FIRST_SUCCESS,
+        )
+
+        val significance = EventCategorizer.categorize(event)
+        assertEquals(EventSignificance.SIGNIFICANT, significance)
     }
 
     @Test

--- a/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/util/EventTypeParserTest.kt
+++ b/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/util/EventTypeParserTest.kt
@@ -6,6 +6,7 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import link.socket.ampere.agents.domain.event.Event
 import link.socket.ampere.agents.domain.event.MeetingEvent
+import link.socket.ampere.agents.domain.event.MemoryEvent
 import link.socket.ampere.agents.domain.event.MessageEvent
 import link.socket.ampere.agents.domain.event.NotificationEvent
 import link.socket.ampere.agents.domain.event.TicketEvent
@@ -81,6 +82,11 @@ class EventTypeParserTest {
     }
 
     @Test
+    fun `parse handles milestone event type`() {
+        assertNotNull(EventTypeParser.parse("MilestoneReached"))
+    }
+
+    @Test
     fun `parseMultiple returns set of EventClassTypes`() {
         val result = EventTypeParser.parseMultiple(
             listOf("TaskCreated", "QuestionRaised", "MeetingScheduled")
@@ -139,6 +145,9 @@ class EventTypeParserTest {
         // Should have notification events
         assertTrue(allNames.contains("notificationtoagent"))
         assertTrue(allNames.contains("notificationtohuman"))
+
+        // Should have milestone events
+        assertTrue(allNames.contains("milestonereached"))
     }
 
     @Test
@@ -158,6 +167,9 @@ class EventTypeParserTest {
 
         // Should have message events
         assertTrue(allTypes.contains(MessageEvent.ThreadCreated.EVENT_TYPE))
+
+        // Should have milestone events
+        assertTrue(allTypes.contains(MemoryEvent.MilestoneReached.EVENT_TYPE))
 
         // Should have notification events
         assertTrue(allTypes.contains(NotificationEvent.ToAgent.EVENT_TYPE))

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/ObservableAgent.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/ObservableAgent.kt
@@ -8,9 +8,11 @@ import kotlinx.serialization.Serializable
 import link.socket.ampere.agents.domain.cognition.Spark
 import link.socket.ampere.agents.domain.event.CognitiveStateSnapshot
 import link.socket.ampere.agents.domain.event.EventSource
+import link.socket.ampere.agents.domain.event.MilestoneCategory
 import link.socket.ampere.agents.domain.event.SparkAppliedEvent
 import link.socket.ampere.agents.domain.event.SparkRemovedEvent
 import link.socket.ampere.agents.domain.state.AgentState
+import link.socket.ampere.agents.domain.task.TaskId
 import link.socket.ampere.agents.events.api.AgentEventApi
 import link.socket.ampere.agents.events.utils.generateUUID
 
@@ -111,5 +113,26 @@ abstract class ObservableAgent<S : AgentState>(
                 api.publish(event)
             }
         }
+    }
+
+    /**
+     * Explicitly publish a milestone for externally declared checkpoints.
+     */
+    suspend fun reachMilestone(
+        category: MilestoneCategory,
+        description: String,
+        knowledgeId: String? = null,
+        taskId: TaskId? = null,
+        runId: String? = null,
+        milestoneId: String = generateUUID("milestone", id),
+    ) {
+        eventApi?.reachMilestone(
+            category = category,
+            description = description,
+            knowledgeId = knowledgeId,
+            taskId = taskId,
+            runId = runId,
+            milestoneId = milestoneId,
+        )
     }
 }

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/EventRegistry.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/EventRegistry.kt
@@ -59,6 +59,7 @@ object EventRegistry {
         // MemoryEvent types
         MemoryEvent.KnowledgeStored.EVENT_TYPE,
         MemoryEvent.KnowledgeRecalled.EVENT_TYPE,
+        MemoryEvent.MilestoneReached.EVENT_TYPE,
 
         // ToolEvent types
         ToolEvent.ToolRegistered.EVENT_TYPE,

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/MemoryEvent.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/MemoryEvent.kt
@@ -3,9 +3,11 @@ package link.socket.ampere.agents.domain.event
 import kotlin.math.roundToInt
 import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
+import link.socket.ampere.agents.definition.AgentId
 import link.socket.ampere.agents.domain.Urgency
 import link.socket.ampere.agents.domain.knowledge.KnowledgeType
 import link.socket.ampere.agents.domain.memory.MemoryContext
+import link.socket.ampere.agents.domain.task.TaskId
 
 /** Format a double to 2 decimal places (multiplatform compatible). */
 private fun Double.formatPercent(): String {
@@ -174,4 +176,65 @@ sealed interface MemoryEvent : Event {
             const val EVENT_TYPE: EventType = "KnowledgeRecalled"
         }
     }
+
+    /**
+     * Event emitted when an agent reaches a meaningful checkpoint.
+     *
+     * Milestones are low-volume signals for significant agent progress. They are
+     * intentionally separate from [KnowledgeStored] so consumers can subscribe to
+     * milestone semantics without filtering routine memory writes.
+     */
+    @Serializable
+    data class MilestoneReached(
+        override val eventId: EventId,
+        override val timestamp: Instant,
+        override val eventSource: EventSource,
+        val agentId: AgentId,
+        val milestoneId: String,
+        val description: String,
+        val knowledgeId: String?,
+        val taskId: TaskId?,
+        val runId: String?,
+        val category: MilestoneCategory,
+        override val urgency: Urgency = Urgency.MEDIUM,
+    ) : MemoryEvent {
+
+        override val eventType: EventType = EVENT_TYPE
+
+        override fun getSummary(
+            formatUrgency: (Urgency) -> String,
+            formatSource: (EventSource) -> String,
+        ): String = buildString {
+            append("Milestone reached: ")
+            append(category.name.lowercase().replace('_', ' ').replaceFirstChar { it.uppercase() })
+            append(" - ")
+            append(description)
+            taskId?.let { append(" (task=$it)") }
+            knowledgeId?.let { append(" knowledge=$it") }
+            append(" ${formatUrgency(urgency)}")
+            append(" by ${formatSource(eventSource)}")
+        }
+
+        companion object {
+            const val EVENT_TYPE: EventType = "MilestoneReached"
+        }
+    }
+}
+
+/**
+ * Categories for [MemoryEvent.MilestoneReached].
+ *
+ * [FIRST_SUCCESS] and [RECOVERY] are emitted by the built-in milestone tracker.
+ * [EXTERNAL] is emitted through the explicit milestone API for human-in-the-loop
+ * approvals or external orchestration scripts. [KEY_INSIGHT] and [CHECKPOINT]
+ * are available for future implementation when AMPERE promotes insight and
+ * long-running progress signals into explicit milestone publish sites.
+ */
+@Serializable
+enum class MilestoneCategory {
+    FIRST_SUCCESS,
+    KEY_INSIGHT,
+    RECOVERY,
+    CHECKPOINT,
+    EXTERNAL,
 }

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/TaskEvent.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/TaskEvent.kt
@@ -85,6 +85,8 @@ sealed interface TaskEvent : Event {
         override val eventSource: EventSource,
         override val timestamp: Instant,
         val summary: String,
+        val taskType: String? = null,
+        val runId: String? = null,
         override val urgency: Urgency = Urgency.MEDIUM,
     ) : TaskEvent {
 
@@ -108,6 +110,7 @@ sealed interface TaskEvent : Event {
         override val eventSource: EventSource,
         override val timestamp: Instant,
         val reason: String,
+        val runId: String? = null,
         override val urgency: Urgency = Urgency.HIGH,
     ) : TaskEvent {
 

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/EventRepository.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/EventRepository.kt
@@ -252,5 +252,8 @@ private fun Event.runIdOrNull(): String? = when (this) {
     is ToolEvent.ToolExecutionCompleted -> runId
     is MemoryEvent.KnowledgeStored -> runId
     is MemoryEvent.KnowledgeRecalled -> runId
+    is MemoryEvent.MilestoneReached -> runId
+    is link.socket.ampere.agents.domain.event.TaskEvent.TaskCompleted -> runId
+    is link.socket.ampere.agents.domain.event.TaskEvent.TaskFailed -> runId
     else -> null
 }

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/api/AgentEventApi.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/api/AgentEventApi.kt
@@ -8,7 +8,9 @@ import link.socket.ampere.agents.domain.Urgency
 import link.socket.ampere.agents.domain.event.Event
 import link.socket.ampere.agents.domain.event.EventSource
 import link.socket.ampere.agents.domain.event.EventType
+import link.socket.ampere.agents.domain.event.MemoryEvent
 import link.socket.ampere.agents.domain.event.MessageEvent
+import link.socket.ampere.agents.domain.event.MilestoneCategory
 import link.socket.ampere.agents.domain.event.PermissionDeniedEvent
 import link.socket.ampere.agents.domain.event.PermissionDeniedReason
 import link.socket.ampere.agents.domain.event.TaskEvent
@@ -56,7 +58,13 @@ class AgentEventApi(
     private val eventRepository: EventRepository,
     private val eventSerialBus: EventSerialBus,
     private val logger: EventLogger = ConsoleEventLogger(),
+    milestoneTrackerState: MilestoneTrackerState = MilestoneTrackerState(),
 ) {
+    private val milestoneTracker = MilestoneTracker(this, milestoneTrackerState)
+
+    init {
+        milestoneTracker.start()
+    }
 
     /** Persist and publish a pre-constructed event. */
     suspend fun publish(event: Event) {
@@ -307,6 +315,8 @@ class AgentEventApi(
     suspend fun publishTaskCompleted(
         taskId: TaskId,
         summary: String,
+        taskType: String? = null,
+        runId: String? = null,
         urgency: Urgency = Urgency.MEDIUM,
     ) {
         val event = TaskEvent.TaskCompleted(
@@ -315,6 +325,8 @@ class AgentEventApi(
             eventSource = EventSource.Agent(agentId),
             timestamp = Clock.System.now(),
             summary = summary,
+            taskType = taskType,
+            runId = runId,
             urgency = urgency,
         )
 
@@ -325,6 +337,7 @@ class AgentEventApi(
     suspend fun publishTaskFailed(
         taskId: TaskId,
         reason: String,
+        runId: String? = null,
         urgency: Urgency = Urgency.HIGH,
     ) {
         val event = TaskEvent.TaskFailed(
@@ -333,6 +346,36 @@ class AgentEventApi(
             eventSource = EventSource.Agent(agentId),
             timestamp = Clock.System.now(),
             reason = reason,
+            runId = runId,
+            urgency = urgency,
+        )
+
+        publish(event)
+    }
+
+    /**
+     * Publish a milestone when an agent or external consumer identifies a significant checkpoint.
+     */
+    suspend fun reachMilestone(
+        category: MilestoneCategory,
+        description: String,
+        knowledgeId: String? = null,
+        taskId: TaskId? = null,
+        runId: String? = null,
+        milestoneId: String = generateUUID("milestone", agentId),
+        urgency: Urgency = Urgency.MEDIUM,
+    ) {
+        val event = MemoryEvent.MilestoneReached(
+            eventId = generateUUID(milestoneId, agentId),
+            timestamp = Clock.System.now(),
+            eventSource = EventSource.Agent(agentId),
+            agentId = agentId,
+            milestoneId = milestoneId,
+            description = description,
+            knowledgeId = knowledgeId,
+            taskId = taskId,
+            runId = runId,
+            category = category,
             urgency = urgency,
         )
 
@@ -435,6 +478,20 @@ class AgentEventApi(
         eventSerialBus.subscribe<TaskEvent.TaskBlocked, EventSubscription.ByEventClassType>(
             agentId = agentId,
             eventType = TaskEvent.TaskBlocked.EVENT_TYPE,
+        ) { event, subscription ->
+            if (filter.execute(event)) {
+                handler(event, subscription)
+            }
+        }
+
+    /** Subscribe to milestone events. */
+    fun onMilestoneReached(
+        filter: EventFilter<MemoryEvent.MilestoneReached> = EventFilter.noFilter(),
+        handler: suspend (MemoryEvent.MilestoneReached, Subscription?) -> Unit,
+    ): Subscription =
+        eventSerialBus.subscribe<MemoryEvent.MilestoneReached, EventSubscription.ByEventClassType>(
+            agentId = agentId,
+            eventType = MemoryEvent.MilestoneReached.EVENT_TYPE,
         ) { event, subscription ->
             if (filter.execute(event)) {
                 handler(event, subscription)

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/api/AgentEventApiFactory.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/api/AgentEventApiFactory.kt
@@ -12,6 +12,8 @@ class AgentEventApiFactory(
     private val eventSerialBus: EventSerialBus,
     private val logger: EventLogger = ConsoleEventLogger(),
 ) {
+    private val milestoneTrackerStates = mutableMapOf<AgentId, MilestoneTrackerState>()
+
     /**
      * Create an [AgentEventApi] for the given [agentId].
      */
@@ -21,5 +23,6 @@ class AgentEventApiFactory(
             eventRepository = eventRepository,
             eventSerialBus = eventSerialBus,
             logger = logger,
+            milestoneTrackerState = milestoneTrackerStates.getOrPut(agentId) { MilestoneTrackerState() },
         )
 }

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/api/MilestoneTracker.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/api/MilestoneTracker.kt
@@ -1,0 +1,71 @@
+package link.socket.ampere.agents.events.api
+
+import link.socket.ampere.agents.domain.event.MemoryEvent
+import link.socket.ampere.agents.domain.event.MilestoneCategory
+import link.socket.ampere.agents.domain.event.TaskEvent
+import link.socket.ampere.agents.domain.task.TaskId
+import link.socket.ampere.agents.events.subscription.Subscription
+
+/**
+ * Per-agent milestone detector driven by task lifecycle events.
+ *
+ * The tracker keeps process-local state for the [AgentEventApi] that owns it.
+ * It does not persist milestone detection state; cross-process aggregation is
+ * left to consumers that subscribe to [MemoryEvent.MilestoneReached].
+ */
+internal class MilestoneTracker(
+    private val agentEventApi: AgentEventApi,
+    private val state: MilestoneTrackerState = MilestoneTrackerState(),
+) {
+    private val subscriptions = mutableListOf<Subscription>()
+
+    fun start() {
+        subscriptions += agentEventApi.onTaskFailed(
+            filter = agentEventApi.filterForEventsCreatedByMe(),
+        ) { event, _ ->
+            state.failedTasks += event.taskId
+        }
+
+        subscriptions += agentEventApi.onTaskCompleted(
+            filter = agentEventApi.filterForEventsCreatedByMe(),
+        ) { event, _ ->
+            publishFirstSuccessMilestone(event)
+            publishRecoveryMilestone(event)
+        }
+    }
+
+    private suspend fun publishFirstSuccessMilestone(event: TaskEvent.TaskCompleted) {
+        val taskType = event.taskType?.takeIf { it.isNotBlank() } ?: event.taskId
+        if (!state.seenSuccessfulTaskTypes.add(taskType)) {
+            return
+        }
+
+        agentEventApi.reachMilestone(
+            category = MilestoneCategory.FIRST_SUCCESS,
+            description = "First successful completion for task type $taskType",
+            taskId = event.taskId,
+            runId = event.runId,
+        )
+    }
+
+    private suspend fun publishRecoveryMilestone(event: TaskEvent.TaskCompleted) {
+        if (!state.failedTasks.remove(event.taskId)) {
+            return
+        }
+
+        agentEventApi.reachMilestone(
+            category = MilestoneCategory.RECOVERY,
+            description = "Recovered after a prior failure on task ${event.taskId}",
+            taskId = event.taskId,
+            runId = event.runId,
+        )
+    }
+}
+
+/**
+ * Process-local milestone detection state shared by APIs for the same agent.
+ */
+class MilestoneTrackerState {
+    internal val seenSuccessfulTaskTypes = mutableSetOf<String>()
+    internal val failedTasks = mutableSetOf<TaskId>()
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/utils/SignificanceAwareEventLogger.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/utils/SignificanceAwareEventLogger.kt
@@ -132,6 +132,7 @@ class SignificanceAwareEventLogger(
         is PlanEvent.PlanStepCompleted -> EventSignificance.SIGNIFICANT
         is PlanEvent.TaskAssigned -> EventSignificance.SIGNIFICANT
         is PlanEvent.MonitoringStarted -> EventSignificance.SIGNIFICANT
+        is MemoryEvent.MilestoneReached -> EventSignificance.SIGNIFICANT
         is GitEvent.BranchCreated -> EventSignificance.SIGNIFICANT
         is GitEvent.Committed -> EventSignificance.SIGNIFICANT
         is GitEvent.Pushed -> EventSignificance.SIGNIFICANT

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/dsl/events/TeamEventAdapter.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/dsl/events/TeamEventAdapter.kt
@@ -22,6 +22,7 @@ class TeamEventAdapter {
         // Memory events
         is MemoryEvent.KnowledgeRecalled -> adaptKnowledgeRecalled(event)
         is MemoryEvent.KnowledgeStored -> null // Internal, not surfaced to DSL users
+        is MemoryEvent.MilestoneReached -> null // Bridge/runtime signal, not surfaced to DSL users
 
         // Plan events
         is PlanEvent.PlanStepStarted -> adaptPlanStepStarted(event)

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/events/AgentEventApiTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/events/AgentEventApiTest.kt
@@ -16,7 +16,10 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.datetime.Clock
 import link.socket.ampere.agents.domain.Urgency
 import link.socket.ampere.agents.domain.event.Event
+import link.socket.ampere.agents.domain.event.MemoryEvent
+import link.socket.ampere.agents.domain.event.MilestoneCategory
 import link.socket.ampere.agents.events.api.AgentEventApiFactory
+import link.socket.ampere.agents.events.api.EventFilter
 import link.socket.ampere.agents.events.api.filterForEventsCreatedByMe
 import link.socket.ampere.agents.events.bus.EventSerialBus
 import link.socket.ampere.agents.events.bus.EventSerialBusFactory
@@ -120,6 +123,141 @@ class AgentEventApiTest {
 
             val events = api.getRecentEvents(since)
             assertEquals(true, events.any { it is Event.QuestionRaised })
+        }
+    }
+
+    @Test
+    fun `first task completion for new task type publishes FIRST_SUCCESS milestone`() {
+        runBlocking {
+            val api = agentEventApiFactory.create(stubAgentId)
+            val received = CompletableDeferred<MemoryEvent.MilestoneReached>()
+
+            api.onMilestoneReached { event, _ ->
+                received.complete(event)
+            }
+
+            api.publishTaskCompleted(
+                taskId = "task-1",
+                summary = "Implemented first code change",
+                taskType = "code_change",
+                runId = "run-1",
+            )
+
+            val milestone = received.await()
+            assertEquals(MilestoneCategory.FIRST_SUCCESS, milestone.category)
+            assertEquals("task-1", milestone.taskId)
+            assertEquals("run-1", milestone.runId)
+            assertEquals(stubAgentId, milestone.agentId)
+        }
+    }
+
+    @Test
+    fun `second completion for same task type does not publish another FIRST_SUCCESS milestone`() {
+        runBlocking {
+            val api = agentEventApiFactory.create(stubAgentId)
+            val milestones = mutableListOf<MemoryEvent.MilestoneReached>()
+
+            api.onMilestoneReached { event, _ ->
+                milestones += event
+            }
+
+            api.publishTaskCompleted(
+                taskId = "task-1",
+                summary = "Implemented first code change",
+                taskType = "code_change",
+            )
+            api.publishTaskCompleted(
+                taskId = "task-2",
+                summary = "Implemented another code change",
+                taskType = "code_change",
+            )
+
+            delay(200)
+            val firstSuccesses = milestones.filter { it.category == MilestoneCategory.FIRST_SUCCESS }
+            assertEquals(1, firstSuccesses.size)
+            assertEquals("task-1", firstSuccesses.single().taskId)
+        }
+    }
+
+    @Test
+    fun `task failure followed by successful retry publishes RECOVERY milestone`() {
+        runBlocking {
+            val api = agentEventApiFactory.create(stubAgentId)
+            val received = CompletableDeferred<MemoryEvent.MilestoneReached>()
+
+            api.onMilestoneReached(
+                filter = EventFilter { event -> event.category == MilestoneCategory.RECOVERY },
+            ) { event, _ ->
+                received.complete(event)
+            }
+
+            api.publishTaskFailed(
+                taskId = "task-retry",
+                reason = "Initial attempt failed",
+                runId = "run-2",
+            )
+            api.publishTaskCompleted(
+                taskId = "task-retry",
+                summary = "Retry succeeded",
+                taskType = "retryable_work",
+                runId = "run-2",
+            )
+
+            val milestone = received.await()
+            assertEquals(MilestoneCategory.RECOVERY, milestone.category)
+            assertEquals("task-retry", milestone.taskId)
+            assertEquals("run-2", milestone.runId)
+        }
+    }
+
+    @Test
+    fun `successful task without prior failure does not publish RECOVERY milestone`() {
+        runBlocking {
+            val api = agentEventApiFactory.create(stubAgentId)
+            val milestones = mutableListOf<MemoryEvent.MilestoneReached>()
+
+            api.onMilestoneReached { event, _ ->
+                milestones += event
+            }
+
+            api.publishTaskCompleted(
+                taskId = "task-success",
+                summary = "Succeeded without retry",
+                taskType = "new_work",
+            )
+
+            delay(200)
+            assertEquals(
+                emptyList(),
+                milestones.filter { it.category == MilestoneCategory.RECOVERY },
+            )
+        }
+    }
+
+    @Test
+    fun `explicit reachMilestone API publishes milestone`() {
+        runBlocking {
+            val api = agentEventApiFactory.create(stubAgentId)
+            val received = CompletableDeferred<MemoryEvent.MilestoneReached>()
+
+            api.onMilestoneReached { event, _ ->
+                received.complete(event)
+            }
+
+            api.reachMilestone(
+                category = MilestoneCategory.EXTERNAL,
+                description = "Human approved checkpoint",
+                knowledgeId = "knowledge-1",
+                taskId = "task-approval",
+                runId = "run-3",
+                milestoneId = "milestone-approval",
+            )
+
+            val milestone = received.await()
+            assertEquals(MilestoneCategory.EXTERNAL, milestone.category)
+            assertEquals("Human approved checkpoint", milestone.description)
+            assertEquals("knowledge-1", milestone.knowledgeId)
+            assertEquals("milestone-approval", milestone.milestoneId)
         }
     }
 

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/events/EventSerializationTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/events/EventSerializationTest.kt
@@ -8,6 +8,8 @@ import kotlinx.serialization.json.Json
 import link.socket.ampere.agents.domain.Urgency
 import link.socket.ampere.agents.domain.event.Event
 import link.socket.ampere.agents.domain.event.EventSource
+import link.socket.ampere.agents.domain.event.MemoryEvent
+import link.socket.ampere.agents.domain.event.MilestoneCategory
 import link.socket.ampere.agents.domain.event.PermissionDeniedEvent
 import link.socket.ampere.agents.domain.event.PermissionDeniedReason
 import link.socket.ampere.plugin.permission.PluginPermission
@@ -92,6 +94,29 @@ class EventSerializationTest {
         val decoded = json.decodeFromString(Event.serializer(), text)
 
         assertIs<PermissionDeniedEvent>(decoded)
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun `serialize and deserialize milestone reached event polymorphic`() {
+        val original: Event = MemoryEvent.MilestoneReached(
+            eventId = "55555555-5555-5555-5555-555555555555",
+            timestamp = stubTimestamp,
+            eventSource = stubEventSource,
+            agentId = "agent-X",
+            milestoneId = "milestone-1",
+            description = "Recovered after a failed retry",
+            knowledgeId = "knowledge-1",
+            taskId = "task-1",
+            runId = "run-1",
+            category = MilestoneCategory.RECOVERY,
+            urgency = Urgency.MEDIUM,
+        )
+
+        val text = json.encodeToString(Event.serializer(), original)
+        val decoded = json.decodeFromString(Event.serializer(), text)
+
+        assertIs<MemoryEvent.MilestoneReached>(decoded)
         assertEquals(original, decoded)
     }
 }

--- a/docs/concepts/cognition-trace.md
+++ b/docs/concepts/cognition-trace.md
@@ -12,7 +12,7 @@ tracked_sources:
   - ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/MemoryEvent.kt
   - ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/RoutingEvent.kt
 related: [PropelLoop, EventSerialBus, MemoryProvenance, CognitiveRelay, SparkSystem]
-last_verified: 2026-04-29
+last_verified: 2026-05-31
 ---
 
 # Cognition Trace
@@ -26,7 +26,7 @@ and `OutcomeMemoryStore` by `run_id` and assembles an `ArcRunTrace`:
 - One `PropelPhase` per phase (Perceive / Recall / Observe / Plan / Execute / Learn) plus a synthetic `Run` row for the overall envelope.
 - `ModelInvocationTrace`s joining `ProviderCallStartedEvent` ↔ `ProviderCallCompletedEvent` with `routingReason`, latency, tokens, and estimated cost.
 - `ToolCallTrace`s joining `ToolEvent.ToolExecutionStarted` ↔ `ToolExecutionCompleted` with duration and success.
-- `MemoryWriteTrace`s for `KnowledgeStored` / `OutcomeRecorded`.
+- `MemoryWriteTrace`s for `KnowledgeStored` / `OutcomeRecorded`, with `MilestoneReached` persisted as a queryable checkpoint event rather than a memory write row.
 - `WattCost` per phase and per invocation, aggregated by `WattCostAggregator`.
 
 This is the glass brain made queryable. It is a *read model* — the trace
@@ -61,7 +61,7 @@ the projection that makes the run *legible*:
 - `commonMain/sqldelight/link/socket/ampere/db/memory/KnowledgeStore.sq`, `OutcomeMemoryStore.sq` — memory stores with `run_id`.
 - `agents/domain/event/ProviderCallStartedEvent.kt`, `ProviderCallCompletedEvent.kt` — model-invocation event pair.
 - `agents/domain/event/ToolEvent.kt` — tool-call event pair (`ToolCallTrace` payload).
-- `agents/domain/event/MemoryEvent.kt` — `KnowledgeStored`, `KnowledgeRecalled`, `OutcomeRecorded`.
+- `agents/domain/event/MemoryEvent.kt` — `KnowledgeStored`, `KnowledgeRecalled`, `MilestoneReached`, `OutcomeRecorded`.
 
 ## Invariants
 

--- a/docs/concepts/event-serial-bus.md
+++ b/docs/concepts/event-serial-bus.md
@@ -11,7 +11,7 @@ tracked_sources:
   - ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/**
   - ampere-core/src/commonMain/sqldelight/link/socket/ampere/db/events/**
 related: [PropelLoop, AgentSurface, CognitionTrace, MemoryProvenance]
-last_verified: 2026-04-29
+last_verified: 2026-05-31
 ---
 
 # EventSerialBus
@@ -74,6 +74,7 @@ properties for free:
 - **Publish an event** — `agentEventApi.publish(SomeEvent(...))`. The api wraps the bus and is the agent-facing entry point.
 - **Subscribe** — `bus.subscribe(eventType, scope) { event, subscription -> ... }`. Hold onto the returned `EventSubscription` so you can `unsubscribe` on shutdown.
 - **Add a new event type** — extend `Event` (or the appropriate sub-sealed family in `agents/domain/event/`), register a `@Serializable` subclass with a stable `@SerialName`, add a CLI display handler, and add a logger summary in `Event.getSummary` if relevant.
+- **Publish an agent milestone** — call `AgentEventApi.reachMilestone(...)` or, for observable agents, `agent.reachMilestone(...)`. Milestones emit `MemoryEvent.MilestoneReached`, a low-volume sibling event to routine memory writes.
 - **Persist for trace** — events flow into `EventStore` via the configured logger. New event types are picked up automatically; just verify `run_id` is set on the emitter.
 
 ## Anti-patterns

--- a/docs/concepts/memory-provenance.md
+++ b/docs/concepts/memory-provenance.md
@@ -8,7 +8,7 @@ tracked_sources:
   - ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/MemoryEvent.kt
   - ampere-core/src/commonMain/sqldelight/link/socket/ampere/db/memory/**
 related: [PropelLoop, CognitionTrace, EventSerialBus, DreamCycle]
-last_verified: 2026-05-27
+last_verified: 2026-05-31
 ---
 
 # Memory Provenance
@@ -61,7 +61,7 @@ through `ArcTraceProjection` into the full phase-by-phase narrative.
 - `agents/domain/knowledge/Knowledge.kt` — sealed knowledge sources.
 - `agents/domain/knowledge/KnowledgeRepository.kt` + `KnowledgeRepositoryImpl.kt` — semantic store.
 - `agents/domain/memory/AgentMemoryService.kt` — the recall facade; scores by similarity, tag overlap, task type, recency, complexity.
-- `agents/domain/event/MemoryEvent.kt` — `KnowledgeStored`, `KnowledgeRecalled`, `OutcomeRecorded` events.
+- `agents/domain/event/MemoryEvent.kt` — `KnowledgeStored`, `KnowledgeRecalled`, `MilestoneReached`, `OutcomeRecorded` events.
 - `commonMain/sqldelight/link/socket/ampere/db/memory/OutcomeMemoryStore.sq`, `KnowledgeStore.sq` — schemas (each carries `run_id`).
 
 ## Invariants
@@ -77,6 +77,7 @@ through `ArcTraceProjection` into the full phase-by-phase narrative.
 
 - **Record an execution outcome** — your tool returns an `ExecutionResult`; `OutcomeEvaluator` wraps it into the appropriate `ExecutionOutcome` variant; `OutcomeMemoryRepository.recordOutcome` writes it. Don't bypass the evaluator.
 - **Extract knowledge** — Loop phase: `KnowledgeExtractor` reads outcomes from the current run, distils into `Knowledge.FromOutcome` (or `FromPlan`, etc.), and `KnowledgeRepository.storeKnowledge` writes it. `KnowledgeStored` event emitted.
+- **Emit a milestone** — milestone detection is separate from knowledge storage. `MilestoneTracker` listens for per-agent task lifecycle transitions and publishes `MilestoneReached` for first successful task types and recovery after failure; external systems use `AgentEventApi.reachMilestone(...)`.
 - **Recall** — `AgentMemoryService.recallRelevantKnowledge(MemoryContext(...))` for in-loop reasoning. Returns scored entries.
 - **Time-travel a run** — `ArcTraceProjection.project(runId)` reads `EventStore`, `KnowledgeStore`, and `OutcomeMemoryStore` by `run_id` and rebuilds the per-phase trace.
 - **Add a new outcome variant** — extend `ExecutionOutcome`, add a `Success`/`Failure` pair, update `OutcomeEvaluator`, add a CLI display handler.
@@ -86,6 +87,7 @@ through `ArcTraceProjection` into the full phase-by-phase narrative.
 - **Updating an outcome in place after the fact.** "I'll just patch the error message." No — write a new outcome. The original is the audit trail.
 - **Storing tool-specific shapes in `ExecutionOutcome`.** Once a variant carries a `KafkaPartition` or similar, cross-executor recall stops working. Keep variants tool-agnostic; put tool detail in nested response types.
 - **Calling `KnowledgeRepository.storeKnowledge` from a tool.** Knowledge is the output of cognitive distillation, not a direct write target. Use `OutcomeMemoryRepository` from tools; let the Loop phase produce knowledge.
+- **Using `KnowledgeStored` as a milestone flag.** Routine memory writes are high volume. Publish `MilestoneReached` as a sibling event when the semantic payload represents a meaningful checkpoint.
 - **Recall by ticket id alone.** `MemoryContext` is built from task type, tags, and description for a reason. Ticket-id recall returns *only* this ticket's prior runs, missing the cross-ticket pattern recognition that's the point.
 - **Filtering failures out of recall.** Failures teach what not to do. A "successful approaches only" filter erases that signal.
 - **Stripping `run_id` when persisting.** A common refactoring trap: a helper drops the `run_id` parameter "because it's not used downstream". `ArcTraceProjection` is downstream. Keep it.

--- a/docs/develop/milestone-events.md
+++ b/docs/develop/milestone-events.md
@@ -1,0 +1,37 @@
+# Milestone Events
+
+`MemoryEvent.MilestoneReached` is the low-volume event for significant agent
+checkpoints. It is a sibling of `KnowledgeStored`, not a flag on it, so bridge
+and renderer consumers can subscribe to `MilestoneReached.EVENT_TYPE` without
+filtering every routine memory write.
+
+## Publish Sites
+
+The built-in `MilestoneTracker` is attached to `AgentEventApi` and keeps
+process-local state for that agent. APIs created from the same
+`AgentEventApiFactory` share the same per-agent state:
+
+| Category | Trigger |
+| --- | --- |
+| `FIRST_SUCCESS` | First `TaskCompleted` for a new `taskType` observed from that agent. If `taskType` is not supplied, the task id is used as the local type key. |
+| `RECOVERY` | `TaskFailed` followed by `TaskCompleted` for the same `taskId` from that agent. |
+| `EXTERNAL` | Explicit call through `AgentEventApi.reachMilestone(...)` or `ObservableAgent.reachMilestone(...)`. |
+
+`KEY_INSIGHT` and `CHECKPOINT` are reserved for future publish sites.
+
+## Bridge Reference
+
+The Lumos bridge can map AMPERE milestones to STAR by subscribing to:
+
+```kotlin
+eventBus.subscribe<MemoryEvent.MilestoneReached, EventSubscription.ByEventClassType>(
+    agentId = bridgeAgentId,
+    eventType = MemoryEvent.MilestoneReached.EVENT_TYPE,
+) { event, _ ->
+    // milestone -> STAR
+}
+```
+
+The event carries `category`, `description`, optional `knowledgeId`, optional
+`taskId`, and optional `runId`, which is enough for the bridge to render a STAR
+and retain provenance back to the agent run.


### PR DESCRIPTION
Closes #504 for Linear AMPR-175.

This PR adds `MemoryEvent.MilestoneReached`, milestone categories, per-agent milestone tracking for first success and recovery, and explicit milestone publishing APIs for external checkpoints. It registers the event for persistence/subscription, updates CLI display/significance handling, and documents the Lumos bridge `milestone -> STAR` path. Tests cover milestone publishing behavior, serialization, event parsing, and CLI categorization. Validation: `./gradlew ktlintFormat` passed; `./gradlew jvmTest` is blocked because this workspace is missing `local.properties`, which repo instructions say not to create or modify.