### PR TITLE
AMPR-180 #508: Emission protocol foundation (Wave 0)

### DIFF
--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/watch/presentation/EventCategorizer.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/watch/presentation/EventCategorizer.kt
@@ -3,6 +3,7 @@ package link.socket.ampere.cli.watch.presentation
 import link.socket.ampere.agents.domain.event.AgentSurfaceEvent
 import link.socket.ampere.agents.domain.event.CognitiveEvent
 import link.socket.ampere.agents.domain.event.CognitivePhaseEvent
+import link.socket.ampere.agents.domain.event.EmissionEvent
 import link.socket.ampere.agents.domain.event.Event
 import link.socket.ampere.agents.domain.event.FileSystemEvent
 import link.socket.ampere.agents.domain.event.GitEvent
@@ -96,7 +97,9 @@ object EventCategorizer {
         is TicketEvent.TicketCompleted,
         is TicketEvent.TicketMeetingScheduled,
         is AgentSurfaceEvent.Requested,
-        is AgentSurfaceEvent.Responded -> EventSignificance.SIGNIFICANT
+        is AgentSurfaceEvent.Responded,
+        is EmissionEvent.Produced,
+        is EmissionEvent.Resolved -> EventSignificance.SIGNIFICANT
 
         // Routine cognitive operations - maintenance work
         is GitEvent.BranchCreated,

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/renderer/EventRenderer.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/renderer/EventRenderer.kt
@@ -15,6 +15,7 @@ import link.socket.ampere.agents.domain.Urgency
 import link.socket.ampere.agents.domain.event.AgentSurfaceEvent
 import link.socket.ampere.agents.domain.event.CognitiveEvent
 import link.socket.ampere.agents.domain.event.CognitivePhaseEvent
+import link.socket.ampere.agents.domain.event.EmissionEvent
 import link.socket.ampere.agents.domain.event.Event
 import link.socket.ampere.agents.domain.event.EventSource
 import link.socket.ampere.agents.domain.event.FileSystemEvent
@@ -168,6 +169,9 @@ class EventRenderer(
             // AgentSurface events: native UI surface request/response
             is AgentSurfaceEvent.Requested -> "🪟" to magenta
             is AgentSurfaceEvent.Responded -> "🪟" to blue
+            // Emission events: the unifying CHI primitive (produced/resolved)
+            is EmissionEvent.Produced -> "📡" to magenta
+            is EmissionEvent.Resolved -> "📡" to blue
         }
     }
 

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/Identifiers.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/Identifiers.kt
@@ -4,3 +4,10 @@ typealias TeamId = String
 typealias SprintId = String
 typealias PRId = String
 typealias RunId = String
+
+/**
+ * Correlation id for a broader reasoning unit (a perception, a plan, a task)
+ * that spans multiple [Event]s. Distinct from [RunId], which scopes a single
+ * Arc execution.
+ */
+typealias WorkflowId = String

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/emission/Affordance.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/emission/Affordance.kt
@@ -1,0 +1,19 @@
+package link.socket.ampere.agents.domain.emission
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * A single response option attached to an [Emission].
+ *
+ * The `signalPayload` is opaque to AMPERE — it travels back out on the bus
+ * as part of `EmissionEvent.Resolved` when the human selects this
+ * affordance. Surface-side consumers decide what to render and what value
+ * to populate; AMPERE only carries the bytes.
+ */
+@Serializable
+data class Affordance(
+    val id: AffordanceId,
+    val label: String,
+    val signalPayload: JsonElement,
+)

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/emission/Emission.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/emission/Emission.kt
@@ -1,0 +1,42 @@
+package link.socket.ampere.agents.domain.emission
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.Serializable
+import link.socket.ampere.agents.domain.reasoning.Confidence
+
+/**
+ * One moment of computer-initiated human contact — the unit of CHI.
+ *
+ * An Emission is published as `EmissionEvent.Produced` on the
+ * `EventSerialBus`. AMPERE has no opinion on rendering: that is a
+ * Socket-side concern. AMPERE owns the noun (this type), the verb (the
+ * event family), and the provenance.
+ *
+ * Construction is the only point at which an Emission is mutated. Once
+ * published it must be treated as immutable; in particular, `dedupKey` is
+ * fixed at construction. Callers compute `dedupKey` via
+ * [computeDedupKey] for effect-bearing kinds (Confirmation today, Action
+ * tomorrow) and leave it `null` for kinds that should always render.
+ */
+@Serializable
+data class Emission(
+    val id: EmissionId,
+    val kind: EmissionKind,
+    val payload: EmissionPayload,
+    val affordances: List<Affordance> = emptyList(),
+    val confidence: Confidence? = null,
+    val provenance: EmissionProvenance,
+    val dedupKey: String? = null,
+    val producedAt: Instant,
+)
+
+/**
+ * Convenience helper for the dedup contract: returns a content digest for
+ * effect-bearing kinds (currently [EmissionKind.Confirmation]) and `null`
+ * otherwise. Callers are free to override this default — the helper exists
+ * so the common case is one call.
+ */
+fun Emission.computeDedupKey(): String? = when (kind) {
+    is EmissionKind.Confirmation -> inputDigest(payload)
+    else -> null
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/emission/EmissionDigest.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/emission/EmissionDigest.kt
@@ -1,0 +1,45 @@
+package link.socket.ampere.agents.domain.emission
+
+import kotlinx.serialization.json.Json
+import okio.ByteString.Companion.encodeUtf8
+
+/**
+ * Canonical [Json] used for [inputDigest]. Kept private so the hash
+ * function is the only public way to produce a dedup digest — any change
+ * to these flags shifts every previously-stored digest, so callers must
+ * not pick their own configuration.
+ *
+ * Mirrors `RepositoryFactory.DEFAULT_JSON`'s `classDiscriminator = "type"`
+ * convention so the digest matches what the bus would serialize.
+ */
+private val DigestJson: Json = Json {
+    classDiscriminator = "type"
+    encodeDefaults = true
+    prettyPrint = false
+}
+
+/**
+ * Number of hex characters retained from the SHA-256 digest. 16 chars =
+ * 64 bits of collision resistance, which is sufficient for the dedup
+ * window (seconds to minutes on a single agent) and keeps the digest
+ * short enough to log inline.
+ */
+private const val DIGEST_HEX_CHARS = 16
+
+/**
+ * Content-deterministic digest of an [EmissionPayload]. The same payload
+ * always yields the same digest; differing payloads always yield
+ * differing digests (modulo SHA-256 collisions).
+ *
+ * Stability comes from two pieces:
+ *  - `kotlinx.serialization` writes data-class fields in declaration order
+ *  - [DigestJson] forces a single canonical configuration
+ *
+ * Field ordering in source code therefore does not affect the digest, and
+ * adding a default-valued field to a payload variant changes the digest
+ * — both of which are the intended semantics.
+ */
+fun inputDigest(payload: EmissionPayload): String {
+    val json = DigestJson.encodeToString(EmissionPayload.serializer(), payload)
+    return json.encodeUtf8().sha256().hex().take(DIGEST_HEX_CHARS)
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/emission/EmissionIds.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/emission/EmissionIds.kt
@@ -1,0 +1,15 @@
+package link.socket.ampere.agents.domain.emission
+
+/**
+ * Random identity for a published [Emission]. Generated via the platform
+ * `randomUUID()` helper. Dedup must never be overloaded onto this id — see
+ * the `EmissionDedup` concept cell.
+ */
+typealias EmissionId = String
+
+/**
+ * Random identity for an [Affordance] attached to an [Emission]. Stable for
+ * the lifetime of the emission so a corresponding `EmissionEvent.Resolved`
+ * can causally link to the chosen affordance.
+ */
+typealias AffordanceId = String

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/emission/EmissionKind.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/emission/EmissionKind.kt
@@ -1,0 +1,36 @@
+package link.socket.ampere.agents.domain.emission
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * The four core kinds of [Emission] surfaced by AMPERE today. The kind is a
+ * peer of the payload — a tag — and is preserved on the wire to allow
+ * consumers to dispatch without unpacking the payload.
+ *
+ * Adding a kind is a wire-format change: introduce a new variant, add the
+ * matching [EmissionPayload] variant, and bump the concept cells.
+ */
+@Serializable
+sealed interface EmissionKind {
+
+    /** Prose narration intended for human reading. */
+    @Serializable
+    @SerialName("EmissionKind.Prose")
+    data object Prose : EmissionKind
+
+    /** A question with affordances representing distinct choices. */
+    @Serializable
+    @SerialName("EmissionKind.Decision")
+    data object Decision : EmissionKind
+
+    /** A request to confirm an effect before it executes. */
+    @Serializable
+    @SerialName("EmissionKind.Confirmation")
+    data object Confirmation : EmissionKind
+
+    /** An ambient observation or reading (gauge, status, latency, …). */
+    @Serializable
+    @SerialName("EmissionKind.Sensor")
+    data object Sensor : EmissionKind
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/emission/EmissionPayload.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/emission/EmissionPayload.kt
@@ -1,0 +1,82 @@
+package link.socket.ampere.agents.domain.emission
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Format applied to an [EmissionPayload.Prose] body. Renderers honour the
+ * tag; AMPERE itself never renders.
+ */
+@Serializable
+enum class ProseFormat {
+    PLAIN,
+    MARKDOWN,
+}
+
+/**
+ * Danger tier for an [EmissionPayload.Confirmation]. Carries no rendering
+ * decision — it expresses the underlying *effect* the human is being asked
+ * to confirm. Surface-side policy decides how loud to be.
+ */
+@Serializable
+enum class DangerLevel {
+    LOW,
+    MEDIUM,
+    HIGH,
+}
+
+/**
+ * Typed body of an [Emission]. One variant per [EmissionKind]; the pairing
+ * is established by callers and validated lightly in [Emission.init].
+ *
+ * Adding a payload variant is a wire-format change — pick a stable
+ * `@SerialName` and never rename it.
+ */
+@Serializable
+sealed interface EmissionPayload {
+
+    /** Prose narration intended for human reading. */
+    @Serializable
+    @SerialName("EmissionPayload.Prose")
+    data class Prose(
+        val text: String,
+        val format: ProseFormat,
+    ) : EmissionPayload
+
+    /**
+     * A question framed for the human. Affordances representing the
+     * available answers live on [Emission.affordances], not in the payload.
+     */
+    @Serializable
+    @SerialName("EmissionPayload.Decision")
+    data class Decision(
+        val prompt: String,
+        val context: String? = null,
+    ) : EmissionPayload
+
+    /**
+     * A request to confirm an effect before AMPERE executes it. `preview`
+     * is a short renderable summary of the effect (for example, the diff
+     * a tool is about to apply).
+     */
+    @Serializable
+    @SerialName("EmissionPayload.Confirmation")
+    data class Confirmation(
+        val action: String,
+        val preview: String? = null,
+        val dangerLevel: DangerLevel,
+    ) : EmissionPayload
+
+    /**
+     * Ambient sensor reading. Optional `refreshUri` lets a renderer pull a
+     * fresh value without going back through the bus.
+     */
+    @Serializable
+    @SerialName("EmissionPayload.Sensor")
+    data class Sensor(
+        val label: String,
+        val value: String,
+        val unit: String? = null,
+        val refreshUri: String? = null,
+    ) : EmissionPayload
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/emission/EmissionProvenance.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/emission/EmissionProvenance.kt
@@ -1,0 +1,31 @@
+package link.socket.ampere.agents.domain.emission
+
+import kotlinx.serialization.Serializable
+import link.socket.ampere.agents.domain.RunId
+import link.socket.ampere.agents.domain.WorkflowId
+import link.socket.ampere.agents.domain.event.EventId
+
+/**
+ * Where this [Emission] came from. Every Emission carries provenance — that
+ * is what makes it auditable downstream.
+ *
+ *  - `runId` / `workflowId` link the Emission to the Arc and reasoning unit
+ *    that produced it.
+ *  - `sourceEventId` records the event that motivated the Emission (for
+ *    example, the tool result that prompted a Confirmation).
+ *  - `toolInvocationId`, `pluginId`, `modelId` are populated when the
+ *    Emission can be attributed to a specific tool call, plugin, or model.
+ *  - `inputDigest` is the deterministic SHA-256 hash of the payload (see
+ *    [inputDigest]) and lets consumers reason about content identity
+ *    without re-hashing.
+ */
+@Serializable
+data class EmissionProvenance(
+    val runId: RunId? = null,
+    val workflowId: WorkflowId? = null,
+    val sourceEventId: EventId? = null,
+    val toolInvocationId: String? = null,
+    val pluginId: String? = null,
+    val modelId: String? = null,
+    val inputDigest: String,
+)

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/EmissionEvent.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/EmissionEvent.kt
@@ -1,0 +1,95 @@
+package link.socket.ampere.agents.domain.event
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+import link.socket.ampere.agents.domain.Urgency
+import link.socket.ampere.agents.domain.emission.AffordanceId
+import link.socket.ampere.agents.domain.emission.Emission
+import link.socket.ampere.agents.domain.emission.EmissionId
+
+/**
+ * Bus-level events that carry an [Emission].
+ *
+ * AMPERE publishes [Produced] when the agent decides to surface an
+ * Emission. A consumer (today: Socket) publishes [Resolved] when an
+ * affordance reply arrives, causally linking the reply back to the
+ * originating Emission and the chosen [AffordanceId].
+ *
+ * Both event types share the `EmissionEvent` discriminator slot in
+ * `EventRegistry.allEventTypes`, so consumers subscribe to exactly the
+ * lifecycle they care about.
+ */
+@Serializable
+sealed interface EmissionEvent : Event {
+
+    /** The Emission whose lifecycle this event refers to. */
+    val emissionId: EmissionId
+
+    /** Published when the agent produces an [Emission]. */
+    @Serializable
+    @SerialName("EmissionEvent.Produced")
+    data class Produced(
+        override val eventId: EventId,
+        override val timestamp: Instant,
+        override val eventSource: EventSource,
+        override val urgency: Urgency = Urgency.MEDIUM,
+        val emission: Emission,
+    ) : EmissionEvent {
+
+        override val emissionId: EmissionId = emission.id
+
+        override val eventType: EventType = EVENT_TYPE
+
+        override fun getSummary(
+            formatUrgency: (Urgency) -> String,
+            formatSource: (EventSource) -> String,
+        ): String = buildString {
+            append("Emission produced: ")
+            append(emission.kind::class.simpleName ?: "Unknown")
+            append(" (id=${emission.id})")
+            emission.dedupKey?.let { append(" dedup=$it") }
+            append(" ${formatUrgency(urgency)}")
+            append(" from ${formatSource(eventSource)}")
+        }
+
+        companion object {
+            const val EVENT_TYPE: EventType = "EmissionProduced"
+        }
+    }
+
+    /**
+     * Published when an affordance reply arrives. `replyContext` carries
+     * the (opaque to AMPERE) `signalPayload` of the chosen affordance, or
+     * `null` if the consumer reports a resolution without a payload (for
+     * example, a confirmation accepted by default).
+     */
+    @Serializable
+    @SerialName("EmissionEvent.Resolved")
+    data class Resolved(
+        override val eventId: EventId,
+        override val timestamp: Instant,
+        override val eventSource: EventSource,
+        override val urgency: Urgency = Urgency.LOW,
+        override val emissionId: EmissionId,
+        val affordanceId: AffordanceId,
+        val replyContext: JsonElement? = null,
+    ) : EmissionEvent {
+
+        override val eventType: EventType = EVENT_TYPE
+
+        override fun getSummary(
+            formatUrgency: (Urgency) -> String,
+            formatSource: (EventSource) -> String,
+        ): String = buildString {
+            append("Emission resolved: $emissionId via $affordanceId")
+            append(" ${formatUrgency(urgency)}")
+            append(" from ${formatSource(eventSource)}")
+        }
+
+        companion object {
+            const val EVENT_TYPE: EventType = "EmissionResolved"
+        }
+    }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/EventRegistry.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/EventRegistry.kt
@@ -113,6 +113,10 @@ object EventRegistry {
         // AgentSurfaceEvent types
         AgentSurfaceEvent.Requested.EVENT_TYPE,
         AgentSurfaceEvent.Responded.EVENT_TYPE,
+
+        // EmissionEvent types
+        EmissionEvent.Produced.EVENT_TYPE,
+        EmissionEvent.Resolved.EVENT_TYPE,
     )
 
     /**

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/reasoning/Confidence.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/reasoning/Confidence.kt
@@ -1,0 +1,45 @@
+package link.socket.ampere.agents.domain.reasoning
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Shared confidence enum used across the cognition layer.
+ *
+ * Currently consumed by:
+ *  - [PerceptionEvaluator] when parsing per-insight confidence from LLM JSON
+ *  - [OutcomeEvaluator] when parsing per-learning confidence from LLM JSON
+ *  - [link.socket.ampere.agents.domain.emission.Emission] for CHI Emissions
+ *
+ * Prompt strings remain lower-case (`"high" | "medium" | "low"`) for LLM
+ * compatibility; [parseOrNull] / [parseOrDefault] handle the conversion to
+ * this enum on the Kotlin side.
+ */
+@Serializable
+enum class Confidence {
+    LOW,
+    MEDIUM,
+    HIGH,
+    ;
+
+    companion object {
+
+        /**
+         * Parse a prompt-style confidence string (case-insensitive) and return
+         * `null` if the input is not recognised.
+         */
+        fun parseOrNull(value: String): Confidence? = when (value.trim().lowercase()) {
+            "low" -> LOW
+            "medium" -> MEDIUM
+            "high" -> HIGH
+            else -> null
+        }
+
+        /**
+         * Parse a prompt-style confidence string, falling back to [default]
+         * when the input is `null`, blank, or unrecognised. Defaults to
+         * [MEDIUM] to match historical evaluator behaviour.
+         */
+        fun parseOrDefault(value: String?, default: Confidence = MEDIUM): Confidence =
+            value?.let { parseOrNull(it) } ?: default
+    }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/reasoning/OutcomeEvaluator.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/reasoning/OutcomeEvaluator.kt
@@ -287,7 +287,7 @@ class OutcomeEvaluator(
                 val pattern = obj["pattern"]?.jsonPrimitive?.content ?: return@mapNotNull null
                 val reasoning = obj["reasoning"]?.jsonPrimitive?.content ?: ""
                 val actionableAdvice = obj["actionableAdvice"]?.jsonPrimitive?.content ?: ""
-                val confidence = obj["confidence"]?.jsonPrimitive?.content ?: "medium"
+                val confidence = Confidence.parseOrDefault(obj["confidence"]?.jsonPrimitive?.content)
                 val evidenceCount = obj["evidenceCount"]?.jsonPrimitive?.content?.toIntOrNull() ?: 1
 
                 val outcomeId = outcomes.firstOrNull { it.id.isNotBlank() }?.id
@@ -301,7 +301,7 @@ class OutcomeEvaluator(
                         appendLine()
                         appendLine("Actionable Advice: $actionableAdvice")
                         appendLine()
-                        appendLine("Confidence: $confidence")
+                        appendLine("Confidence: ${confidence.name.lowercase()}")
                         appendLine("Evidence Count: $evidenceCount")
                     },
                     timestamp = now,

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/reasoning/PerceptionEvaluator.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/reasoning/PerceptionEvaluator.kt
@@ -142,9 +142,9 @@ class PerceptionEvaluator(
             val obj = element.jsonObject
             val observation = obj["observation"]?.jsonPrimitive?.content ?: "No observation"
             val implication = obj["implication"]?.jsonPrimitive?.content ?: "No implication"
-            val confidence = obj["confidence"]?.jsonPrimitive?.content ?: "medium"
+            val confidence = Confidence.parseOrDefault(obj["confidence"]?.jsonPrimitive?.content)
 
-            "$observation → $implication (confidence: $confidence)"
+            "$observation → $implication (confidence: ${confidence.name.lowercase()})"
         }
 
         return Idea(

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/utils/SignificanceAwareEventLogger.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/utils/SignificanceAwareEventLogger.kt
@@ -5,6 +5,7 @@ import link.socket.ampere.agents.domain.Urgency
 import link.socket.ampere.agents.domain.event.AgentSurfaceEvent
 import link.socket.ampere.agents.domain.event.CognitiveEvent
 import link.socket.ampere.agents.domain.event.CognitivePhaseEvent
+import link.socket.ampere.agents.domain.event.EmissionEvent
 import link.socket.ampere.agents.domain.event.Event
 import link.socket.ampere.agents.domain.event.EventSource
 import link.socket.ampere.agents.domain.event.EventType
@@ -170,6 +171,11 @@ class SignificanceAwareEventLogger(
         // AgentSurface events - significant; users see them directly via the renderer
         is AgentSurfaceEvent.Requested -> EventSignificance.SIGNIFICANT
         is AgentSurfaceEvent.Responded -> EventSignificance.SIGNIFICANT
+
+        // Emission events - the unifying CHI primitive. Produced is what the
+        // human will see; Resolved is the reply travelling back.
+        is EmissionEvent.Produced -> EventSignificance.SIGNIFICANT
+        is EmissionEvent.Resolved -> EventSignificance.SIGNIFICANT
     }
 
     private fun formatUrgency(urgency: Urgency): String = when (urgency) {

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/emission/EmissionDigestTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/emission/EmissionDigestTest.kt
@@ -1,0 +1,122 @@
+package link.socket.ampere.agents.domain.emission
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.datetime.Instant
+import kotlinx.serialization.json.JsonPrimitive
+
+class EmissionDigestTest {
+
+    private val provenance = EmissionProvenance(inputDigest = "irrelevant")
+    private val producedAt = Instant.fromEpochMilliseconds(0)
+
+    @Test
+    fun `digest is deterministic across calls`() {
+        val payload = EmissionPayload.Confirmation(
+            action = "rm -rf node_modules",
+            preview = null,
+            dangerLevel = DangerLevel.MEDIUM,
+        )
+        val a = inputDigest(payload)
+        val b = inputDigest(payload)
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun `digest is 16 hex chars`() {
+        val digest = inputDigest(EmissionPayload.Prose(text = "anything", format = ProseFormat.PLAIN))
+        assertEquals(16, digest.length)
+        assertTrue(digest.all { it in "0123456789abcdef" }, "Expected lowercase hex, got: $digest")
+    }
+
+    @Test
+    fun `equal Confirmations produce equal digests`() {
+        val a = EmissionPayload.Confirmation("act", "preview", DangerLevel.LOW)
+        val b = EmissionPayload.Confirmation("act", "preview", DangerLevel.LOW)
+        assertEquals(inputDigest(a), inputDigest(b))
+    }
+
+    @Test
+    fun `Confirmations differing in action produce different digests`() {
+        val a = EmissionPayload.Confirmation("delete x", null, DangerLevel.HIGH)
+        val b = EmissionPayload.Confirmation("delete y", null, DangerLevel.HIGH)
+        assertNotEquals(inputDigest(a), inputDigest(b))
+    }
+
+    @Test
+    fun `Confirmations differing in danger level produce different digests`() {
+        val a = EmissionPayload.Confirmation("act", null, DangerLevel.LOW)
+        val b = EmissionPayload.Confirmation("act", null, DangerLevel.HIGH)
+        assertNotEquals(inputDigest(a), inputDigest(b))
+    }
+
+    @Test
+    fun `Prose differing in format produces different digests`() {
+        val a = EmissionPayload.Prose("hello", ProseFormat.PLAIN)
+        val b = EmissionPayload.Prose("hello", ProseFormat.MARKDOWN)
+        assertNotEquals(inputDigest(a), inputDigest(b))
+    }
+
+    @Test
+    fun `digest differs between payload kinds for identical content`() {
+        val sensor = EmissionPayload.Sensor(label = "x", value = "y", unit = null, refreshUri = null)
+        val prose = EmissionPayload.Prose(text = "x", format = ProseFormat.PLAIN)
+        assertNotEquals(inputDigest(sensor), inputDigest(prose))
+    }
+
+    @Test
+    fun `computeDedupKey returns digest for Confirmation`() {
+        val payload = EmissionPayload.Confirmation("act", null, DangerLevel.LOW)
+        val emission = Emission(
+            id = "id-1",
+            kind = EmissionKind.Confirmation,
+            payload = payload,
+            provenance = provenance,
+            producedAt = producedAt,
+        )
+        assertEquals(inputDigest(payload), emission.computeDedupKey())
+    }
+
+    @Test
+    fun `computeDedupKey returns null for Prose`() {
+        val payload = EmissionPayload.Prose("hi", ProseFormat.PLAIN)
+        val emission = Emission(
+            id = "id-2",
+            kind = EmissionKind.Prose,
+            payload = payload,
+            provenance = provenance,
+            producedAt = producedAt,
+        )
+        assertNull(emission.computeDedupKey())
+    }
+
+    @Test
+    fun `computeDedupKey returns null for Decision`() {
+        val payload = EmissionPayload.Decision("Which?", null)
+        val emission = Emission(
+            id = "id-3",
+            kind = EmissionKind.Decision,
+            payload = payload,
+            affordances = listOf(Affordance("aff-1", "Yes", JsonPrimitive(true))),
+            provenance = provenance,
+            producedAt = producedAt,
+        )
+        assertNull(emission.computeDedupKey())
+    }
+
+    @Test
+    fun `computeDedupKey returns null for Sensor`() {
+        val payload = EmissionPayload.Sensor("queue", "42", "items", null)
+        val emission = Emission(
+            id = "id-4",
+            kind = EmissionKind.Sensor,
+            payload = payload,
+            provenance = provenance,
+            producedAt = producedAt,
+        )
+        assertNull(emission.computeDedupKey())
+    }
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/emission/EmissionSerializationTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/emission/EmissionSerializationTest.kt
@@ -1,0 +1,131 @@
+package link.socket.ampere.agents.domain.emission
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.datetime.Instant
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import link.socket.ampere.agents.domain.reasoning.Confidence
+
+class EmissionSerializationTest {
+
+    private val json = Json {
+        prettyPrint = false
+        encodeDefaults = true
+        classDiscriminator = "type"
+        ignoreUnknownKeys = true
+    }
+
+    private val baseProvenance = EmissionProvenance(
+        runId = "run-1",
+        workflowId = "wf-1",
+        sourceEventId = "evt-1",
+        toolInvocationId = "tool-inv-1",
+        pluginId = "plugin-x",
+        modelId = "claude-sonnet-4-0",
+        inputDigest = "abcdef0123456789",
+    )
+
+    private fun emission(payload: EmissionPayload, kind: EmissionKind): Emission = Emission(
+        id = "emission-id",
+        kind = kind,
+        payload = payload,
+        affordances = listOf(
+            Affordance(
+                id = "aff-1",
+                label = "Confirm",
+                signalPayload = JsonPrimitive("ok"),
+            ),
+        ),
+        confidence = Confidence.HIGH,
+        provenance = baseProvenance,
+        dedupKey = null,
+        producedAt = Instant.fromEpochMilliseconds(1_700_000_000_000),
+    )
+
+    @Test
+    fun `Prose payload round-trips`() {
+        val original = emission(
+            payload = EmissionPayload.Prose(text = "hello", format = ProseFormat.MARKDOWN),
+            kind = EmissionKind.Prose,
+        )
+
+        val encoded = json.encodeToString(Emission.serializer(), original)
+        val decoded = json.decodeFromString(Emission.serializer(), encoded)
+
+        assertEquals(original, decoded)
+        assertTrue(encoded.contains("\"type\":\"EmissionPayload.Prose\""))
+        assertTrue(encoded.contains("\"type\":\"EmissionKind.Prose\""))
+    }
+
+    @Test
+    fun `Decision payload round-trips`() {
+        val original = emission(
+            payload = EmissionPayload.Decision(prompt = "Which?", context = "background"),
+            kind = EmissionKind.Decision,
+        )
+
+        val encoded = json.encodeToString(Emission.serializer(), original)
+        val decoded = json.decodeFromString(Emission.serializer(), encoded)
+
+        assertEquals(original, decoded)
+        assertTrue(encoded.contains("\"type\":\"EmissionPayload.Decision\""))
+        assertTrue(encoded.contains("\"type\":\"EmissionKind.Decision\""))
+    }
+
+    @Test
+    fun `Confirmation payload round-trips`() {
+        val original = emission(
+            payload = EmissionPayload.Confirmation(
+                action = "delete branch",
+                preview = "deleting refs/heads/feature/x",
+                dangerLevel = DangerLevel.HIGH,
+            ),
+            kind = EmissionKind.Confirmation,
+        )
+
+        val encoded = json.encodeToString(Emission.serializer(), original)
+        val decoded = json.decodeFromString(Emission.serializer(), encoded)
+
+        assertEquals(original, decoded)
+        assertTrue(encoded.contains("\"type\":\"EmissionPayload.Confirmation\""))
+        assertTrue(encoded.contains("\"type\":\"EmissionKind.Confirmation\""))
+    }
+
+    @Test
+    fun `Sensor payload round-trips`() {
+        val original = emission(
+            payload = EmissionPayload.Sensor(
+                label = "queue depth",
+                value = "42",
+                unit = "items",
+                refreshUri = "/q/depth",
+            ),
+            kind = EmissionKind.Sensor,
+        )
+
+        val encoded = json.encodeToString(Emission.serializer(), original)
+        val decoded = json.decodeFromString(Emission.serializer(), encoded)
+
+        assertEquals(original, decoded)
+        assertTrue(encoded.contains("\"type\":\"EmissionPayload.Sensor\""))
+        assertTrue(encoded.contains("\"type\":\"EmissionKind.Sensor\""))
+    }
+
+    @Test
+    fun `provenance fields survive round-trip`() {
+        val original = emission(
+            payload = EmissionPayload.Prose(text = "x", format = ProseFormat.PLAIN),
+            kind = EmissionKind.Prose,
+        )
+
+        val encoded = json.encodeToString(Emission.serializer(), original)
+        val decoded = json.decodeFromString(Emission.serializer(), encoded)
+
+        assertEquals(baseProvenance, decoded.provenance)
+        assertEquals("run-1", decoded.provenance.runId)
+        assertEquals("plugin-x", decoded.provenance.pluginId)
+        assertEquals("abcdef0123456789", decoded.provenance.inputDigest)
+    }
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/event/EmissionEventTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/event/EmissionEventTest.kt
@@ -1,0 +1,226 @@
+package link.socket.ampere.agents.domain.event
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import kotlinx.datetime.Instant
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import link.socket.ampere.agents.domain.Urgency
+import link.socket.ampere.agents.domain.emission.Affordance
+import link.socket.ampere.agents.domain.emission.DangerLevel
+import link.socket.ampere.agents.domain.emission.Emission
+import link.socket.ampere.agents.domain.emission.EmissionKind
+import link.socket.ampere.agents.domain.emission.EmissionPayload
+import link.socket.ampere.agents.domain.emission.EmissionProvenance
+import link.socket.ampere.agents.domain.reasoning.Confidence
+import link.socket.ampere.agents.events.bus.EventSerialBus
+import link.socket.ampere.agents.events.bus.subscribe
+import link.socket.ampere.agents.events.subscription.EventSubscription
+
+class EmissionEventTest {
+
+    private val json = Json {
+        prettyPrint = false
+        encodeDefaults = true
+        classDiscriminator = "type"
+        ignoreUnknownKeys = true
+    }
+
+    private val now = Instant.fromEpochMilliseconds(1_700_000_000_000)
+    private val provenance = EmissionProvenance(
+        runId = "run-1",
+        workflowId = "wf-1",
+        sourceEventId = "src-1",
+        toolInvocationId = null,
+        pluginId = "plugin-x",
+        modelId = "claude-sonnet-4-0",
+        inputDigest = "deadbeefdeadbeef",
+    )
+
+    private fun confirmationEmission() = Emission(
+        id = "em-1",
+        kind = EmissionKind.Confirmation,
+        payload = EmissionPayload.Confirmation(
+            action = "delete branch",
+            preview = "feature/x",
+            dangerLevel = DangerLevel.HIGH,
+        ),
+        affordances = listOf(
+            Affordance("aff-yes", "Yes", JsonPrimitive("yes")),
+            Affordance("aff-no", "No", JsonPrimitive("no")),
+        ),
+        confidence = Confidence.MEDIUM,
+        provenance = provenance,
+        dedupKey = "abcdef0123456789",
+        producedAt = now,
+    )
+
+    @Test
+    fun `Produced exposes the expected EVENT_TYPE`() {
+        val event = EmissionEvent.Produced(
+            eventId = "evt-1",
+            timestamp = now,
+            eventSource = EventSource.Agent("agent-1"),
+            emission = confirmationEmission(),
+        )
+        assertEquals("EmissionProduced", event.eventType)
+        assertEquals("em-1", event.emissionId)
+    }
+
+    @Test
+    fun `Resolved exposes the expected EVENT_TYPE`() {
+        val event = EmissionEvent.Resolved(
+            eventId = "evt-2",
+            timestamp = now,
+            eventSource = EventSource.Human,
+            emissionId = "em-1",
+            affordanceId = "aff-yes",
+            replyContext = JsonPrimitive("yes"),
+        )
+        assertEquals("EmissionResolved", event.eventType)
+        assertEquals("em-1", event.emissionId)
+        assertEquals("aff-yes", event.affordanceId)
+    }
+
+    @Test
+    fun `EventRegistry includes both EmissionEvent types`() {
+        assertTrue(EmissionEvent.Produced.EVENT_TYPE in EventRegistry.allEventTypes)
+        assertTrue(EmissionEvent.Resolved.EVENT_TYPE in EventRegistry.allEventTypes)
+    }
+
+    @Test
+    fun `Produced summary mentions the kind and id`() {
+        val event = EmissionEvent.Produced(
+            eventId = "evt-1",
+            timestamp = now,
+            eventSource = EventSource.Agent("agent-1"),
+            emission = confirmationEmission(),
+        )
+        val summary = event.getSummary(
+            formatUrgency = { "[${it.name}]" },
+            formatSource = { (it as? EventSource.Agent)?.agentId ?: "human" },
+        )
+        assertTrue(summary.contains("Confirmation"))
+        assertTrue(summary.contains("em-1"))
+        assertTrue(summary.contains("agent-1"))
+    }
+
+    @Test
+    fun `Resolved summary mentions both ids`() {
+        val event = EmissionEvent.Resolved(
+            eventId = "evt-2",
+            timestamp = now,
+            eventSource = EventSource.Human,
+            emissionId = "em-1",
+            affordanceId = "aff-yes",
+        )
+        val summary = event.getSummary(
+            formatUrgency = { "[${it.name}]" },
+            formatSource = { "human" },
+        )
+        assertTrue(summary.contains("em-1"))
+        assertTrue(summary.contains("aff-yes"))
+    }
+
+    @Test
+    fun `Produced round-trips through JSON preserving nested Emission`() {
+        val event = EmissionEvent.Produced(
+            eventId = "evt-1",
+            timestamp = now,
+            eventSource = EventSource.Agent("agent-1"),
+            urgency = Urgency.HIGH,
+            emission = confirmationEmission(),
+        )
+
+        val encoded = json.encodeToString(EmissionEvent.serializer(), event)
+        val decoded = json.decodeFromString(EmissionEvent.serializer(), encoded)
+
+        val produced = decoded as EmissionEvent.Produced
+        assertEquals(event.eventId, produced.eventId)
+        assertEquals(event.emission, produced.emission)
+        assertEquals(Urgency.HIGH, produced.urgency)
+        assertTrue(encoded.contains("\"type\":\"EmissionEvent.Produced\""))
+    }
+
+    @Test
+    fun `Resolved round-trips through JSON`() {
+        val event = EmissionEvent.Resolved(
+            eventId = "evt-2",
+            timestamp = now,
+            eventSource = EventSource.Human,
+            emissionId = "em-1",
+            affordanceId = "aff-yes",
+            replyContext = JsonPrimitive("yes"),
+        )
+
+        val encoded = json.encodeToString(EmissionEvent.serializer(), event)
+        val decoded = json.decodeFromString(EmissionEvent.serializer(), encoded)
+
+        val resolved = decoded as EmissionEvent.Resolved
+        assertEquals(event, resolved)
+        assertTrue(encoded.contains("\"type\":\"EmissionEvent.Resolved\""))
+    }
+
+    @Test
+    fun `bus delivers Produced to a subscribed handler`() = runTest {
+        coroutineScope {
+            val bus = EventSerialBus(scope = this)
+            val received = CompletableDeferred<EmissionEvent.Produced>()
+
+            bus.subscribe<EmissionEvent.Produced, EventSubscription.ByEventClassType>(
+                agentId = "renderer-stub",
+                eventType = EmissionEvent.Produced.EVENT_TYPE,
+            ) { event, _ ->
+                if (!received.isCompleted) received.complete(event)
+            }
+
+            val event = EmissionEvent.Produced(
+                eventId = "evt-1",
+                timestamp = now,
+                eventSource = EventSource.Agent("agent-1"),
+                emission = confirmationEmission(),
+            )
+            bus.publish(event)
+
+            val seen = withTimeout(5.seconds) { received.await() }
+            assertNotNull(seen)
+            assertEquals(event.eventId, seen.eventId)
+            assertEquals("em-1", seen.emission.id)
+        }
+    }
+
+    @Test
+    fun `bus delivers Resolved to a subscribed handler`() = runTest {
+        coroutineScope {
+            val bus = EventSerialBus(scope = this)
+            val received = CompletableDeferred<EmissionEvent.Resolved>()
+
+            bus.subscribe<EmissionEvent.Resolved, EventSubscription.ByEventClassType>(
+                agentId = "originator",
+                eventType = EmissionEvent.Resolved.EVENT_TYPE,
+            ) { event, _ ->
+                if (!received.isCompleted) received.complete(event)
+            }
+
+            val event = EmissionEvent.Resolved(
+                eventId = "evt-2",
+                timestamp = now,
+                eventSource = EventSource.Human,
+                emissionId = "em-1",
+                affordanceId = "aff-yes",
+                replyContext = JsonPrimitive("yes"),
+            )
+            bus.publish(event)
+
+            val seen = withTimeout(5.seconds) { received.await() }
+            assertEquals("aff-yes", seen.affordanceId)
+        }
+    }
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/reasoning/ConfidenceParsingTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/reasoning/ConfidenceParsingTest.kt
@@ -1,0 +1,58 @@
+package link.socket.ampere.agents.domain.reasoning
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ConfidenceParsingTest {
+
+    @Test
+    fun `parseOrNull recognises lowercase tokens`() {
+        assertEquals(Confidence.LOW, Confidence.parseOrNull("low"))
+        assertEquals(Confidence.MEDIUM, Confidence.parseOrNull("medium"))
+        assertEquals(Confidence.HIGH, Confidence.parseOrNull("high"))
+    }
+
+    @Test
+    fun `parseOrNull is case-insensitive`() {
+        assertEquals(Confidence.HIGH, Confidence.parseOrNull("HIGH"))
+        assertEquals(Confidence.HIGH, Confidence.parseOrNull("High"))
+        assertEquals(Confidence.MEDIUM, Confidence.parseOrNull("MEDIUM"))
+        assertEquals(Confidence.LOW, Confidence.parseOrNull("Low"))
+    }
+
+    @Test
+    fun `parseOrNull trims whitespace`() {
+        assertEquals(Confidence.HIGH, Confidence.parseOrNull("  high  "))
+        assertEquals(Confidence.LOW, Confidence.parseOrNull("\tlow\n"))
+    }
+
+    @Test
+    fun `parseOrNull returns null for unknown tokens`() {
+        assertNull(Confidence.parseOrNull("unknown"))
+        assertNull(Confidence.parseOrNull(""))
+        assertNull(Confidence.parseOrNull("very-high"))
+    }
+
+    @Test
+    fun `parseOrDefault returns MEDIUM for null`() {
+        assertEquals(Confidence.MEDIUM, Confidence.parseOrDefault(null))
+    }
+
+    @Test
+    fun `parseOrDefault returns MEDIUM for unknown strings`() {
+        assertEquals(Confidence.MEDIUM, Confidence.parseOrDefault("nonsense"))
+    }
+
+    @Test
+    fun `parseOrDefault honours an explicit default`() {
+        assertEquals(Confidence.HIGH, Confidence.parseOrDefault(null, default = Confidence.HIGH))
+        assertEquals(Confidence.LOW, Confidence.parseOrDefault("nonsense", default = Confidence.LOW))
+    }
+
+    @Test
+    fun `parseOrDefault still parses known values`() {
+        assertEquals(Confidence.HIGH, Confidence.parseOrDefault("high"))
+        assertEquals(Confidence.LOW, Confidence.parseOrDefault("low", default = Confidence.HIGH))
+    }
+}

--- a/docs/concepts/_index.md
+++ b/docs/concepts/_index.md
@@ -41,5 +41,7 @@ How the cognitive substrate meets the user, the platform, and the plugin ecosyst
 |---------|--------|------------------|
 | [AgentSurface](agent-surface.md) | stable | Typed, serializable UI render request (Form, Choice, Confirmation, Card). Plugins emit; platform renderers translate. No platform types in the contract. |
 | [ChiProtocol](chi.md) | experimental | Computer-Human Interface: the inverse of HCI. Runtime protocol for computer-initiated human contact. Four uncoordinated paths today; target collapse onto `EmissionKind.Decision`. |
+| [Emission](emission.md) | experimental | The unifying CHI primitive. Typed domain object + `EmissionEvent` family on the bus. Four kinds (Prose, Decision, Confirmation, Sensor). AMPERE owns the noun; Socket owns rendering. |
+| [EmissionDedup](emission-dedup.md) | experimental | Content-based dedup via `dedupKey` (SHA-256, 16 hex chars). Optional and never overloaded onto `EmissionId`. Window length is a consumer-side policy. |
 | [PluginPermissions](plugin-permissions.md) | stable | Deterministic gate that runs *before* any plugin tool dispatch. Compares manifest + tool-requested permissions against user grants. |
 | [Ampere](ampere.md) | stable | The meta-concept: what makes a framework an AMPERE framework. Glass brain, AniMA agents, electrical metaphor, event-first coordination. |

--- a/docs/concepts/emission-dedup.md
+++ b/docs/concepts/emission-dedup.md
@@ -1,0 +1,62 @@
+---
+concept: EmissionDedup
+status: experimental
+tracked_sources:
+  - ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/emission/EmissionDigest.kt
+  - ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/emission/Emission.kt
+related: [Emission, ChiProtocol]
+last_verified: 2026-05-27
+---
+
+# EmissionDedup
+
+## What it is
+
+Emission deduplication is content-based: each [Emission](emission.md) may
+carry an optional `dedupKey` derived from its payload via `inputDigest`
+(SHA-256 over canonical JSON, truncated to 16 hex chars). Two Emissions
+with the same `dedupKey` represent the same content; the *window* over
+which they should collapse into a single rendered moment is a
+consumer-side policy.
+
+## Why it exists
+
+The dedup contract sits next to `EmissionId` because the two answer
+different questions. `EmissionId` is identity ("is this the same
+record?"); `dedupKey` is content equivalence ("is this saying the same
+thing?"). Conflating the two — for example, by reusing a stable id in
+place of generating a random one — would make every replay or retry of
+the same Emission collide with its predecessor and lose audit trail.
+
+Effect-bearing kinds need dedup. A `Confirmation` raised twice in
+quick succession for the same action is noise that the human shouldn't
+see twice. Observation kinds (`Prose`, `Sensor`) often don't: two
+identical sensor readings a minute apart may legitimately want to
+render twice.
+
+## Where it lives
+
+- `agents/domain/emission/EmissionDigest.kt` — `inputDigest(payload: EmissionPayload): String`. SHA-256 over the canonical JSON serialization, hex, first 16 chars.
+- `agents/domain/emission/Emission.kt` — the `dedupKey: String?` field on `Emission` and the `Emission.computeDedupKey()` convenience extension.
+
+## Invariants
+
+- **Content-based, not identity-based.** `dedupKey` is a hash of `EmissionPayload`, never of `EmissionId`.
+- **Optional.** `null` means "this Emission is unique and should always render". The constructor does not auto-populate `dedupKey`; callers decide.
+- **Stable across runs.** The same payload always hashes to the same digest. Canonical JSON serialization is enforced inside `EmissionDigest.kt` — callers must not pass a custom `Json` instance.
+- **Effect-bearing kinds carry one.** `EmissionKind.Confirmation` (and any future `Action`) should always include a `dedupKey`. `computeDedupKey()` does this by default.
+- **The dedup *window* is not part of the protocol.** AMPERE only publishes the key. How long two equal-keyed Emissions are considered duplicates is a Socket-side policy.
+
+## Common operations
+
+- **Compute the default key** — `emission.computeDedupKey()` returns `inputDigest(payload)` for effect-bearing kinds, `null` otherwise.
+- **Compute manually** — `inputDigest(payload)` exposes the hash directly when the caller wants to combine it with other fields.
+- **Compare two Emissions for content equality** — `a.dedupKey != null && a.dedupKey == b.dedupKey`. If either is null, treat as distinct.
+
+## Anti-patterns
+
+- **Using `EmissionId` as a dedup key.** `EmissionId` is a random UUID; equality collapses to "is this literally the same record", not "is this saying the same thing".
+- **Embedding random nonces in payload.** A timestamp, a `Random().nextInt()`, or a `Clock.now()` inside the payload defeats content determinism — every Emission becomes its own dedup class.
+- **Picking a custom `Json` configuration for digesting.** The hash is only stable because the configuration is shared. A caller-supplied `Json { encodeDefaults = false }` would silently re-key every previously-stored Emission.
+- **Treating `dedupKey == null` as "render once" rather than "render always".** A null key is a positive statement: "do not dedup this". Consumers that collapse nulls together will swallow distinct observations.
+- **Implementing the dedup *window* inside AMPERE.** Window length is a UX policy. It belongs in the consumer, alongside surface arbitration.

--- a/docs/concepts/emission.md
+++ b/docs/concepts/emission.md
@@ -1,0 +1,91 @@
+---
+concept: Emission
+status: experimental
+tracked_sources:
+  - ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/emission/Emission.kt
+  - ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/emission/EmissionKind.kt
+  - ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/emission/EmissionPayload.kt
+  - ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/emission/Affordance.kt
+  - ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/emission/EmissionProvenance.kt
+  - ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/EmissionEvent.kt
+related: [ChiProtocol, EventSerialBus, AgentSurface, PropelLoop, EmissionDedup]
+last_verified: 2026-05-27
+---
+
+# Emission
+
+## What it is
+
+An `Emission` is one moment of computer-initiated human contact — the
+typed unit of CHI (see [ChiProtocol](chi.md)). Each Emission carries a
+`kind` (`Prose`, `Decision`, `Confirmation`, `Sensor`), a typed `payload`,
+optional `affordances`, an optional `Confidence`, full `provenance`, an
+optional content-deterministic `dedupKey`, and a `producedAt` timestamp.
+Emissions ride the `EventSerialBus` inside the `EmissionEvent` family
+(`Produced` when AMPERE surfaces one, `Resolved` when an affordance
+reply arrives).
+
+## Why it exists
+
+Four uncoordinated mechanisms each implement a slice of CHI today —
+`ToolAskHuman`, `MessageEvent.EscalationRequested`, `AgentPause`, and
+`HumanInteractionEvent`. Each one has its own correlation pattern, its
+own lifecycle, and its own renderer. The result is that "the moment the
+computer needs the human" is not a single thing the system can reason
+about — it's four overlapping things.
+
+Emission is the unifying primitive. AMPERE defines the noun (this
+domain object) and the verb (`EmissionEvent`). A consumer such as Socket
+defines the adjective and adverb — surface arbitration, rendering,
+affordance interaction, push delivery. Splitting the protocol this way
+preserves AMPERE's substrate-free positioning: any consumer can adopt
+the protocol; AMPERE has no knowledge of `Surface`,
+`EmissionRendererRegistry`, or platform UI types.
+
+Three design pressures shape the Wave 0 cut:
+
+1. **One event type with a `kind` field beats per-kind event types.**
+   `EventSerialBus` subscribes by exact `EventType`. At expected volumes
+   a single `EmissionEvent.Produced` carrying an `EmissionKind` tag is
+   the simpler interface for consumers.
+2. **Dedup must not be overloaded onto `EmissionId`.** AMPERE ids are
+   random UUIDs; dedup is content-deterministic and lives in
+   `dedupKey`. See the [EmissionDedup](emission-dedup.md) cell.
+3. **Provenance is a first-class field, not metadata.** Every Emission
+   must be attributable to the `runId`, `workflowId`, source event,
+   tool invocation, plugin, and model that produced it.
+
+## Where it lives
+
+- `agents/domain/emission/Emission.kt` — the data class and `computeDedupKey` extension.
+- `agents/domain/emission/EmissionKind.kt` — the four core kinds as sealed `data object`s.
+- `agents/domain/emission/EmissionPayload.kt` — sealed payload variants (one per kind).
+- `agents/domain/emission/Affordance.kt` — response options attached to an Emission.
+- `agents/domain/emission/EmissionProvenance.kt` — the provenance schema.
+- `agents/domain/emission/EmissionDigest.kt` — `inputDigest(payload)` helper.
+- `agents/domain/emission/EmissionIds.kt` — `EmissionId` and `AffordanceId` typealiases.
+- `agents/domain/event/EmissionEvent.kt` — `Produced` and `Resolved` bus events.
+
+## Invariants
+
+- **Immutable once published.** Treat `dedupKey`, `provenance`, and `id` as fixed at construction time. Subscribers may copy, never mutate.
+- **Dedup is content-based, never identity-based.** `dedupKey` is the dedup signal. `EmissionId` is a random UUID — using it as a dedup key is a category error.
+- **Every Emission carries provenance.** `EmissionProvenance` is non-nullable on the data class. An Emission without `inputDigest` cannot exist.
+- **`EmissionEvent.Resolved` references the originating Emission by id and the chosen affordance by id.** Both ids are stable for the lifetime of the Emission.
+- **`@SerialName`s are wire format.** Every sealed variant carries a stable `@SerialName`. Renames are a wire-format change that must be co-ordinated with consumers.
+- **No platform types in this package.** Emissions live in `commonMain`; rendering, surface arbitration, and push delivery are Socket-side concerns.
+
+## Common operations
+
+- **Produce an Emission** — construct an `Emission`, call `computeDedupKey()` for effect-bearing kinds, then `bus.publish(EmissionEvent.Produced(...))`.
+- **Render or log on the consumer side** — subscribe to `EmissionEvent.Produced.EVENT_TYPE` on the `EventSerialBus`.
+- **Resolve an affordance** — when a human selects an affordance, publish `EmissionEvent.Resolved(emissionId, affordanceId, replyContext)`. The `replyContext` carries the affordance's `signalPayload` opaquely back to the originator.
+- **Compute the content digest manually** — `inputDigest(payload)` returns the 16-char hex SHA-256 used by both `EmissionProvenance.inputDigest` and `dedupKey`.
+
+## Anti-patterns
+
+- **Mutating an Emission after publishing.** Subscribers may have copies; later changes won't propagate, but bus replay will surface the originals.
+- **Deriving `dedupKey` from `EmissionId`.** Two semantically identical Emissions get different random ids; dedup must look at content.
+- **Treating Emissions as request/response RPC.** Emissions are observation events — `Produced` is one-way. The reply, if any, is a separate `Resolved` event. Anything resembling `awaitEmission(...)` belongs in a consumer.
+- **Embedding rendering decisions in payload** (font, colour, layout). Surface is a Socket concept; `EmissionPayload` describes *what*, never *how*.
+- **Skipping provenance because "this one is trivial".** Provenance is what makes Emissions auditable — the lazy case is the one that bites first in a trace review.


### PR DESCRIPTION
Closes #508 (Linear AMPR-180).

## Summary

I introduce the Emission domain object and `EmissionEvent` family in `commonMain`, with four core kinds (`Prose`, `Decision`, `Confirmation`, `Sensor`), the shared `Confidence` enum migrated through `PerceptionEvaluator`/`OutcomeEvaluator`, a content-deterministic dedup key via `inputDigest` (SHA-256/16 hex) kept separate from random `EmissionId`s, full `EmissionProvenance`, and stable `@SerialName`s. `EmissionEvent.{Produced,Resolved}` are registered on `EventRegistry` and categorized in `SignificanceAwareEventLogger`; the `emission` and `emission-dedup` concept cells (plus the `_index` entry) document the CHI primitive.

## Test plan

- [x] \`./gradlew :ampere-core:jvmTest\` — 33 new tests pass (serialization round-trip per payload variant, bus delivery, registry membership, digest determinism, Confidence parsing)
- [x] \`./gradlew :ampere-core:ktlintFormat\` clean
- [x] \`./gradlew :ampere-core:compileCommonMainKotlinMetadata\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)