### PR TITLE
[codex][AMPR-180 #508] Emission protocol foundation

### DIFF
--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/EventRepository.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/EventRepository.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.datetime.Instant
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
+import link.socket.ampere.agents.domain.event.EmissionEvent
 import link.socket.ampere.agents.domain.event.Event
 import link.socket.ampere.agents.domain.event.EventId
 import link.socket.ampere.agents.domain.event.EventType
@@ -255,5 +256,6 @@ private fun Event.runIdOrNull(): String? = when (this) {
     is MemoryEvent.MilestoneReached -> runId
     is link.socket.ampere.agents.domain.event.TaskEvent.TaskCompleted -> runId
     is link.socket.ampere.agents.domain.event.TaskEvent.TaskFailed -> runId
+    is EmissionEvent.Produced -> emission.provenance.runId
     else -> null
 }

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/messages/AgentMessageApi.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/messages/AgentMessageApi.kt
@@ -164,6 +164,9 @@ class AgentMessageApi(
      *    until the human replies.
      * 4. Transition thread back to [EventStatus.Open] and post the reply.
      *
+     * Set [awaitReply] to `false` for legacy fire-and-forget thread escalation
+     * where the caller only needs the durable status transition and bus events.
+     *
      * Thread state transitions are owned exclusively by this method — handlers must not
      * re-transition (CHI cell invariant).
      */
@@ -171,6 +174,7 @@ class AgentMessageApi(
         threadId: MessageThreadId,
         reason: String,
         context: Map<String, String> = emptyMap(),
+        awaitReply: Boolean = true,
     ) {
         val thread = messageRepository
             .findThreadById(threadId)
@@ -226,6 +230,10 @@ class AgentMessageApi(
                 newStatus = newStatus,
             ),
         )
+
+        if (!awaitReply) {
+            return
+        }
 
         // Step 3: Produce the Emission and suspend for reply.
         val contextString = context.entries.joinToString("\n") { "${it.key}: ${it.value}" }

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/tickets/TicketOrchestrator.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/tickets/TicketOrchestrator.kt
@@ -436,6 +436,7 @@ class TicketOrchestrator(
                     "reportedBy" to reportedByAgentId,
                     "priority" to updatedTicket.priority.name,
                 ),
+                awaitReply = false,
             )
         }
 

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/data/EventRepositoryTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/data/EventRepositoryTest.kt
@@ -15,7 +15,16 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
+import kotlinx.serialization.json.JsonPrimitive
 import link.socket.ampere.agents.domain.Urgency
+import link.socket.ampere.agents.domain.emission.Affordance
+import link.socket.ampere.agents.domain.emission.DangerLevel
+import link.socket.ampere.agents.domain.emission.Emission
+import link.socket.ampere.agents.domain.emission.EmissionKind
+import link.socket.ampere.agents.domain.emission.EmissionPayload
+import link.socket.ampere.agents.domain.emission.EmissionProvenance
+import link.socket.ampere.agents.domain.emission.inputDigest
+import link.socket.ampere.agents.domain.event.EmissionEvent
 import link.socket.ampere.agents.domain.event.Event
 import link.socket.ampere.agents.domain.event.EventSource
 import link.socket.ampere.agents.events.EventRepository
@@ -32,13 +41,14 @@ class EventRepositoryTest {
     private val stubEventSourceB = EventSource.Agent("agent-B")
 
     private lateinit var driver: JdbcSqliteDriver
+    private lateinit var database: Database
     private lateinit var repo: EventRepository
 
     @BeforeTest
     fun setUp() {
         driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
         Database.Schema.create(driver)
-        val database = Database.Companion(driver)
+        database = Database.Companion(driver)
         repo = EventRepository(stubJson, testScope, database)
     }
 
@@ -82,6 +92,52 @@ class EventRepositoryTest {
             assertNotNull(loaded)
             assertIs<Event.TaskCreated>(loaded)
             assertEquals("task-123", loaded.taskId)
+        }
+    }
+
+    @Test
+    fun `saveEvent stores emission produced provenance run id`() {
+        runBlocking {
+            val payload = EmissionPayload.Confirmation(
+                action = "deploy production",
+                preview = "Release v2",
+                dangerLevel = DangerLevel.HIGH,
+            )
+            val digest = inputDigest(payload)
+            val event = EmissionEvent.BaseProduced(
+                eventId = "evt-emission-produced",
+                timestamp = Instant.fromEpochSeconds(1_000),
+                eventSource = stubEventSourceA,
+                urgency = Urgency.HIGH,
+                emission = Emission(
+                    id = "emission-1",
+                    kind = EmissionKind.Confirmation,
+                    payload = payload,
+                    affordances = listOf(
+                        Affordance(
+                            id = "approve",
+                            label = "Approve",
+                            signalPayload = JsonPrimitive("approve"),
+                        ),
+                    ),
+                    provenance = EmissionProvenance(
+                        runId = "run-emission-1",
+                        workflowId = "workflow-1",
+                        sourceEventId = "source-event-1",
+                        toolInvocationId = "tool-1",
+                        pluginId = "plugin-1",
+                        modelId = "model-1",
+                        inputDigest = digest,
+                    ),
+                    dedupKey = digest,
+                    producedAt = Instant.fromEpochSeconds(1_000),
+                ),
+            )
+
+            repo.saveEvent(event).getOrThrow()
+
+            val row = database.eventStoreQueries.getEventById("evt-emission-produced").executeAsOne()
+            assertEquals("run-emission-1", row.run_id)
         }
     }
 

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/events/messages/AgentMessageApiTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/events/messages/AgentMessageApiTest.kt
@@ -8,7 +8,9 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -102,42 +104,50 @@ class AgentMessageApiTest {
             assertEquals(2, fetchedThread2.messages.size)
 
             // Escalate -> WAITING_FOR_HUMAN
-            api.escalateToHuman(
-                threadId = thread.id,
-                reason = "Need approval",
-            )
-            val fetchedThread3 = api.getThread(thread.id).getOrNull()
-            assertNotNull(fetchedThread3)
-            assertEquals(EventStatus.WaitingForHuman, fetchedThread3.status)
-
-            // Posting now should fail, since the thread is waiting for human
-            var threw = false
-            try {
-                api.postMessage(
+            val escalationJob = launch {
+                api.escalateToHuman(
                     threadId = thread.id,
-                    content = "Should fail",
+                    reason = "Need approval",
                 )
-            } catch (e: IllegalArgumentException) {
-                threw = true
-            } catch (e: IllegalStateException) {
-                threw = true
             }
-            assertTrue(threw)
 
-            // Resolve
-            api.resolveThread(thread.id)
-            val fetched4 = api.getThread(thread.id).getOrNull()
-            assertNotNull(fetched4)
-            assertEquals(EventStatus.Resolved, fetched4.status)
+            try {
+                delay(200)
+                val fetchedThread3 = api.getThread(thread.id).getOrNull()
+                assertNotNull(fetchedThread3)
+                assertEquals(EventStatus.WaitingForHuman, fetchedThread3.status)
 
-            // allow async event handlers to run
-            delay(200)
+                // Posting now should fail, since the thread is waiting for human
+                var threw = false
+                try {
+                    api.postMessage(
+                        threadId = thread.id,
+                        content = "Should fail",
+                    )
+                } catch (e: IllegalArgumentException) {
+                    threw = true
+                } catch (e: IllegalStateException) {
+                    threw = true
+                }
+                assertTrue(threw)
 
-            // Events were published (at least 1 create, 2 posts, 1 escalation, 2 status changes)
-            assertTrue(received.any { it is MessageEvent.ThreadCreated })
-            assertTrue(received.count { it is MessageEvent.MessagePosted } >= 2)
-            assertTrue(received.any { it is MessageEvent.EscalationRequested })
-            assertTrue(received.count { it is MessageEvent.ThreadStatusChanged } >= 2)
+                // Resolve
+                api.resolveThread(thread.id)
+                val fetched4 = api.getThread(thread.id).getOrNull()
+                assertNotNull(fetched4)
+                assertEquals(EventStatus.Resolved, fetched4.status)
+
+                // allow async event handlers to run
+                delay(200)
+
+                // Events were published (at least 1 create, 2 posts, 1 escalation, 2 status changes)
+                assertTrue(received.any { it is MessageEvent.ThreadCreated })
+                assertTrue(received.count { it is MessageEvent.MessagePosted } >= 2)
+                assertTrue(received.any { it is MessageEvent.EscalationRequested })
+                assertTrue(received.count { it is MessageEvent.ThreadStatusChanged } >= 2)
+            } finally {
+                escalationJob.cancelAndJoin()
+            }
 
             // ** TODO: Test subscriptions can be unsubscribed from. */
         }
@@ -166,48 +176,56 @@ class AgentMessageApiTest {
             assertEquals(EventStatus.Open, fetchedThread1.status)
 
             // Escalate to WAITING_FOR_HUMAN
-            api.escalateToHuman(
-                threadId = thread.id,
-                reason = "Need human input",
-            )
-
-            val fetchedThread2 = api.getThread(thread.id).getOrNull()
-            assertNotNull(fetchedThread2)
-            assertEquals(EventStatus.WaitingForHuman, fetchedThread2.status)
-
-            // Verify posting is blocked
-            var blocked = false
-            try {
-                api.postMessage(thread.id, "Should fail")
-            } catch (e: IllegalArgumentException) {
-                blocked = true
+            val escalationJob = launch {
+                api.escalateToHuman(
+                    threadId = thread.id,
+                    reason = "Need human input",
+                )
             }
-            assertTrue(blocked, "Posting should be blocked when waiting for human")
 
-            // Reopen the thread
-            api.reopenThread(thread.id)
+            try {
+                delay(200)
 
-            val fetchedThread3 = api.getThread(thread.id).getOrNull()
-            assertNotNull(fetchedThread3)
-            assertEquals(EventStatus.Open, fetchedThread3.status)
+                val fetchedThread2 = api.getThread(thread.id).getOrNull()
+                assertNotNull(fetchedThread2)
+                assertEquals(EventStatus.WaitingForHuman, fetchedThread2.status)
 
-            // Now posting should succeed
-            val newMessage = api.postMessage(thread.id, "Human intervention complete")
-            assertEquals("Human intervention complete", newMessage.content)
+                // Verify posting is blocked
+                var blocked = false
+                try {
+                    api.postMessage(thread.id, "Should fail")
+                } catch (e: IllegalArgumentException) {
+                    blocked = true
+                }
+                assertTrue(blocked, "Posting should be blocked when waiting for human")
 
-            // Verify thread has the new message
-            val fetchedThread4 = api.getThread(thread.id).getOrNull()
-            assertNotNull(fetchedThread4)
-            assertEquals(2, fetchedThread4.messages.size)
+                // Reopen the thread
+                api.reopenThread(thread.id)
 
-            // Allow async handlers to run
-            delay(200)
+                val fetchedThread3 = api.getThread(thread.id).getOrNull()
+                assertNotNull(fetchedThread3)
+                assertEquals(EventStatus.Open, fetchedThread3.status)
 
-            // Verify status change events
-            val statusChanges = received.filterIsInstance<MessageEvent.ThreadStatusChanged>()
-            assertTrue(statusChanges.size >= 2)
-            assertTrue(statusChanges.any { it.newStatus == EventStatus.WaitingForHuman })
-            assertTrue(statusChanges.any { it.newStatus == EventStatus.Open })
+                // Now posting should succeed
+                val newMessage = api.postMessage(thread.id, "Human intervention complete")
+                assertEquals("Human intervention complete", newMessage.content)
+
+                // Verify thread has the new message
+                val fetchedThread4 = api.getThread(thread.id).getOrNull()
+                assertNotNull(fetchedThread4)
+                assertEquals(2, fetchedThread4.messages.size)
+
+                // Allow async handlers to run
+                delay(200)
+
+                // Verify status change events
+                val statusChanges = received.filterIsInstance<MessageEvent.ThreadStatusChanged>()
+                assertTrue(statusChanges.size >= 2)
+                assertTrue(statusChanges.any { it.newStatus == EventStatus.WaitingForHuman })
+                assertTrue(statusChanges.any { it.newStatus == EventStatus.Open })
+            } finally {
+                escalationJob.cancelAndJoin()
+            }
         }
     }
 
@@ -227,19 +245,25 @@ class AgentMessageApiTest {
                 initialMessageContent = "Need a decision",
             )
 
-            api.escalateToHuman(
-                threadId = thread.id,
-                reason = "Need human input on release timing",
-                context = mapOf("release" to "v1"),
-            )
+            val escalationJob = launch {
+                api.escalateToHuman(
+                    threadId = thread.id,
+                    reason = "Need human input on release timing",
+                    context = mapOf("release" to "v1"),
+                )
+            }
 
-            delay(200)
+            try {
+                delay(200)
 
-            assertEquals(1, received.size)
-            val event = received.single()
-            assertEquals(thread.id, event.threadId)
-            assertEquals("Need human input on release timing", event.reason)
-            assertEquals(mapOf("release" to "v1"), event.context)
+                assertEquals(1, received.size)
+                val event = received.single()
+                assertEquals(thread.id, event.threadId)
+                assertEquals("Need human input on release timing", event.reason)
+                assertEquals(mapOf("release" to "v1"), event.context)
+            } finally {
+                escalationJob.cancelAndJoin()
+            }
         }
     }
 

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/execution/tools/HumanEscalationFlowTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/execution/tools/HumanEscalationFlowTest.kt
@@ -202,7 +202,7 @@ class HumanEscalationFlowTest {
         val registry = newRegistry()
         val baseReceived = mutableListOf<EmissionEvent>()
 
-        bus.subscribe<EmissionEvent.BaseProduced, EventSubscription.ByEventClassType>(
+        bus.subscribe<EmissionEvent, EventSubscription.ByEventClassType>(
             agentId = "base-sub",
             eventType = EmissionEvent.Produced.EVENT_TYPE,
         ) { event, _ ->

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/execution/tools/HumanEscalationFlowTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/execution/tools/HumanEscalationFlowTest.kt
@@ -8,9 +8,12 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import kotlinx.datetime.Clock
 import link.socket.ampere.agents.domain.Urgency
 import link.socket.ampere.agents.domain.emission.EmissionReplyRegistry
@@ -49,8 +52,8 @@ class HumanEscalationFlowTest {
 
     private fun newRegistry() = EmissionReplyRegistry()
 
-    private fun newBus() = EventSerialBus(
-        scope = kotlinx.coroutines.GlobalScope,
+    private fun newBus(scope: CoroutineScope) = EventSerialBus(
+        scope = scope,
     )
 
     private fun createTestContext(instructions: String): ExecutionContext.NoChanges {
@@ -149,15 +152,17 @@ class HumanEscalationFlowTest {
 
     @Test
     fun `askHuman publishes HumanInteractionEvent InputRequested`() = runTest {
-        val bus = newBus()
+        val bus = newBus(backgroundScope)
         val registry = newRegistry()
-        val receivedEvents = mutableListOf<HumanInteractionEvent.InputRequested>()
+        val receivedEvent = CompletableDeferred<HumanInteractionEvent.InputRequested>()
 
         bus.subscribe<HumanInteractionEvent.InputRequested, EventSubscription.ByEventClassType>(
             agentId = "test-sub",
             eventType = HumanInteractionEvent.InputRequested.EVENT_TYPE,
         ) { event, _ ->
-            receivedEvents.add(event)
+            if (!receivedEvent.isCompleted) {
+                receivedEvent.complete(event)
+            }
         }
 
         val askDeferred = async {
@@ -172,10 +177,7 @@ class HumanEscalationFlowTest {
             }
         }
 
-        delay(200.milliseconds)
-        assertEquals(1, receivedEvents.size)
-
-        val published = receivedEvents.first()
+        val published = withTimeout(5.seconds) { receivedEvent.await() }
         assertIs<HumanInteractionEvent.InputRequested>(published)
         assertIs<EmissionEvent.Produced>(published)
         assertEquals("test-agent", published.agentId)
@@ -198,15 +200,17 @@ class HumanEscalationFlowTest {
 
     @Test
     fun `base EmissionProduced subscriber receives InputRequested via polymorphic dispatch`() = runTest {
-        val bus = newBus()
+        val bus = newBus(backgroundScope)
         val registry = newRegistry()
-        val baseReceived = mutableListOf<EmissionEvent>()
+        val baseReceived = CompletableDeferred<EmissionEvent>()
 
         bus.subscribe<EmissionEvent, EventSubscription.ByEventClassType>(
             agentId = "base-sub",
             eventType = EmissionEvent.Produced.EVENT_TYPE,
         ) { event, _ ->
-            baseReceived.add(event)
+            if (!baseReceived.isCompleted) {
+                baseReceived.complete(event)
+            }
         }
 
         val askDeferred = async {
@@ -219,11 +223,9 @@ class HumanEscalationFlowTest {
             }
         }
 
-        delay(200.milliseconds)
-        assertEquals(1, baseReceived.size)
-        assertIs<HumanInteractionEvent.InputRequested>(baseReceived.first())
-
-        val requestedEvent = baseReceived.first() as HumanInteractionEvent.InputRequested
+        val requestedEvent = withTimeout(5.seconds) {
+            assertIs<HumanInteractionEvent.InputRequested>(baseReceived.await())
+        }
         registry.deliver(
             EmissionEvent.BaseResolved(
                 eventId = randomUUID(),
@@ -239,15 +241,17 @@ class HumanEscalationFlowTest {
 
     @Test
     fun `askHuman timeout publishes RequestTimedOut event`() = runTest {
-        val bus = newBus()
+        val bus = newBus(backgroundScope)
         val registry = newRegistry()
-        val timedOutEvents = mutableListOf<HumanInteractionEvent.RequestTimedOut>()
+        val timedOutEvent = CompletableDeferred<HumanInteractionEvent.RequestTimedOut>()
 
         bus.subscribe<HumanInteractionEvent.RequestTimedOut, EventSubscription.ByEventClassType>(
             agentId = "timeout-sub",
             eventType = HumanInteractionEvent.RequestTimedOut.EVENT_TYPE,
         ) { event, _ ->
-            timedOutEvents.add(event)
+            if (!timedOutEvent.isCompleted) {
+                timedOutEvent.complete(event)
+            }
         }
 
         val caught = try {
@@ -264,9 +268,8 @@ class HumanEscalationFlowTest {
         }
 
         assertNotNull(caught)
-        delay(100.milliseconds)
-        assertEquals(1, timedOutEvents.size)
-        assertEquals(0L, timedOutEvents.first().timeoutMinutes) // 100ms → 0 minutes
+        val timeoutEvent = withTimeout(5.seconds) { timedOutEvent.await() }
+        assertEquals(0L, timeoutEvent.timeoutMinutes) // 100ms → 0 minutes
     }
 
     // ── Coverage assertion: no GlobalHumanResponseRegistry usage ───────────

--- a/docs/concepts/chi.md
+++ b/docs/concepts/chi.md
@@ -10,7 +10,7 @@ tracked_sources:
   - ampere-core/src/commonMain/kotlin/link/socket/ampere/pause/AgentPause.kt
   - ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/HumanInteractionEvent.kt
 related: [Emission, AgentPause, MessageEvent, EventSerialBus]
-last_verified: 2026-05-27
+last_verified: 2026-06-04
 ---
 
 # CHI (Computer-Human Interface)
@@ -65,11 +65,11 @@ The four current CHI paths:
   - **Shape:** blocking suspend, no bus emission, console-only surface, 30-min hard-coded timeout.
 
 - **Path 2 — `MessageEvent.EscalationRequested` (thread escalation).**
-  - `ampere-core/.../agents/events/messages/AgentMessageApi.kt:151` — `escalateToHuman(threadId, reason, context)` transitions the thread to `EventStatus.WaitingForHuman` and publishes `EscalationRequested` + `ThreadStatusChanged`.
+  - `ampere-core/.../agents/events/messages/AgentMessageApi.kt:151` — `escalateToHuman(threadId, reason, context, awaitReply)` transitions the thread to `EventStatus.WaitingForHuman` and publishes `EscalationRequested` + `ThreadStatusChanged`.
   - `ampere-core/.../agents/domain/event/MessageEvent.kt:86` — the event itself (`threadId`, `reason`, `context`, `urgency`).
   - `ampere-core/.../agents/events/escalation/EscalationEventHandler.kt` — subscribes to `EscalationRequested` and calls `humanNotifier.notifyEscalation(...)`.
   - `ampere-core/.../agents/events/escalation/DefaultEscalationPolicy.kt` — keyword-based classification into the `Escalation` sealed hierarchy.
-  - **Shape:** fire-and-forget bus emission, thread-scoped, no response pairing on the publishing side, status transition is the durable record.
+  - **Shape:** explicit lifecycle. `awaitReply = false` is the legacy fire-and-forget thread escalation where status transition is the durable record; the default `awaitReply = true` also emits `HumanInteractionEvent.InputRequested` and suspends for the paired reply.
 
 - **Path 3 — `AgentPause` (typed pause contract).**
   - `ampere-core/.../pause/AgentPause.kt` — `correlationId: PauseCorrelationId`, `reason`, `urgency: PauseUrgency` (`Routine` | `Important` | `Critical`), `suggestedChannels: List<EscalationChannel>` (ordered fallback), `timeoutMillis`, optional `fallbackUrl`.
@@ -79,13 +79,13 @@ The four current CHI paths:
 
 - **Path 4 — `HumanInteractionEvent` (request/response event pair).**
   - `ampere-core/.../agents/domain/event/HumanInteractionEvent.kt` — sealed interface with `InputRequested(requestId, agentId, question, context, ticketId?, taskId?)`, `InputProvided(requestId, agentId, response, respondedBy?)`, `RequestTimedOut(requestId, agentId, timeoutMinutes)`.
-  - **Shape:** event types defined and ready for bus dispatch — but **not currently emitted** by `ToolAskHuman` or `AgentMessageApi.escalateToHuman`. Pairing is by `requestId`.
+  - **Shape:** emitted by `EmissionScope.askHuman`; `AgentMessageApi.escalateToHuman(awaitReply = true)` uses this path. Pairing is by `requestId` plus the Emission id.
 
 ### Path comparison
 
 | Dimension          | `ToolAskHuman`                    | `MessageEvent.EscalationRequested` | `AgentPause`                          | `HumanInteractionEvent`            |
 |--------------------|-----------------------------------|------------------------------------|---------------------------------------|------------------------------------|
-| Entry point        | Tool dispatch                     | `AgentMessageApi.escalateToHuman`  | (W0.3: contract only)                 | (defined, no emitter)              |
+| Entry point        | Tool dispatch                     | `AgentMessageApi.escalateToHuman`  | (W0.3: contract only)                 | `EmissionScope.askHuman`           |
 | Payload            | `instructions` string             | `reason` + `context: Map`          | `reason` + `urgency` + channels       | `question` + `context: Map`        |
 | Correlation field  | `requestId` (UUID)                | `threadId` + `eventId`             | `correlationId: PauseCorrelationId`   | `requestId` (UUID)                 |
 | Persistence        | In-memory registry (singleton)    | `EventStore` + thread status row   | None yet                              | `EventStore` (when emitted)        |
@@ -93,7 +93,7 @@ The four current CHI paths:
 | Timeout            | `30.minutes` hard-coded           | None                               | `timeoutMillis` per pause             | `timeoutMinutes` per event         |
 | Channel selection  | Console only                      | `humanNotifier` (single sink)      | Ordered `suggestedChannels` fallback  | None — surface decides             |
 | Response delivery  | `provideResponse(requestId, ...)` | None (out-of-band human action)    | `AgentPauseResponse` (target)         | `InputProvided` event (paired)     |
-| Calling-side block | Blocks calling coroutine          | Fire-and-forget                    | Suspends agent (target)               | Fire-and-forget (target)           |
+| Calling-side block | Blocks calling coroutine          | Explicit: default suspend-until-response; `awaitReply = false` fire-and-forget | Suspends agent (target)               | Fire-and-forget (target)           |
 
 ## Invariants
 
@@ -102,14 +102,14 @@ The four current CHI paths:
 - **A CHI request must declare its timeout posture.** A missing timeout is not the same as an infinite timeout; both differ from a fixed 30-minute wall. The current paths span all three.
 - **Channel selection is policy, not payload.** `AgentPause.suggestedChannels` is an *ordered preference*; the channel selector (W1.5) decides what actually fires. CHI requests must not assume any specific surface — adding "send a Slack message" inside `ToolAskHuman` is the canonical violation.
 - **Thread state transitions on `EscalationRequested` are owned by `AgentMessageApi.escalateToHuman`, not by handlers.** `EscalationEventHandler` only notifies; the `EventStatus.WaitingForHuman` transition is committed inside the API before the event is published. Handlers must not re-transition.
-- **`HumanInteractionEvent` is the future bus-side contract; its non-emission today is a gap, not a design choice.** Treating `InputRequested` / `InputProvided` as deprecated would break the target unification before it ships.
+- **`HumanInteractionEvent` is the bus-side CHI contract for human input.** Treating `InputRequested` / `InputProvided` as deprecated would break the target unification.
 
 ## Common operations
 
 Today (use the path that fits the lifecycle, do not mix them):
 
 - **Block an executing tool waiting on a person** — call `ToolAskHuman` from a tool definition with `requiredAgentAutonomy` set; the JVM `actual` will print to console and block on `GlobalHumanResponseRegistry`. Respond out-of-band with `./ampere-cli/ampere respond <requestId> "<text>"`.
-- **Escalate a conversational thread** — `agentMessageApi.escalateToHuman(threadId, reason, context)`. Status transitions to `WaitingForHuman`, two events publish, and `EscalationEventHandler` fires `humanNotifier.notifyEscalation(...)`.
+- **Escalate a conversational thread** — `agentMessageApi.escalateToHuman(threadId, reason, context, awaitReply)`. Status transitions to `WaitingForHuman`, two message events publish, and `EscalationEventHandler` fires `humanNotifier.notifyEscalation(...)`. With the default `awaitReply = true`, the API also emits `HumanInteractionEvent.InputRequested` and suspends for the paired reply; use `awaitReply = false` when the caller must return after the durable transition.
 - **Construct a typed pause descriptor** — build an `AgentPause(correlationId, reason, urgency, suggestedChannels, timeoutMillis, fallbackUrl?)`. The dispatching infrastructure ships in a later wave; for now the contract is consumed by per-Arc override UI and unit tests.
 - **Classify an escalation reason** — `DefaultEscalationPolicy` maps free-text reasons into the `Escalation` sealed hierarchy (`Discussion`, `Decision`, `Budget`, `Priorities`, `Scope`, `External`) and an `EscalationProcess`.
 

--- a/docs/concepts/emission-dedup.md
+++ b/docs/concepts/emission-dedup.md
@@ -5,7 +5,7 @@ tracked_sources:
   - ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/emission/EmissionDigest.kt
   - ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/emission/Emission.kt
 related: [Emission, ChiProtocol]
-last_verified: 2026-05-27
+last_verified: 2026-06-04
 ---
 
 # EmissionDedup

--- a/docs/concepts/emission.md
+++ b/docs/concepts/emission.md
@@ -9,7 +9,7 @@ tracked_sources:
   - ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/emission/EmissionProvenance.kt
   - ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/EmissionEvent.kt
 related: [ChiProtocol, EventSerialBus, AgentSurface, PropelLoop, EmissionDedup]
-last_verified: 2026-05-27
+last_verified: 2026-06-04
 ---
 
 # Emission

--- a/docs/concepts/event-serial-bus.md
+++ b/docs/concepts/event-serial-bus.md
@@ -11,7 +11,7 @@ tracked_sources:
   - ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/**
   - ampere-core/src/commonMain/sqldelight/link/socket/ampere/db/events/**
 related: [PropelLoop, AgentSurface, CognitionTrace, MemoryProvenance]
-last_verified: 2026-05-31
+last_verified: 2026-06-04
 ---
 
 # EventSerialBus

--- a/docs/concepts/propel-loop.md
+++ b/docs/concepts/propel-loop.md
@@ -8,7 +8,7 @@ tracked_sources:
   - ampere-core/src/commonMain/kotlin/link/socket/ampere/trace/ArcRunTrace.kt
   - docs/AGENT_LIFECYCLE.md
 related: [CognitiveRelay, MemoryProvenance, SparkSystem, CognitionTrace, EventSerialBus]
-last_verified: 2026-05-31
+last_verified: 2026-06-04
 ---
 
 # PROPEL Loop


### PR DESCRIPTION
Implements the AMPERE-side Emission protocol foundation for AMPR-180: domain types, payloads, affordances, provenance, digest dedup helpers, Confidence parsing, and EmissionEvent bus registration/rendering support.

Adds concept cells and tests covering serialization, bus delivery, registry membership, digest determinism, and confidence parsing.

Closes #508.

Validation: `./gradlew :ampere-core:compileCommonMainKotlinMetadata`, `./gradlew ktlintFormat`, `./gradlew jvmTest`, `git diff --check`.