### PR TITLE
AMPR-182 #524: Remove EVALUATE→LEARN paveover after PHO-28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,13 +47,15 @@ The project is pre-1.0; breaking changes are acceptable and explicitly called ou
     persist `CognitivePhase` across runs today, so no data migration is
     required.
 
-- **CLI `AmperePhosphorBridge` removes the `LEARN → EVALUATE` paveover.**
-  The bridge now uses `PhosphorPhase.RECALL` for AMPERE's `RECALL`,
-  reuses the `PERCEIVE` height-pulse for `OBSERVE` (until Phosphor adds
-  an `OBSERVE` ramp of its own), and continues to map `LEARN` to
-  Phosphor's `EVALUATE` only as an interop bridge until Phosphor's enum
-  is renamed in a sibling ticket. The `LEARN → EVALUATE` mapping is now
-  documented as a known interop gap rather than a silent rename.
+- **CLI `AmperePhosphorBridge` removes the `LEARN → EVALUATE` paveover
+  ([AMPR-182](https://linear.app/miley/issue/AMPR-182)).**
+  Phosphor 0.6.2 ships with [PHO-28](https://linear.app/miley/issue/PHO-28),
+  adding `OBSERVE` and renaming `EVALUATE → LEARN` to align with the
+  canonical PROPEL phases. The bridge now maps directly:
+  `PERCEIVE → PERCEIVE`, `RECALL → RECALL`, `OBSERVE → OBSERVE`,
+  `PLAN → PLAN`, `EXECUTE → EXECUTE`, `LEARN → LEARN`.
+  The `CognitiveChoreographer`, `CognitivePalette`, and related rendering
+  surfaces updated to reference the canonical phases.
 
 ### Added
 
@@ -64,12 +66,8 @@ The project is pre-1.0; breaking changes are acceptable and explicitly called ou
 
 ### Notes
 
-- Phosphor's own `CognitivePhase` enum (in
-  `link.socket.phosphor.signal.CognitivePhase`) still uses
-  `PERCEIVE / RECALL / PLAN / EXECUTE / EVALUATE / LOOP / NONE` and is
-  out of scope for this change. A sibling Phosphor ticket should add
-  `OBSERVE` and rename `EVALUATE → LEARN` to bring Phosphor onto the
-  canonical PROPEL acronym.
+- Phosphor 0.6.2 ([PHO-28](https://linear.app/miley/issue/PHO-28)) now
+  aligns with canonical PROPEL phases: `PERCEIVE / RECALL / OBSERVE / PLAN / EXECUTE / LEARN / LOOP / NONE`.
 
 ## [0.6.0] — 2026-05
 

--- a/ampere-cli/build.gradle.kts
+++ b/ampere-cli/build.gradle.kts
@@ -85,7 +85,7 @@ kotlin {
             dependencies {
                 implementation(project(":ampere-core"))
                 implementation(project(":ampere-phosphor"))
-                implementation("link.socket:phosphor-core:0.5.0")
+                implementation("link.socket:phosphor-core:0.6.2")
 
                 // CLI argument parsing
                 implementation("com.github.ajalt.clikt:clikt:4.4.0")

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/animation/choreography/CognitiveChoreographer.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/animation/choreography/CognitiveChoreographer.kt
@@ -24,9 +24,10 @@ import kotlin.math.sin
  * Each PROPEL phase has a distinct visual signature:
  * - PERCEIVE: Particles drift inward from edges toward the agent (sensory gathering)
  * - RECALL: Existing particles near agent brighten and cluster (memory activation)
+ * - OBSERVE: Particles drift inward, similar to perceive (state monitoring)
  * - PLAN: Particles form tentative structures, testing arrangements (strategy formation)
  * - EXECUTE: Particles align and accelerate outward (discharge/committed action)
- * - EVALUATE: Particles slow, some fade, some persist as new anchors (reflection)
+ * - LEARN: Particles slow, some fade, some persist as new anchors (reflection)
  * - LOOP: Brief stillness, then subtle pulse (cycle reset)
  *
  * The choreographer observes phase transitions on agents and orchestrates particle
@@ -67,8 +68,8 @@ class CognitiveChoreographer(
         /** Radius for LOOP despawn area */
         private const val LOOP_DESPAWN_RADIUS = 3f
 
-        /** Radius for EVALUATE fade effect */
-        private const val EVALUATE_FADE_RADIUS = 10f
+        /** Radius for LEARN fade effect */
+        private const val LEARN_FADE_RADIUS = 10f
 
         /** Particle count per PERCEIVE stream direction */
         private const val PERCEIVE_PARTICLES_PER_DIR = 2
@@ -148,8 +149,8 @@ class CognitiveChoreographer(
             spawnSparkBurst(agent.position, TRANSITION_SPARK_COUNT)
         }
 
-        // EXECUTE → EVALUATE: Trail particles along the executed flow connection
-        if (from == CognitivePhase.EXECUTE && to == CognitivePhase.EVALUATE) {
+        // EXECUTE → LEARN: Trail particles along the executed flow connection
+        if (from == CognitivePhase.EXECUTE && to == CognitivePhase.LEARN) {
             spawnTrailFromAgent(agent.position)
         }
 
@@ -174,9 +175,10 @@ class CognitiveChoreographer(
         return when (phase) {
             CognitivePhase.PERCEIVE -> applyPerceive(agent, substrate, deltaTime)
             CognitivePhase.RECALL -> applyRecall(agent, substrate, deltaTime)
+            CognitivePhase.OBSERVE -> applyObserve(agent, substrate, deltaTime)
             CognitivePhase.PLAN -> applyPlan(agent, substrate, deltaTime)
             CognitivePhase.EXECUTE -> applyExecute(agent, substrate, deltaTime)
-            CognitivePhase.EVALUATE -> applyEvaluate(agent, substrate, deltaTime)
+            CognitivePhase.LEARN -> applyLearn(agent, substrate, deltaTime)
             CognitivePhase.LOOP -> applyLoop(agent, substrate, deltaTime)
             CognitivePhase.NONE -> substrate
         }
@@ -234,7 +236,7 @@ class CognitiveChoreographer(
         val nearbyParticles = particles.getParticlesNear(
             agent.position.x.roundToInt(),
             agent.position.y.roundToInt(),
-            radius = EVALUATE_FADE_RADIUS
+            radius = LEARN_FADE_RADIUS
         )
         nearbyParticles.forEach { p ->
             p.life = (p.life + 0.3f * deltaTime).coerceAtMost(1f)
@@ -243,6 +245,43 @@ class CognitiveChoreographer(
         // Substrate: warm pulse at agent position
         val center = Point(agent.position.x.roundToInt(), agent.position.y.roundToInt())
         return substrateAnimator.pulse(substrate, center, intensity = 0.3f * deltaTime, radius = 5f)
+    }
+
+    // ── OBSERVE: Particles drift inward (state monitoring) ──
+
+    private fun applyObserve(
+        agent: AgentVisualState,
+        substrate: SubstrateState,
+        deltaTime: Float
+    ): SubstrateState {
+        // Similar to PERCEIVE: particles drift inward from edges
+        if (canSpawn(agent.id)) {
+            val angleStep = 2 * PI / PERCEIVE_DIRECTIONS
+            for (i in 0 until PERCEIVE_DIRECTIONS) {
+                val angle = i * angleStep
+                val spawnPos = Vector2(
+                    agent.position.x + cos(angle).toFloat() * PERCEIVE_SPAWN_RADIUS,
+                    agent.position.y + sin(angle).toFloat() * PERCEIVE_SPAWN_RADIUS
+                )
+
+                val inwardAngle = angle + PI
+                val emitter = StreamEmitter()
+                val config = EmitterConfig(
+                    type = ParticleType.MOTE,
+                    speed = 1.2f,
+                    speedVariance = 0.4f,
+                    life = 1.0f,
+                    lifeVariance = 0.2f,
+                    spread = 15f,
+                    direction = (inwardAngle * 180.0 / PI).toFloat()
+                )
+                particles.spawn(emitter, PERCEIVE_PARTICLES_PER_DIR, spawnPos, config)
+            }
+            markSpawned(agent.id)
+        }
+
+        val center = Point(agent.position.x.roundToInt(), agent.position.y.roundToInt())
+        return substrateAnimator.flowToward(substrate, center, strength = 0.25f)
     }
 
     // ── PLAN: Tentative structures testing formations ──
@@ -336,9 +375,9 @@ class CognitiveChoreographer(
         )
     }
 
-    // ── EVALUATE: Afterglow, particles slow and persist (reflection) ──
+    // ── LEARN: Afterglow, particles slow and persist (reflection) ──
 
-    private fun applyEvaluate(
+    private fun applyLearn(
         agent: AgentVisualState,
         substrate: SubstrateState,
         deltaTime: Float
@@ -347,7 +386,7 @@ class CognitiveChoreographer(
         val nearbyParticles = particles.getParticlesNear(
             agent.position.x.roundToInt(),
             agent.position.y.roundToInt(),
-            radius = EVALUATE_FADE_RADIUS
+            radius = LEARN_FADE_RADIUS
         )
         nearbyParticles.forEach { p ->
             // Slow particles down (drag effect)

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/render/AmperePhosphorBridge.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/render/AmperePhosphorBridge.kt
@@ -48,18 +48,17 @@ class AmperePhosphorBridge(
         AmperePhase.RECALL -> EmitterEffect.ColorWash(
             colorRamp = CognitiveColorRamp.forPhase(PhosphorPhase.RECALL)
         )
-        // OBSERVE is sensing/state-monitoring — share the PERCEIVE visual until Phosphor adds OBSERVE.
-        AmperePhase.OBSERVE -> EmitterEffect.HeightPulse()
+        AmperePhase.OBSERVE -> EmitterEffect.ColorWash(
+            colorRamp = CognitiveColorRamp.forPhase(PhosphorPhase.OBSERVE)
+        )
         AmperePhase.PLAN -> EmitterEffect.ColorWash(
             colorRamp = CognitiveColorRamp.forPhase(PhosphorPhase.PLAN)
         )
         AmperePhase.EXECUTE -> EmitterEffect.SparkBurst(
             palette = AsciiLuminancePalette.EXECUTE
         )
-        // Phosphor's enum still uses EVALUATE for the reflection phase that AMPERE calls LEARN.
-        // Follow-up: file a Phosphor ticket to rename PhosphorPhase.EVALUATE -> LEARN.
         AmperePhase.LEARN -> EmitterEffect.ColorWash(
-            colorRamp = CognitiveColorRamp.forPhase(PhosphorPhase.EVALUATE)
+            colorRamp = CognitiveColorRamp.forPhase(PhosphorPhase.LEARN)
         )
         null -> EmitterEffect.HeightPulse()
     }

--- a/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/cli/animation/choreography/CognitiveChoreographerTest.kt
+++ b/ampere-cli/src/jvmTest/kotlin/link/socket/ampere/cli/animation/choreography/CognitiveChoreographerTest.kt
@@ -156,7 +156,24 @@ class CognitiveChoreographerTest {
     }
 
     @Test
-    fun `EVALUATE slows particles and creates anchors`() {
+    fun `OBSERVE spawns inward-directed particles`() {
+        val (choreographer, particles, _) = createChoreographer(maxParticles = 100)
+        val substrate = SubstrateState.create(40, 20)
+        val agents = createAgentLayer(
+            40, 20,
+            Triple("agent-1", Vector2(20f, 10f), CognitivePhase.OBSERVE)
+        )
+
+        choreographer.update(agents, substrate, 0.1f)
+
+        // Particles should exist and be near agent position (similar to PERCEIVE)
+        assertTrue(particles.count > 0, "OBSERVE should spawn particles")
+        val nearAgent = particles.getParticlesNear(20, 10, radius = 15f)
+        assertTrue(nearAgent.isNotEmpty(), "Particles should be within range of agent")
+    }
+
+    @Test
+    fun `LEARN slows particles and creates anchors`() {
         val (choreographer, particles, _) = createChoreographer()
         val substrate = SubstrateState.create(40, 20)
 
@@ -168,17 +185,17 @@ class CognitiveChoreographerTest {
         choreographer.update(executeAgents, substrate, 0.1f)
         assertTrue(particles.count > 0)
 
-        // Transition to EVALUATE
-        val evaluateAgents = createAgentLayer(
+        // Transition to LEARN
+        val learnAgents = createAgentLayer(
             40, 20,
-            Triple("agent-1", Vector2(20f, 10f), CognitivePhase.EVALUATE)
+            Triple("agent-1", Vector2(20f, 10f), CognitivePhase.LEARN)
         )
-        choreographer.update(evaluateAgents, substrate, 0.1f)
+        choreographer.update(learnAgents, substrate, 0.1f)
 
         // Some particles should now have attractors (anchored)
         val anchored = particles.getParticles().filter { it.attractor != null }
         // At least some high-life particles get anchored
-        assertTrue(particles.count > 0, "EVALUATE should not despawn all particles")
+        assertTrue(particles.count > 0, "LEARN should not despawn all particles")
     }
 
     @Test

--- a/ampere-compose/build.gradle.kts
+++ b/ampere-compose/build.gradle.kts
@@ -34,7 +34,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation("link.socket:phosphor-core:0.4.0")
+                implementation("link.socket:phosphor-core:0.6.2")
                 implementation(compose.runtime)
                 implementation(compose.foundation)
                 implementation(compose.ui)

--- a/ampere-compose/src/commonMain/kotlin/link/socket/ampere/compose/CognitivePalette.kt
+++ b/ampere-compose/src/commonMain/kotlin/link/socket/ampere/compose/CognitivePalette.kt
@@ -49,7 +49,7 @@ object CognitivePalette {
     val recall = toComposeColor(composeColorAdapter.adapt(colorModel.phaseColorFor(CognitivePhase.RECALL)))
     val plan = toComposeColor(composeColorAdapter.adapt(colorModel.phaseColorFor(CognitivePhase.PLAN)))
     val execute = toComposeColor(composeColorAdapter.adapt(colorModel.phaseColorFor(CognitivePhase.EXECUTE)))
-    val evaluate = toComposeColor(composeColorAdapter.adapt(colorModel.phaseColorFor(CognitivePhase.EVALUATE)))
+    val learn = toComposeColor(composeColorAdapter.adapt(colorModel.phaseColorFor(CognitivePhase.LEARN)))
     val loop = toComposeColor(composeColorAdapter.adapt(colorModel.phaseColorFor(CognitivePhase.LOOP)))
 
     fun forDensity(density: Float): Color = when {
@@ -61,9 +61,10 @@ object CognitivePalette {
     fun forPhase(phase: CognitivePhase): Color = when (phase) {
         CognitivePhase.PERCEIVE -> perceive
         CognitivePhase.RECALL -> recall
+        CognitivePhase.OBSERVE -> perceive
         CognitivePhase.PLAN -> plan
         CognitivePhase.EXECUTE -> execute
-        CognitivePhase.EVALUATE -> evaluate
+        CognitivePhase.LEARN -> learn
         CognitivePhase.LOOP -> loop
         CognitivePhase.NONE -> agentIdle
     }

--- a/ampere-compose/src/commonMain/kotlin/link/socket/ampere/compose/SceneSnapshotController.kt
+++ b/ampere-compose/src/commonMain/kotlin/link/socket/ampere/compose/SceneSnapshotController.kt
@@ -31,9 +31,10 @@ class SceneSnapshotController(
     private val phaseCycle = listOf(
         CognitivePhase.PERCEIVE,
         CognitivePhase.RECALL,
+        CognitivePhase.OBSERVE,
         CognitivePhase.PLAN,
         CognitivePhase.EXECUTE,
-        CognitivePhase.EVALUATE,
+        CognitivePhase.LEARN,
         CognitivePhase.LOOP
     )
     private var phaseIndex = 0

--- a/ampere-compose/src/commonTest/kotlin/link/socket/ampere/compose/CognitivePaletteTest.kt
+++ b/ampere-compose/src/commonTest/kotlin/link/socket/ampere/compose/CognitivePaletteTest.kt
@@ -40,8 +40,13 @@ class CognitivePaletteTest {
     }
 
     @Test
-    fun forPhase_evaluate_returns_aquamarine() {
-        assertEquals(CognitivePalette.evaluate, CognitivePalette.forPhase(CognitivePhase.EVALUATE))
+    fun forPhase_observe_mirrors_perceive() {
+        assertEquals(CognitivePalette.perceive, CognitivePalette.forPhase(CognitivePhase.OBSERVE))
+    }
+
+    @Test
+    fun forPhase_learn_returns_aquamarine() {
+        assertEquals(CognitivePalette.learn, CognitivePalette.forPhase(CognitivePhase.LEARN))
     }
 
     @Test
@@ -79,7 +84,8 @@ class CognitivePaletteTest {
     fun each_phase_maps_to_distinct_color() {
         val phases = CognitivePhase.entries.filter { it != CognitivePhase.NONE }
         val colors = phases.map { CognitivePalette.forPhase(it) }.toSet()
-        assertEquals(phases.size, colors.size, "Each cognitive phase should have a distinct color")
+        // OBSERVE mirrors PERCEIVE per Wave 3 mapping convention, so expect phases.size - 1 distinct colors
+        assertEquals(phases.size - 1, colors.size, "Each cognitive phase should have a distinct color (OBSERVE mirrors PERCEIVE)")
     }
 
     @Test
@@ -96,7 +102,7 @@ class CognitivePaletteTest {
             CognitivePalette.recall,
             CognitivePalette.plan,
             CognitivePalette.execute,
-            CognitivePalette.evaluate,
+            CognitivePalette.learn,
             CognitivePalette.loop,
         )
         for (color in colors) {

--- a/ampere-compose/src/commonTest/kotlin/link/socket/ampere/compose/WaveformCanvasRendererTest.kt
+++ b/ampere-compose/src/commonTest/kotlin/link/socket/ampere/compose/WaveformCanvasRendererTest.kt
@@ -66,15 +66,15 @@ class WaveformCanvasRendererTest {
     fun dominantPhaseAt_exact_position_dominates() {
         val agents = listOf(
             Triple(0f, 0f, CognitivePhase.RECALL),
-            Triple(5f, 5f, CognitivePhase.EVALUATE),
+            Triple(5f, 5f, CognitivePhase.LEARN),
         )
-        // Query at exact position of EVALUATE agent
+        // Query at exact position of LEARN agent
         val result = WaveformCanvasRenderer.dominantPhaseAt(
             worldX = 5f,
             worldZ = 5f,
             agentPositions = agents
         )
-        assertEquals(CognitivePhase.EVALUATE, result)
+        assertEquals(CognitivePhase.LEARN, result)
     }
 
     @Test

--- a/ampere-desktop/build.gradle.kts
+++ b/ampere-desktop/build.gradle.kts
@@ -21,7 +21,7 @@ kotlin {
                 implementation(project(":ampere-core"))
                 implementation(project(":ampere-compose"))
                 implementation(project(":ampere-cli"))
-                implementation("link.socket:phosphor-core:0.4.0")
+                implementation("link.socket:phosphor-core:0.6.2")
                 implementation(compose.desktop.currentOs)
             }
         }

--- a/ampere-phosphor/build.gradle.kts
+++ b/ampere-phosphor/build.gradle.kts
@@ -80,8 +80,8 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 api(project(":ampere-core"))
-                api("link.socket:phosphor-core:0.5.0")
-                api("link.socket:phosphor-lumos:0.5.0")
+                api("link.socket:phosphor-core:0.6.2")
+                api("link.socket:phosphor-lumos:0.6.2")
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
             }
         }


### PR DESCRIPTION
## Summary
Phosphor 0.6.2 ships with PHO-28, adding OBSERVE and renaming EVALUATE → LEARN to align with canonical PROPEL phases. This PR removes the CLI bridge paveover and updates all AMPERE references to use the canonical phase names.

## Changes
- Bump Phosphor to 0.6.2 across all modules
- Remove `LEARN → EVALUATE` paveover in `AmperePhosphorBridge`; map phases directly to canonical names
- Update `CognitiveChoreographer` to use LEARN instead of EVALUATE, add OBSERVE handling
- Update `CognitivePalette` to support OBSERVE (mirrors PERCEIVE per Wave 3 convention)
- Update test suites and CHANGELOG to reflect canonical PROPEL phases

Closes #524