### PR TITLE
ci: split JVM and iOS test jobs, bump ubuntu to JDK 21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,28 +7,18 @@ on:
     branches: [ main ]
 
 jobs:
-  tests:
-    name: Tests (${{ matrix.os }}, JDK ${{ matrix.java }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-            java: '17'
-            ios: false
-          - os: macos-latest
-            java: '21'
-            ios: true
+  jvm-tests:
+    name: JVM + Android Tests (ubuntu, JDK 21)
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up JDK ${{ matrix.java }}
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: ${{ matrix.java }}
+          java-version: '21'
           distribution: 'temurin'
 
       - name: Setup Gradle
@@ -50,7 +40,31 @@ jobs:
         timeout-minutes: 20
         run: ./gradlew :ampere-core:jvmTest :ampere-core:testDebugUnitTest :ampere-cli:jvmTest :ampere-compose:jvmTest :ampere-compose:testDebugUnitTest
 
+  ios-tests:
+    name: iOS Simulator Tests (macos, JDK 21)
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Create local.properties
+        run: |
+          cat > local.properties << 'EOF'
+          anthropic_api_key=placeholder
+          google_api_key=placeholder
+          openai_api_key=placeholder
+          EOF
+
       - name: Run iOS simulator tests
-        if: ${{ matrix.ios }}
         timeout-minutes: 25
         run: ./gradlew :ampere-core:iosSimulatorArm64Test


### PR DESCRIPTION
## Summary

Previously both ubuntu and macos runners ran the full JVM + Android test suite, with macos additionally running iOS simulator tests. Mac runners cost ~10x Linux on GH Actions and the JVM/Android duplication wasn't earning much, since KMP JVM bytecode behavior is nearly identical across OSes.

I split this into two parallel jobs: ubuntu runs ktlint + JVM/Android, macos only runs iOS simulator tests. Both now use JDK 21 (ubuntu was previously on 17).

## Heads up

Branch protection rules referencing the old check names (`Tests (ubuntu-latest, JDK 17)` / `Tests (macos-latest, JDK 21)`) will need updating to the new names: `JVM + Android Tests (ubuntu, JDK 21)` and `iOS Simulator Tests (macos, JDK 21)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)