### PR TITLE
Release 0.7.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,4 +26,4 @@ sqldelight.version=2.2.1
 mosaic.version=0.18.0
 
 #Ampere
-ampereVersion=0.6.0
+ampereVersion=0.7.0


### PR DESCRIPTION
## Summary
I bumped `ampereVersion` from `0.6.0` to `0.7.0` in `gradle.properties` to cut the next minor release, following the recent 0.4.0 → 0.5.0 → 0.6.0 cadence. Once merged, tag `v0.7.0` on `main` and push to trigger the Maven Central publish workflow per `docs/RELEASING.md`.

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, tag `v0.7.0` and confirm the release workflow publishes to Maven Central