### PR TITLE
AMPR-170 #499: wire AMPR-169 bridge into CLI, add --headless flag

### DIFF
--- a/ampere-cli/README.md
+++ b/ampere-cli/README.md
@@ -83,8 +83,28 @@ ampere --auto-work         # Start with background issue work
 
 The TUI shows:
 - **Left pane (35%)**: Event stream (filtered by significance)
-- **Middle pane (40%)**: Cognitive cycle progress / system vitals
+- **Middle pane (40%)**: Cognitive cycle progress / system vitals (Phosphor waveform; atmosphere shifts with the active PROPEL phase)
 - **Right pane (25%)**: Agent memory stats (or logs in verbose mode)
+
+The cognitive scene is driven by an [AMPERE Phosphor bridge](../ampere-phosphor/README.md) that subscribes to the agent's `EventSerialBus`: every PROPEL `PhaseEntered` event re-targets the Lumos atmosphere, `EscalationFired` snaps to `UNCERTAIN`, and `TaskCompleted` / `TaskFailed` / `ToolExecutionCompleted` / `MilestoneReached` queue glyph cues on the runtime.
+
+**Terminal requirements:** the TUI needs at least **40 columns × 15 rows** and a connected TTY. If either condition is missing, the CLI auto-falls-back to headless mode with a one-line notice on stderr.
+
+### Headless mode
+
+Use `--headless` to disable the dashboard and stream plain-text event lines to stdout — useful in CI, log pipes, or environments without a usable terminal:
+
+```bash
+ampere --goal "Implement FizzBuzz" --headless
+ampere --issue 42 --headless
+ampere --headless | tee run.log
+```
+
+Auto-detection enables headless mode in the same conditions:
+- `stdout` is not a TTY (e.g. the output is piped or redirected).
+- The terminal is smaller than 40×15.
+
+In headless mode `ampere` exits after synchronous one-shot work (`--issue N`, `--use-arc-phases`); other modes stay resident streaming events until you `Ctrl+C`.
 
 **Keyboard controls:**
 - `d` - Dashboard mode (system vitals, agent status)

--- a/ampere-cli/build.gradle.kts
+++ b/ampere-cli/build.gradle.kts
@@ -84,7 +84,8 @@ kotlin {
         val jvmMain by getting {
             dependencies {
                 implementation(project(":ampere-core"))
-                implementation("link.socket:phosphor-core:0.4.0")
+                implementation(project(":ampere-phosphor"))
+                implementation("link.socket:phosphor-core:0.5.0")
 
                 // CLI argument parsing
                 implementation("com.github.ajalt.clikt:clikt:4.4.0")

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/AmpereCommand.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/AmpereCommand.kt
@@ -30,6 +30,15 @@ import link.socket.ampere.cli.layout.RichEventPane
 import link.socket.ampere.cli.layout.StatusBar
 import link.socket.ampere.cli.layout.TaskChecklistPane
 import link.socket.ampere.cli.hybrid.HybridDashboardRenderer
+import link.socket.ampere.cli.launch.HeadlessReason
+import link.socket.ampere.cli.launch.TuiDecision
+import link.socket.ampere.cli.launch.decideTuiUsage
+import link.socket.ampere.cli.launch.userMessage
+import link.socket.ampere.cli.render.LumosBridgeController
+import link.socket.ampere.agents.events.api.EventHandler
+import link.socket.ampere.agents.events.subscription.Subscription
+import link.socket.ampere.agents.domain.event.Event
+import kotlinx.coroutines.CompletableDeferred
 import link.socket.ampere.cli.watch.CommandExecutor
 import link.socket.ampere.cli.watch.CommandResult
 import link.socket.ampere.cli.watch.presentation.EventSignificance
@@ -129,6 +138,11 @@ class AmpereCommand(
         help = "Execute goal using Arc phases (Charge -> Flow -> Pulse) instead of direct agent execution"
     ).flag(default = false)
 
+    private val headless: Boolean by option(
+        "--headless",
+        help = "Disable the Lumos TUI dashboard and stream plain-text agent events to stdout (auto-enabled when stdout is not a TTY or the terminal is too small)"
+    ).flag(default = false)
+
     override fun run() = runBlocking {
         // Handle --list-arcs flag (non-TUI, prints and exits)
         if (listArcs) {
@@ -174,12 +188,32 @@ class AmpereCommand(
 
         val context = contextProvider()
         val agentScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+        val tuiDecision = decideTuiUsage(
+            userRequestedHeadless = headless,
+            capabilities = TerminalFactory.getCapabilities(),
+        )
+        if (tuiDecision.useHeadless) {
+            runHeadless(
+                context = context,
+                agentScope = agentScope,
+                selectedArc = selectedArc,
+                hasActiveWork = hasActiveWork,
+                decision = tuiDecision,
+            )
+            return@runBlocking
+        }
+
         val terminal = TerminalFactory.createTerminal()
         val presenter = WatchPresenter(context.eventRelayService)
         val workspaceStateStore = context.environmentService.workspaceStateStore
 
         // Create TUI components
         val hybridRenderer = HybridDashboardRenderer(terminal).also { it.initialize() }
+        val lumosBridgeController = LumosBridgeController(
+            bus = context.environmentService.eventBus,
+            sceneProvider = { hybridRenderer.waveformPane?.runtimeAdapter?.scene },
+        )
         val eventPane = RichEventPane(terminal)
         val jazzPane = CognitiveProgressPane(terminal)
         val memoryPane = AgentMemoryPane(terminal)
@@ -447,6 +481,11 @@ class AmpereCommand(
                         )
                     }
 
+                    // Bridge AMPERE bus → Phosphor atmosphere/glyphs. Lazy-starts once
+                    // the waveform pane has built its CognitiveSceneRuntime; subsequent
+                    // ticks flush coalesced atmosphere targets.
+                    lumosBridgeController.tick()
+
                     // Write every frame (animation state changes even when pane content doesn't)
                     val out = LogCapture.getOriginalOut() ?: System.out
                     out.print(output)
@@ -470,6 +509,7 @@ class AmpereCommand(
             out.flush()
             throw e
         } finally {
+            lumosBridgeController.stop()
             LogCapture.stop()
             presenter.stop()
             inputHandler.close()
@@ -633,6 +673,158 @@ class AmpereCommand(
                 jazzPane.setFailed("Arc execution failed: ${e.message}")
                 updateStatus(StatusBar.SystemStatus.ATTENTION_NEEDED)
             }
+        }
+    }
+
+    /**
+     * Run AMPERE without the Lumos TUI dashboard.
+     *
+     * Streams every event from the bus as a single text line so the run is
+     * usable in CI, pipes, and minimal terminals. Blocks until the user
+     * interrupts (Ctrl+C) — matching the TUI's stay-resident behavior.
+     */
+    private suspend fun runHeadless(
+        context: AmpereContext,
+        agentScope: CoroutineScope,
+        selectedArc: ArcConfig,
+        hasActiveWork: Boolean,
+        decision: TuiDecision,
+    ) {
+        val capabilities = TerminalFactory.getCapabilities()
+        val reason = decision.reason
+        if (reason != null && reason != HeadlessReason.USER_REQUESTED) {
+            System.err.println(reason.userMessage(capabilities))
+        }
+        println("AMPERE headless mode. Press Ctrl+C to exit.")
+
+        context.subscribeToAll(
+            agentId = HEADLESS_AGENT_ID,
+            handler = EventHandler<Event, Subscription> { event, _ ->
+                println(formatHeadlessEvent(event))
+            },
+        )
+
+        // Headless goal activation uses GoalHandler unchanged. The progress and
+        // memory panes only hold internal state when nothing renders them, so a
+        // dangling Terminal here is harmless — we never draw.
+        val unrenderedTerminal = TerminalFactory.createTerminal()
+        val noopProgressPane = CognitiveProgressPane(unrenderedTerminal)
+        val noopMemoryPane = AgentMemoryPane(unrenderedTerminal)
+
+        try {
+            if (autoWork) {
+                context.startAutonomousWork()
+            }
+
+            var isOneShot = false
+            when {
+                goal != null -> {
+                    val effectiveGoal = goal!!
+                    if (useArcPhases) {
+                        executeArcPhasesHeadless(effectiveGoal, selectedArc)
+                        isOneShot = true
+                    } else {
+                        val goalHandler = GoalHandler(
+                            context = context,
+                            agentScope = agentScope,
+                            progressPane = noopProgressPane,
+                            memoryPane = noopMemoryPane,
+                            aiConfiguration = context.aiConfiguration,
+                        )
+                        val result = goalHandler.activateGoal(effectiveGoal)
+                        if (result.isFailure) {
+                            System.err.println(
+                                "Goal activation failed: ${result.exceptionOrNull()?.message}"
+                            )
+                        }
+                    }
+                }
+                issues -> context.startAutonomousWork()
+                issue != null -> {
+                    val availableIssues = context.codeIssueWorkflow.queryAvailableIssues()
+                    val targetIssue = availableIssues.find { it.number == issue }
+                    if (targetIssue == null) {
+                        System.err.println("Issue #$issue not found or not available")
+                    } else {
+                        val issueResult = context.codeIssueWorkflow.workOnIssue(
+                            targetIssue,
+                            context.codeAgent,
+                        )
+                        if (issueResult.isFailure) {
+                            System.err.println("Failed: ${issueResult.exceptionOrNull()?.message}")
+                        }
+                    }
+                    isOneShot = true
+                }
+                else -> {
+                    val configGoal = context.userConfig?.goal
+                    if (configGoal != null) {
+                        val goalHandler = GoalHandler(
+                            context = context,
+                            agentScope = agentScope,
+                            progressPane = noopProgressPane,
+                            memoryPane = noopMemoryPane,
+                            aiConfiguration = context.aiConfiguration,
+                        )
+                        val result = goalHandler.activateGoal(configGoal)
+                        if (result.isFailure) {
+                            System.err.println(
+                                "Goal activation failed: ${result.exceptionOrNull()?.message}"
+                            )
+                        }
+                    }
+                }
+            }
+
+            // `--issue N` and `--use-arc-phases` are synchronous one-shots: exit
+            // after the work returns. All other modes stay resident so the user
+            // can keep observing the event stream (matches TUI behavior).
+            if (!isOneShot) {
+                CompletableDeferred<Unit>().await()
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            System.err.println("Error: ${e.message}")
+            throw e
+        } finally {
+            agentScope.cancel()
+            println("AMPERE stopped")
+        }
+    }
+
+    private suspend fun executeArcPhasesHeadless(goal: String, arcConfig: ArcConfig) {
+        val projectDirPath = File(System.getProperty("user.dir")).absolutePath
+        val runtime = AmpereRuntime.create(
+            arcConfig = arcConfig,
+            projectDirPath = projectDirPath,
+        )
+        val chargeResult = runtime.executeChargeOnly(goal)
+        println(
+            "Charge complete. Project: ${chargeResult.projectContext.projectId}, " +
+                "${chargeResult.agents.size} agents"
+        )
+        val result = runtime.execute(goal)
+        println(
+            "Pulse: ${result.pulseResult.evaluationReport.goalsCompleted}/" +
+                "${result.pulseResult.evaluationReport.goalsTotal} goals"
+        )
+        if (!result.success) {
+            System.err.println("Arc completed with failures")
+        }
+    }
+
+    companion object {
+        const val HEADLESS_AGENT_ID: String = "ampere-headless"
+
+        internal fun formatHeadlessEvent(event: Event): String {
+            val summary = runCatching {
+                event.getSummary(
+                    formatUrgency = { it.name },
+                    formatSource = { it.toString() },
+                )
+            }.getOrElse { event.eventType }
+            return "[${event.timestamp}] ${event.eventType}  $summary"
         }
     }
 }

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/launch/TuiAvailability.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/launch/TuiAvailability.kt
@@ -1,0 +1,56 @@
+package link.socket.ampere.cli.launch
+
+import link.socket.ampere.repl.TerminalFactory
+
+/**
+ * Decides whether the Lumos TUI dashboard is usable in the current environment,
+ * or whether the CLI should fall back to plain-text headless output.
+ *
+ * The TUI is the default experience. We only fall back when:
+ *   - The user explicitly asks for headless mode via `--headless`.
+ *   - stdout is not a TTY (e.g. CI, piped runs).
+ *   - The terminal is too small for the dashboard to be legible.
+ */
+data class TuiDecision(
+    val useHeadless: Boolean,
+    val reason: HeadlessReason?,
+) {
+    val useTui: Boolean get() = !useHeadless
+}
+
+enum class HeadlessReason {
+    USER_REQUESTED,
+    NON_TTY,
+    TERMINAL_TOO_SMALL,
+}
+
+const val MIN_TUI_WIDTH: Int = 40
+const val MIN_TUI_HEIGHT: Int = 15
+
+fun decideTuiUsage(
+    userRequestedHeadless: Boolean,
+    capabilities: TerminalFactory.TerminalCapabilities,
+    minWidth: Int = MIN_TUI_WIDTH,
+    minHeight: Int = MIN_TUI_HEIGHT,
+): TuiDecision = when {
+    userRequestedHeadless -> TuiDecision(true, HeadlessReason.USER_REQUESTED)
+    !capabilities.isInteractive -> TuiDecision(true, HeadlessReason.NON_TTY)
+    capabilities.width < minWidth || capabilities.height < minHeight ->
+        TuiDecision(true, HeadlessReason.TERMINAL_TOO_SMALL)
+    else -> TuiDecision(false, null)
+}
+
+fun HeadlessReason.userMessage(
+    capabilities: TerminalFactory.TerminalCapabilities,
+    minWidth: Int = MIN_TUI_WIDTH,
+    minHeight: Int = MIN_TUI_HEIGHT,
+): String = when (this) {
+    HeadlessReason.USER_REQUESTED ->
+        "Running in headless mode (--headless)."
+    HeadlessReason.NON_TTY ->
+        "stdout is not a TTY; falling back to headless mode."
+    HeadlessReason.TERMINAL_TOO_SMALL ->
+        "Terminal is too small for the Lumos TUI " +
+            "(${capabilities.width}x${capabilities.height}; need at least ${minWidth}x$minHeight); " +
+            "falling back to headless mode."
+}

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/render/CognitiveSceneRuntimeAdapter.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/render/CognitiveSceneRuntimeAdapter.kt
@@ -35,6 +35,9 @@ class CognitiveSceneRuntimeAdapter {
     val agents: AgentLayer?
         get() = runtime?.agents
 
+    val scene: CognitiveSceneRuntime?
+        get() = runtime
+
     fun update(
         width: Int,
         height: Int,

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/render/LumosBridgeController.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/render/LumosBridgeController.kt
@@ -1,0 +1,56 @@
+package link.socket.ampere.cli.render
+
+import link.socket.ampere.agents.events.bus.EventSerialBus
+import link.socket.ampere.phosphor.AmperePhosphorBridge
+import link.socket.phosphor.lumos.VoxelFrameBuilder
+import link.socket.phosphor.runtime.CognitiveSceneRuntime
+
+/**
+ * Owns the AMPR-169 [AmperePhosphorBridge] for the TUI's lifetime.
+ *
+ * The bridge needs a [CognitiveSceneRuntime] instance, which the dashboard
+ * builds lazily on the first render (dimensions are required). This controller
+ * lets the dashboard be constructed before that runtime exists: each [tick]
+ * polls [sceneProvider] until a runtime is available, then starts the bridge
+ * and forwards subsequent ticks to [AmperePhosphorBridge.onFrameTick].
+ *
+ * [stop] is idempotent so it is safe to call from a finally block even if the
+ * bridge never started (e.g. dashboard was disposed before its first render).
+ */
+class LumosBridgeController(
+    private val bus: EventSerialBus,
+    private val sceneProvider: () -> CognitiveSceneRuntime?,
+    private val voxelResolution: Int = DEFAULT_VOXEL_RESOLUTION,
+    private val bridgeFactory: (EventSerialBus, CognitiveSceneRuntime, VoxelFrameBuilder) -> AmperePhosphorBridge =
+        { b, r, vfb -> AmperePhosphorBridge(bus = b, runtime = r, voxelFrameBuilder = vfb) },
+) {
+    private var bridge: AmperePhosphorBridge? = null
+    private var voxelFrameBuilder: VoxelFrameBuilder? = null
+
+    val isStarted: Boolean
+        get() = bridge != null
+
+    suspend fun tick() {
+        val active = bridge ?: tryStart() ?: return
+        active.onFrameTick()
+    }
+
+    fun stop() {
+        bridge?.stop()
+        bridge = null
+        voxelFrameBuilder = null
+    }
+
+    private fun tryStart(): AmperePhosphorBridge? {
+        val runtime = sceneProvider() ?: return null
+        val vfb = VoxelFrameBuilder(initialResolution = voxelResolution)
+        val started = bridgeFactory(bus, runtime, vfb).also { it.start() }
+        voxelFrameBuilder = vfb
+        bridge = started
+        return started
+    }
+
+    companion object {
+        const val DEFAULT_VOXEL_RESOLUTION: Int = 16
+    }
+}

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/render/WaveformPaneRenderer.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/render/WaveformPaneRenderer.kt
@@ -24,7 +24,7 @@ import link.socket.phosphor.choreography.AgentLayer
  */
 class WaveformPaneRenderer(
     private val agentLayer: AgentLayer,
-    private val runtimeAdapter: CognitiveSceneRuntimeAdapter = CognitiveSceneRuntimeAdapter()
+    val runtimeAdapter: CognitiveSceneRuntimeAdapter = CognitiveSceneRuntimeAdapter()
 ) : PaneRenderer {
     private val lighting = SurfaceLighting()
     private val phaseBlender = PhaseBlender(influenceRadius = 8f)

--- a/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/AmpereCommandTest.kt
+++ b/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/AmpereCommandTest.kt
@@ -60,6 +60,15 @@ class AmpereCommandTest {
     }
 
     @Test
+    fun `help text shows headless flag`() {
+        val command = AmpereCommand { lazyContext() }
+        val result = command.test("--help")
+
+        assertContains(result.output, "--headless")
+        assertContains(result.output, "Disable the Lumos TUI dashboard")
+    }
+
+    @Test
     fun `list-arcs flag displays available arcs`() {
         val command = AmpereCommand { lazyContext() }
         val result = command.test("--list-arcs")

--- a/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/cli/launch/TuiAvailabilityTest.kt
+++ b/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/cli/launch/TuiAvailabilityTest.kt
@@ -1,0 +1,81 @@
+package link.socket.ampere.cli.launch
+
+import com.github.ajalt.mordant.rendering.AnsiLevel
+import link.socket.ampere.repl.TerminalFactory
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class TuiAvailabilityTest {
+
+    private fun caps(
+        width: Int = 120,
+        height: Int = 40,
+        isInteractive: Boolean = true,
+    ) = TerminalFactory.TerminalCapabilities(
+        supportsUnicode = true,
+        supportsColors = true,
+        colorLevel = AnsiLevel.TRUECOLOR,
+        isInteractive = isInteractive,
+        width = width,
+        height = height,
+    )
+
+    @Test
+    fun `interactive terminal at full size keeps the TUI on`() {
+        val decision = decideTuiUsage(userRequestedHeadless = false, capabilities = caps())
+        assertTrue(decision.useTui)
+        assertNull(decision.reason)
+    }
+
+    @Test
+    fun `user --headless flag overrides everything else`() {
+        val decision = decideTuiUsage(userRequestedHeadless = true, capabilities = caps())
+        assertTrue(decision.useHeadless)
+        assertEquals(HeadlessReason.USER_REQUESTED, decision.reason)
+    }
+
+    @Test
+    fun `non-TTY auto-falls-back to headless`() {
+        val decision = decideTuiUsage(
+            userRequestedHeadless = false,
+            capabilities = caps(isInteractive = false),
+        )
+        assertTrue(decision.useHeadless)
+        assertEquals(HeadlessReason.NON_TTY, decision.reason)
+    }
+
+    @Test
+    fun `terminal narrower than threshold falls back`() {
+        val decision = decideTuiUsage(
+            userRequestedHeadless = false,
+            capabilities = caps(width = MIN_TUI_WIDTH - 1),
+        )
+        assertTrue(decision.useHeadless)
+        assertEquals(HeadlessReason.TERMINAL_TOO_SMALL, decision.reason)
+    }
+
+    @Test
+    fun `terminal shorter than threshold falls back`() {
+        val decision = decideTuiUsage(
+            userRequestedHeadless = false,
+            capabilities = caps(height = MIN_TUI_HEIGHT - 1),
+        )
+        assertTrue(decision.useHeadless)
+        assertEquals(HeadlessReason.TERMINAL_TOO_SMALL, decision.reason)
+    }
+
+    @Test
+    fun `user-requested message reads as the default branch`() {
+        val message = HeadlessReason.USER_REQUESTED.userMessage(caps())
+        assertEquals("Running in headless mode (--headless).", message)
+    }
+
+    @Test
+    fun `too-small message includes actual and required dimensions`() {
+        val message = HeadlessReason.TERMINAL_TOO_SMALL.userMessage(caps(width = 20, height = 10))
+        assertTrue("20x10" in message, "actual size missing: $message")
+        assertTrue("${MIN_TUI_WIDTH}x$MIN_TUI_HEIGHT" in message, "threshold missing: $message")
+    }
+}

--- a/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/cli/render/LumosBridgeControllerTest.kt
+++ b/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/cli/render/LumosBridgeControllerTest.kt
@@ -1,0 +1,119 @@
+package link.socket.ampere.cli.render
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.datetime.Instant
+import link.socket.ampere.agents.domain.cognition.sparks.CognitivePhase
+import link.socket.ampere.agents.domain.event.CognitivePhaseEvent
+import link.socket.ampere.agents.domain.event.EventSource
+import link.socket.ampere.agents.events.bus.EventSerialBus
+import link.socket.phosphor.palette.AtmospherePresets
+import link.socket.phosphor.runtime.CognitiveSceneRuntime
+import link.socket.phosphor.runtime.SceneConfiguration
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class LumosBridgeControllerTest {
+
+    private val largeTickSeconds = 5.0f
+    private val maxTransitionTicks = 8
+
+    private fun newScene(): CognitiveSceneRuntime = CognitiveSceneRuntime(
+        SceneConfiguration(
+            width = 8,
+            height = 8,
+            enableWaveform = false,
+            enableParticles = false,
+            enableFlow = false,
+            enableEmitters = false,
+            enableCamera = false,
+            enableAtmosphere = true,
+            initialAtmosphere = AtmospherePresets.IDLE,
+        ),
+    )
+
+    @Test
+    fun `tick is a no-op when the scene provider returns null`() = runBlocking {
+        val scope = TestScope(UnconfinedTestDispatcher())
+        val bus = EventSerialBus(scope)
+        val controller = LumosBridgeController(bus = bus, sceneProvider = { null })
+
+        controller.tick()
+        assertFalse(controller.isStarted, "bridge must not start without a scene")
+    }
+
+    @Test
+    fun `tick lazy-starts the bridge once the scene becomes available`() = runBlocking {
+        val scope = TestScope(UnconfinedTestDispatcher())
+        val bus = EventSerialBus(scope)
+        var scene: CognitiveSceneRuntime? = null
+        val controller = LumosBridgeController(bus = bus, sceneProvider = { scene })
+
+        controller.tick()
+        assertFalse(controller.isStarted)
+
+        scene = newScene()
+        controller.tick()
+        assertTrue(controller.isStarted, "bridge must start once scene is available")
+    }
+
+    @Test
+    fun `phase event drives the runtime to the strategy's atmosphere`() = runBlocking {
+        val scope = TestScope(UnconfinedTestDispatcher())
+        val bus = EventSerialBus(scope)
+        val scene = newScene()
+        val controller = LumosBridgeController(bus = bus, sceneProvider = { scene })
+
+        controller.tick() // start the bridge
+        assertTrue(controller.isStarted)
+
+        bus.publish(phaseEntered(CognitivePhase.EXECUTE))
+        completeInFlightTransition(scene, controller)
+
+        assertEquals(AtmospherePresets.READY, scene.currentAtmosphere)
+    }
+
+    @Test
+    fun `stop is idempotent`() = runBlocking {
+        val scope = TestScope(UnconfinedTestDispatcher())
+        val bus = EventSerialBus(scope)
+        val controller = LumosBridgeController(bus = bus, sceneProvider = { newScene() })
+
+        controller.tick()
+        controller.stop()
+        controller.stop() // must not throw
+
+        assertFalse(controller.isStarted)
+    }
+
+    private suspend fun completeInFlightTransition(
+        scene: CognitiveSceneRuntime,
+        controller: LumosBridgeController,
+    ) {
+        repeat(maxTransitionTicks) {
+            val choreographer = scene.atmosphereChoreographer ?: return
+            if (choreographer.activeTransition == null) {
+                controller.tick()
+                return
+            }
+            scene.update(largeTickSeconds)
+        }
+        controller.tick()
+    }
+
+    private fun phaseEntered(phase: CognitivePhase): CognitivePhaseEvent.PhaseEntered =
+        CognitivePhaseEvent.PhaseEntered(
+            eventId = "evt-phase-${phase.name}",
+            timestamp = Instant.fromEpochSeconds(0),
+            eventSource = EventSource.Agent("agent-A"),
+            agentId = "agent-A",
+            oldPhase = null,
+            newPhase = phase,
+            nestingDepth = 0,
+        )
+}

--- a/ampere-phosphor/build.gradle.kts
+++ b/ampere-phosphor/build.gradle.kts
@@ -79,9 +79,9 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(project(":ampere-core"))
-                implementation("link.socket:phosphor-core:0.5.0")
-                implementation("link.socket:phosphor-lumos:0.5.0")
+                api(project(":ampere-core"))
+                api("link.socket:phosphor-core:0.5.0")
+                api("link.socket:phosphor-lumos:0.5.0")
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
             }
         }


### PR DESCRIPTION
## Summary

Authored by Claude (Opus 4.7) on Miley's direction. Implements AMPR-170 against the current `ampere-cli` architecture — the Lumos TUI is already the default, so the original ticket's opt-in `--with-lumos` flag is replaced by an inverse `--headless` flag with auto-fallback when stdout is not a TTY or the terminal is smaller than 40×15. Wires the AMPR-169 `:ampere-phosphor` bridge into the running `CognitiveSceneRuntime` via a new `LumosBridgeController` (lazy-starts once the scene exists, drives `onFrameTick` from the render loop, stops idempotently in `finally`), bumps `:ampere-cli` to `phosphor-core:0.5.0` to match `:ampere-phosphor`, and promotes `:ampere-phosphor`'s phosphor deps to `api` so consumers see the bridge's public types. Note: the bridge queues glyphs through `VoxelFrameBuilder`, but the existing waveform pane does not yet render `VoxelFrame.glyph` overlays — atmosphere transitions are fully wired; glyph visuals are a documented follow-up.

Closes #499

## Test plan

- [x] `./gradlew :ampere-cli:jvmTest :ampere-phosphor:jvmTest` (passes)
- [x] `./gradlew ktlintFormat` (clean)
- [ ] Manual: `./ampere-cli/ampere --goal "..."` and observe the waveform pane responds to PROPEL phase transitions
- [ ] Manual: `./ampere-cli/ampere --goal "..." --headless` and confirm plain-text event stream
- [ ] Manual: `./ampere-cli/ampere --goal "..." | tee log.txt` and confirm auto-fallback to headless with stderr notice

🤖 Generated with [Claude Code](https://claude.com/claude-code)