### PR TITLE
add ampere-phosphor to Maven Central publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,13 +76,13 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
         run: |
           export ORG_GRADLE_PROJECT_signingInMemoryKey="$(cat /tmp/signing-key.asc)"
-          ./gradlew :ampere-core:publishAllPublicationsToMavenCentralRepository
+          ./gradlew :ampere-core:publishAllPublicationsToMavenCentralRepository :ampere-phosphor:publishAllPublicationsToMavenCentralRepository
 
       - name: Dry run publish
         if: ${{ github.event.inputs.dry_run == 'true' }}
         run: |
           echo "Dry run mode - skipping actual publish"
-          ./gradlew :ampere-core:publishAllPublicationsToMavenCentralRepository --dry-run
+          ./gradlew :ampere-core:publishAllPublicationsToMavenCentralRepository :ampere-phosphor:publishAllPublicationsToMavenCentralRepository --dry-run
 
       - name: Create GitHub Release
         if: startsWith(github.ref, 'refs/tags/v') && github.event.inputs.dry_run != 'true'

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,4 +26,4 @@ sqldelight.version=2.2.1
 mosaic.version=0.18.0
 
 #Ampere
-ampereVersion=0.7.0
+ampereVersion=0.8.0


### PR DESCRIPTION
The `ampere-phosphor` module was added with full Maven publishing config in its `build.gradle.kts`, but was never included in the CI publish workflow. This adds `:ampere-phosphor:publishAllPublicationsToMavenCentralRepository` to both the real publish step and the dry-run step so it gets released alongside `ampere-core`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)