### PR TITLE
Fix Kotlin compiler warnings

### DIFF
--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/execution/tools/ToolAskHumanTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/execution/tools/ToolAskHumanTest.kt
@@ -32,6 +32,7 @@ import link.socket.ampere.agents.execution.request.ExecutionContext
 import link.socket.ampere.agents.execution.request.ExecutionRequest
 import link.socket.ampere.util.randomUUID
 
+@OptIn(kotlinx.coroutines.DelicateCoroutinesApi::class)
 class ToolAskHumanTest {
 
     private fun makeContext(instructions: String) = ExecutionContext.NoChanges(
@@ -158,7 +159,7 @@ class ToolAskHumanTest {
                 timestamp = Clock.System.now(),
                 eventSource = EventSource.Human,
                 urgency = Urgency.HIGH,
-                emissionId = callbackEvent!!.emissionId,
+                emissionId = callbackEvent.emissionId,
                 affordanceId = "free-text",
             ),
         )

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/llm/UpstreamLlmClientTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/llm/UpstreamLlmClientTest.kt
@@ -54,7 +54,7 @@ class UpstreamLlmClientTest {
         val captured = assertNotNull(recorder.lastRequest, "Custom client must be invoked")
         assertEquals(AIModel_Claude.Sonnet_4.name, captured.model.id)
         assertEquals(0.7, captured.temperature)
-        assertEquals(256, captured.maxTokens)
+        assertEquals(256, captured.maxCompletionTokens)
         assertEquals(2, captured.messages.size)
         assertEquals(ChatRole.System, captured.messages[0].role)
         assertEquals("You are a database expert.", captured.messages[0].content)

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/events/messages/escalation/EscalationEventHandlerTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/events/messages/escalation/EscalationEventHandlerTest.kt
@@ -28,7 +28,7 @@ import link.socket.ampere.agents.events.messages.MessageThread
 import link.socket.ampere.data.DEFAULT_JSON
 import link.socket.ampere.db.Database
 
-@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class, kotlinx.coroutines.DelicateCoroutinesApi::class)
 class EscalationEventHandlerTest {
 
     private val scope = TestScope(UnconfinedTestDispatcher())

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/execution/tools/HumanEscalationFlowTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/execution/tools/HumanEscalationFlowTest.kt
@@ -45,6 +45,7 @@ import link.socket.ampere.util.randomUUID
  * - Subscribers on base EmissionEvent.Produced receive HumanInteractionEvent.InputRequested
  * - GlobalHumanResponseRegistry is NOT referenced (coverage assertion)
  */
+@OptIn(kotlinx.coroutines.DelicateCoroutinesApi::class)
 class HumanEscalationFlowTest {
 
     private fun newRegistry() = EmissionReplyRegistry()


### PR DESCRIPTION
## Summary
- Remove unnecessary non-null assertion in ToolAskHumanTest.kt:161
- Replace deprecated `maxTokens` with `maxCompletionTokens` in UpstreamLlmClientTest.kt:57
- Add @OptIn(DelicateCoroutinesApi::class) annotations for GlobalScope usage in test files

## Changes
- ToolAskHumanTest.kt: Removed `!!` operator and added @OptIn annotation
- UpstreamLlmClientTest.kt: Updated to use non-deprecated API
- EscalationEventHandlerTest.kt: Added @OptIn annotation for DelicateCoroutinesApi
- HumanEscalationFlowTest.kt: Added @OptIn annotation for DelicateCoroutinesApi

🤖 Generated with [Claude Code](https://claude.com/claude-code)