### PR TITLE
AMPR-183 #530: ampere-eval Trace — capture, persist, replay

### DIFF
--- a/ampere-eval/build.gradle.kts
+++ b/ampere-eval/build.gradle.kts
@@ -1,0 +1,141 @@
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.KotlinMultiplatform
+import com.vanniktech.maven.publish.SonatypeHost
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
+
+plugins {
+    kotlin("multiplatform")
+    kotlin("plugin.serialization")
+    id("app.cash.sqldelight")
+    id("com.vanniktech.maven.publish")
+    id("org.jlleitschuh.gradle.ktlint")
+}
+
+val ampereVersion: String by project
+
+group = "link.socket"
+version = ampereVersion
+
+mavenPublishing {
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+    signAllPublications()
+
+    configure(KotlinMultiplatform(javadocJar = JavadocJar.Empty()))
+
+    coordinates("link.socket", "ampere-eval", version.toString())
+
+    pom {
+        name.set("Ampere Eval")
+        description.set(
+            "Measurement substrate for AMPERE: capturable, partially-replayable " +
+                "Trace of an EventSerialBus run stream, persisted via SQLDelight.",
+        )
+        url.set("https://github.com/socket-link/ampere")
+        inceptionYear.set("2026")
+
+        licenses {
+            license {
+                name.set("The Apache License, Version 2.0")
+                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                distribution.set("repo")
+            }
+        }
+
+        developers {
+            developer {
+                id.set("socket-link")
+                name.set("Socket Link")
+                url.set("https://github.com/socket-link")
+            }
+        }
+
+        scm {
+            connection.set("scm:git:git://github.com/socket-link/ampere.git")
+            developerConnection.set("scm:git:ssh://git@github.com:socket-link/ampere.git")
+            url.set("https://github.com/socket-link/ampere")
+        }
+
+        issueManagement {
+            system.set("GitHub Issues")
+            url.set("https://github.com/socket-link/ampere/issues")
+        }
+    }
+}
+
+kotlin {
+    applyDefaultHierarchyTemplate()
+
+    jvm {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_21)
+        }
+    }
+
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
+
+    jvmToolchain(21)
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                api(project(":ampere-core"))
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
+                implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.1")
+                implementation("app.cash.sqldelight:runtime:2.2.1")
+            }
+        }
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
+                implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.1")
+            }
+        }
+        val jvmTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+                implementation("app.cash.sqldelight:sqlite-driver:2.2.1")
+            }
+        }
+    }
+}
+
+sqldelight {
+    databases {
+        create("EvalDatabase") {
+            packageName.set("link.socket.ampere.eval.db")
+        }
+    }
+}
+
+tasks.named<Test>("jvmTest") {
+    useJUnitPlatform()
+}
+
+ktlint {
+    verbose.set(true)
+    outputToConsole.set(true)
+    debug.set(true)
+
+    version.set("0.49.1")
+
+    additionalEditorconfig.set(
+        mapOf(
+            "ktlint_code_style" to "intellij_idea",
+        ),
+    )
+
+    filter {
+        exclude { element -> element.file.path.contains("build/") }
+        exclude { element -> element.file.path.contains("generated/") }
+    }
+
+    reporters {
+        reporter(ReporterType.PLAIN)
+        reporter(ReporterType.CHECKSTYLE)
+    }
+}

--- a/ampere-eval/src/commonMain/kotlin/link/socket/ampere/eval/trace/Trace.kt
+++ b/ampere-eval/src/commonMain/kotlin/link/socket/ampere/eval/trace/Trace.kt
@@ -1,0 +1,64 @@
+package link.socket.ampere.eval.trace
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * A single captured bus event, frozen into an ordered, serializable form.
+ *
+ * @property index zero-based position of this event within its [Trace], in emission order.
+ * @property timestamp epoch milliseconds at which the source event occurred.
+ * @property type the bus event-type discriminator (the source `Event.eventType`),
+ *   used for human/queryable identification — NOT the kotlinx `"type"` payload
+ *   discriminator (which lives inside [payload]).
+ * @property payload the full serialized source event as a [JsonElement]; decodable
+ *   back to the original `Event` via `Event.serializer()` with the shared `DEFAULT_JSON`.
+ */
+@Serializable
+data class TraceEvent(
+    val index: Int,
+    val timestamp: Long,
+    val type: String,
+    val payload: JsonElement,
+)
+
+/**
+ * An ordered, serializable capture of a single run's `EventSerialBus` stream.
+ *
+ * A `Trace` is the one measurement primitive the eval set is built on: evals,
+ * regression gates, and the later reward function are all consumers of a captured,
+ * replayable event stream. Replay is handled by [TraceCursor].
+ *
+ * @property id unique identifier for this trace.
+ * @property runId the run this trace was recorded for (see RECON-trace.md §3).
+ * @property arcId the orchestration pathway (Arc) this run belongs to.
+ * @property createdAt epoch milliseconds when the trace was recorded.
+ * @property events the captured events, in emission order.
+ */
+@Serializable
+data class Trace(
+    val id: String,
+    val runId: String,
+    val arcId: String,
+    val createdAt: Long,
+    val events: List<TraceEvent>,
+) {
+    /** Number of events in the trace. */
+    val size: Int get() = events.size
+
+    /** Events `0..index` inclusive. Delegates to [List.take], so out-of-range is safe. */
+    fun upTo(index: Int): List<TraceEvent> = events.take(index + 1)
+}
+
+/**
+ * Queryable metadata for a persisted [Trace] without its event blob.
+ * Returned by `TraceService.list`.
+ */
+@Serializable
+data class TraceSummary(
+    val id: String,
+    val runId: String,
+    val arcId: String,
+    val createdAt: Long,
+    val eventCount: Int,
+)

--- a/ampere-eval/src/commonMain/kotlin/link/socket/ampere/eval/trace/TraceCursor.kt
+++ b/ampere-eval/src/commonMain/kotlin/link/socket/ampere/eval/trace/TraceCursor.kt
@@ -1,0 +1,49 @@
+package link.socket.ampere.eval.trace
+
+import kotlinx.serialization.Serializable
+
+/**
+ * A signal marking where replay stops and a fresh ("branched") execution would
+ * take over. The handoff begins at [branchIndex]; [replayed] is the exact prefix
+ * of events to replay before that point.
+ *
+ * Eval is the degenerate case where the handoff never fires: `branchAfter(size - 1)`
+ * replays the whole trace and yields a [branchIndex] one past the last event.
+ */
+@Serializable
+data class BranchPoint(
+    val replayed: List<TraceEvent>,
+    val branchIndex: Int,
+)
+
+/**
+ * Read-only cursor over a [Trace] for partial replay. Live re-execution and the
+ * playback relay are out of scope here (ampere-eval ticket 2).
+ */
+class TraceCursor(private val trace: Trace) {
+
+    /**
+     * Events `0..index` inclusive. The index is coerced into bounds, so this
+     * never throws: values `>= size` return the whole trace, and values `< 0`
+     * (or any index against an empty trace) return an empty list.
+     */
+    fun replayTo(index: Int): List<TraceEvent> =
+        trace.events.take(coerce(index) + 1)
+
+    /**
+     * A [BranchPoint] whose handoff begins at `index + 1`: [BranchPoint.replayed]
+     * is events `0..index`, and [BranchPoint.branchIndex] is the coerced
+     * `index + 1`. `branchAfter(-1)` branches from the very start;
+     * `branchAfter(size - 1)` replays everything.
+     */
+    fun branchAfter(index: Int): BranchPoint {
+        val coerced = coerce(index)
+        return BranchPoint(
+            replayed = trace.events.take(coerced + 1),
+            branchIndex = coerced + 1,
+        )
+    }
+
+    /** Coerce an index into `-1..size-1` (so `+1` lands in `0..size`); `-1` means "before the first event". */
+    private fun coerce(index: Int): Int = index.coerceIn(-1, (trace.size - 1).coerceAtLeast(-1))
+}

--- a/ampere-eval/src/commonMain/kotlin/link/socket/ampere/eval/trace/TraceRecorder.kt
+++ b/ampere-eval/src/commonMain/kotlin/link/socket/ampere/eval/trace/TraceRecorder.kt
@@ -1,0 +1,131 @@
+package link.socket.ampere.eval.trace
+
+import kotlinx.coroutines.channels.Channel
+import kotlinx.datetime.Clock
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.encodeToJsonElement
+import link.socket.ampere.agents.domain.event.Event
+import link.socket.ampere.agents.domain.event.EventRegistry
+import link.socket.ampere.agents.domain.event.EventType
+import link.socket.ampere.agents.events.api.EventHandler
+import link.socket.ampere.agents.events.bus.EventSerialBus
+import link.socket.ampere.agents.events.subscription.Subscription
+import link.socket.ampere.agents.events.utils.generateUUID
+import link.socket.ampere.data.DEFAULT_JSON
+
+/**
+ * Captures a run's `EventSerialBus` stream into a [Trace].
+ *
+ * A recorded trajectory *is* the captured bus stream — there is no parallel
+ * recording channel. The recorder subscribes to every known event type
+ * ([EventRegistry.allEventTypes], the same source of truth the live relay uses),
+ * buffers events in emission order for the recording window, and on stop builds
+ * and persists a [Trace] via [TraceService].
+ *
+ * Scoping note (see RECON-trace.md §3): the base `Event` does not carry a
+ * `runId`, so events are scoped to a run by the *recording window* (start→stop),
+ * and the supplied `runId` / `arcId` are stamped onto the resulting [Trace] as
+ * metadata rather than used to filter individual events.
+ *
+ * @param bus the `EventSerialBus` to capture from (AMPR-183 calls this `EventSerializerBus`).
+ * @param traceService persistence boundary the built [Trace] is saved through on stop.
+ */
+class TraceRecorder(
+    private val bus: EventSerialBus,
+    private val traceService: TraceService,
+    private val json: Json = DEFAULT_JSON,
+    private val eventTypes: List<EventType> = EventRegistry.allEventTypes,
+    private val clockMillis: () -> Long = { Clock.System.now().toEpochMilliseconds() },
+    private val idGenerator: () -> String = { generateUUID() },
+) {
+    /**
+     * Begin recording. Subscribes to the bus immediately; events published after
+     * this call are captured until [RecordingHandle.stop].
+     */
+    fun start(runId: String, arcId: String): RecordingHandle {
+        val buffer = Channel<Event>(Channel.UNLIMITED)
+        val agentId = "trace-recorder/$runId/${idGenerator()}"
+
+        eventTypes.forEach { eventType ->
+            bus.subscribe(
+                agentId = agentId,
+                eventType = eventType,
+                handler = EventHandler<Event, Subscription> { event, _ ->
+                    buffer.trySend(event)
+                },
+            )
+        }
+
+        return RecordingHandle(
+            traceId = idGenerator(),
+            runId = runId,
+            arcId = arcId,
+            createdAt = clockMillis(),
+            buffer = buffer,
+            subscribedTypes = eventTypes,
+            bus = bus,
+            traceService = traceService,
+            json = json,
+        )
+    }
+}
+
+/**
+ * Handle to an in-progress recording. Call [stop] exactly once to finalize.
+ */
+class RecordingHandle internal constructor(
+    private val traceId: String,
+    private val runId: String,
+    private val arcId: String,
+    private val createdAt: Long,
+    private val buffer: Channel<Event>,
+    private val subscribedTypes: List<EventType>,
+    private val bus: EventSerialBus,
+    private val traceService: TraceService,
+    private val json: Json,
+) {
+    /**
+     * Stop recording, build the [Trace] from buffered events (in emission order),
+     * persist it via the [TraceService], and return it.
+     *
+     * Returns failure if persistence fails. Idempotent only insofar as the
+     * channel is drained once; call exactly once.
+     */
+    suspend fun stop(): Result<Trace> {
+        // Stop receiving new events. NOTE: EventSerialBus.unsubscribe removes ALL
+        // handlers for a type (see RECON-trace.md §1) — fine for eval-controlled
+        // runs where the recorder is the sole subscriber.
+        subscribedTypes.forEach { bus.unsubscribe(it) }
+        buffer.close()
+
+        // Dedup by eventId: an event with parentEventTypes is dispatched to more
+        // than one subscribed type (see RECON-trace.md §1/§2), so the recorder may
+        // see it once per matching type. Keep the first arrival, preserving order.
+        val seenEventIds = mutableSetOf<String>()
+        val captured = buildList {
+            while (true) {
+                val event = buffer.tryReceive().getOrNull() ?: break
+                if (seenEventIds.add(event.eventId)) add(event)
+            }
+        }
+
+        val events = captured.mapIndexed { index, event ->
+            TraceEvent(
+                index = index,
+                timestamp = event.timestamp.toEpochMilliseconds(),
+                type = event.eventType,
+                payload = json.encodeToJsonElement(Event.serializer(), event),
+            )
+        }
+
+        val trace = Trace(
+            id = traceId,
+            runId = runId,
+            arcId = arcId,
+            createdAt = createdAt,
+            events = events,
+        )
+
+        return traceService.save(trace).map { trace }
+    }
+}

--- a/ampere-eval/src/commonMain/kotlin/link/socket/ampere/eval/trace/TraceService.kt
+++ b/ampere-eval/src/commonMain/kotlin/link/socket/ampere/eval/trace/TraceService.kt
@@ -1,0 +1,81 @@
+package link.socket.ampere.eval.trace
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+import link.socket.ampere.data.DEFAULT_JSON
+import link.socket.ampere.eval.db.EvalDatabase
+import link.socket.ampere.util.ioDispatcher
+
+/**
+ * Persistence boundary for [Trace]s, backed by the `ampere-eval` SQLDelight
+ * database. All fallible operations return [Result]; no exceptions cross this
+ * boundary.
+ *
+ * Note: AMPR-183 names this parameter `AmpereDatabase`. RECON-trace.md (AMPR-188)
+ * established that the real ampere-core handle is `link.socket.ampere.db.Database`
+ * (production schema). The eval Trace table is an eval-only concern and lives in
+ * this module's own [EvalDatabase] — keeping production code free of any
+ * dependency on `ampere-eval`, per the ticket's conventions.
+ */
+class TraceService(
+    private val db: EvalDatabase,
+    private val json: Json = DEFAULT_JSON,
+    private val dispatcher: CoroutineDispatcher = ioDispatcher,
+) {
+    private val queries get() = db.traceQueries
+
+    private val eventsSerializer = ListSerializer(TraceEvent.serializer())
+
+    /** Persist [trace] atomically (insert or overwrite by id). */
+    suspend fun save(trace: Trace): Result<Unit> = withContext(dispatcher) {
+        runCatching {
+            queries.upsertTrace(
+                id = trace.id,
+                run_id = trace.runId,
+                arc_id = trace.arcId,
+                created_at = trace.createdAt,
+                event_count = trace.size.toLong(),
+                events_json = json.encodeToString(eventsSerializer, trace.events),
+            )
+            Unit
+        }
+    }
+
+    /** Load a full [Trace] by id. Fails if no trace with [traceId] exists. */
+    suspend fun load(traceId: String): Result<Trace> = withContext(dispatcher) {
+        runCatching {
+            queries.selectById(traceId) { id, runId, arcId, createdAt, _, eventsJson ->
+                Trace(
+                    id = id,
+                    runId = runId,
+                    arcId = arcId,
+                    createdAt = createdAt,
+                    events = json.decodeFromString(eventsSerializer, eventsJson),
+                )
+            }.executeAsOneOrNull()
+                ?: error("Trace not found: $traceId")
+        }
+    }
+
+    /** List trace metadata, newest first; optionally scoped to a single [arcId]. */
+    suspend fun list(arcId: String? = null): Result<List<TraceSummary>> = withContext(dispatcher) {
+        runCatching {
+            val mapper = { id: String, runId: String, arc: String, createdAt: Long, eventCount: Long ->
+                TraceSummary(
+                    id = id,
+                    runId = runId,
+                    arcId = arc,
+                    createdAt = createdAt,
+                    eventCount = eventCount.toInt(),
+                )
+            }
+            if (arcId == null) {
+                queries.selectSummaries(mapper).executeAsList()
+            } else {
+                queries.selectSummariesByArcId(arcId, mapper).executeAsList()
+            }
+        }
+    }
+}

--- a/ampere-eval/src/commonMain/sqldelight/link/socket/ampere/eval/db/Trace.sq
+++ b/ampere-eval/src/commonMain/sqldelight/link/socket/ampere/eval/db/Trace.sq
@@ -1,0 +1,45 @@
+-- Single-row-per-trace persistence for ampere-eval.
+--
+-- v1 stores the ordered event stream as a serialized JSON blob (`events_json`)
+-- alongside queryable metadata. This is intentional over normalized per-event
+-- rows: a trace is written atomically on recording stop, and replay always
+-- reads the whole stream back, so there is no query that benefits from
+-- per-event rows in v1.
+
+CREATE TABLE trace (
+  id          TEXT NOT NULL PRIMARY KEY,
+  run_id      TEXT NOT NULL,
+  arc_id      TEXT NOT NULL,
+  created_at  INTEGER NOT NULL,
+  event_count INTEGER NOT NULL,
+  events_json TEXT NOT NULL
+);
+
+CREATE INDEX idx_trace_arc_id ON trace(arc_id);
+CREATE INDEX idx_trace_run_id ON trace(run_id);
+CREATE INDEX idx_trace_created_at ON trace(created_at);
+
+-- Persist (or overwrite) a full trace.
+upsertTrace:
+INSERT OR REPLACE INTO trace(id, run_id, arc_id, created_at, event_count, events_json)
+VALUES (?, ?, ?, ?, ?, ?);
+
+-- Load a full trace (blob included) by id.
+selectById:
+SELECT id, run_id, arc_id, created_at, event_count, events_json
+FROM trace
+WHERE id = ?
+LIMIT 1;
+
+-- Metadata-only listing (no blob) of all traces, newest first.
+selectSummaries:
+SELECT id, run_id, arc_id, created_at, event_count
+FROM trace
+ORDER BY created_at DESC;
+
+-- Metadata-only listing (no blob) filtered by arc, newest first.
+selectSummariesByArcId:
+SELECT id, run_id, arc_id, created_at, event_count
+FROM trace
+WHERE arc_id = ?
+ORDER BY created_at DESC;

--- a/ampere-eval/src/commonTest/kotlin/link/socket/ampere/eval/trace/TraceCursorTest.kt
+++ b/ampere-eval/src/commonTest/kotlin/link/socket/ampere/eval/trace/TraceCursorTest.kt
@@ -1,0 +1,81 @@
+package link.socket.ampere.eval.trace
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.JsonNull
+
+/** AMPR-183 task 1.5 validation. */
+class TraceCursorTest {
+
+    private fun trace(n: Int): Trace = Trace(
+        id = "t",
+        runId = "r",
+        arcId = "a",
+        createdAt = 0L,
+        events = (0 until n).map { TraceEvent(it, it.toLong(), "type-$it", JsonNull) },
+    )
+
+    @Test
+    fun `replayTo(n) returns exactly events 0 through n`() {
+        val cursor = TraceCursor(trace(5))
+        val result = cursor.replayTo(2)
+        assertEquals(3, result.size)
+        assertEquals(listOf(0, 1, 2), result.map { it.index })
+    }
+
+    @Test
+    fun `replayTo(size-1) returns all events`() {
+        val t = trace(5)
+        val cursor = TraceCursor(t)
+        assertEquals(t.events, cursor.replayTo(t.size - 1))
+    }
+
+    @Test
+    fun `replayTo out-of-range is coerced and never throws`() {
+        val cursor = TraceCursor(trace(5))
+        // Above range -> whole trace.
+        assertEquals(5, cursor.replayTo(100).size)
+        // Below range -> empty.
+        assertTrue(cursor.replayTo(-1).isEmpty())
+        assertTrue(cursor.replayTo(-100).isEmpty())
+    }
+
+    @Test
+    fun `replayTo on empty trace never throws`() {
+        val cursor = TraceCursor(trace(0))
+        assertTrue(cursor.replayTo(0).isEmpty())
+        assertTrue(cursor.replayTo(10).isEmpty())
+        assertTrue(cursor.replayTo(-5).isEmpty())
+    }
+
+    @Test
+    fun `branchAfter handoff begins at index plus one`() {
+        val cursor = TraceCursor(trace(5))
+        val branch = cursor.branchAfter(2)
+        assertEquals(3, branch.branchIndex)
+        assertEquals(listOf(0, 1, 2), branch.replayed.map { it.index })
+    }
+
+    @Test
+    fun `branchAfter at last index replays everything (degenerate eval case)`() {
+        val t = trace(5)
+        val branch = TraceCursor(t).branchAfter(t.size - 1)
+        assertEquals(5, branch.branchIndex)
+        assertEquals(t.events, branch.replayed)
+    }
+
+    @Test
+    fun `branchAfter(-1) branches from the start`() {
+        val branch = TraceCursor(trace(5)).branchAfter(-1)
+        assertEquals(0, branch.branchIndex)
+        assertTrue(branch.replayed.isEmpty())
+    }
+
+    @Test
+    fun `branchAfter out-of-range is coerced`() {
+        val branch = TraceCursor(trace(5)).branchAfter(100)
+        assertEquals(5, branch.branchIndex)
+        assertEquals(5, branch.replayed.size)
+    }
+}

--- a/ampere-eval/src/commonTest/kotlin/link/socket/ampere/eval/trace/TraceSerializationTest.kt
+++ b/ampere-eval/src/commonTest/kotlin/link/socket/ampere/eval/trace/TraceSerializationTest.kt
@@ -1,0 +1,50 @@
+package link.socket.ampere.eval.trace
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import link.socket.ampere.data.DEFAULT_JSON
+
+/** AMPR-183 task 1.1 validation. */
+class TraceSerializationTest {
+
+    private val json = DEFAULT_JSON
+
+    @Test
+    fun `round-trips a 3-event trace to identical content`() {
+        val original = Trace(
+            id = "trace-1",
+            runId = "run-1",
+            arcId = "arc-1",
+            createdAt = 1_000L,
+            events = listOf(
+                TraceEvent(
+                    index = 0,
+                    timestamp = 10L,
+                    type = "TaskCreated",
+                    payload = buildJsonObject { put("taskId", "T-1") },
+                ),
+                TraceEvent(
+                    index = 1,
+                    timestamp = 20L,
+                    type = "QuestionRaised",
+                    payload = buildJsonObject { put("questionText", "why?") },
+                ),
+                TraceEvent(
+                    index = 2,
+                    timestamp = 30L,
+                    type = "CodeSubmitted",
+                    payload = buildJsonObject { put("filePath", "Main.kt") },
+                ),
+            ),
+        )
+
+        val encoded = json.encodeToString(Trace.serializer(), original)
+        val decoded = json.decodeFromString(Trace.serializer(), encoded)
+
+        assertEquals(original, decoded)
+        assertEquals(3, decoded.size)
+        assertEquals(original.events, decoded.events)
+    }
+}

--- a/ampere-eval/src/jvmTest/kotlin/link/socket/ampere/eval/trace/TraceRecorderTest.kt
+++ b/ampere-eval/src/jvmTest/kotlin/link/socket/ampere/eval/trace/TraceRecorderTest.kt
@@ -1,0 +1,94 @@
+package link.socket.ampere.eval.trace
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import link.socket.ampere.agents.domain.Urgency
+import link.socket.ampere.agents.domain.event.Event
+import link.socket.ampere.agents.domain.event.EventSource
+import link.socket.ampere.agents.events.bus.EventSerialBus
+import link.socket.ampere.data.DEFAULT_JSON
+import link.socket.ampere.eval.db.EvalDatabase
+
+/** AMPR-183 task 1.4 validation + record -> persist -> load -> replay round-trip. */
+@OptIn(ExperimentalCoroutinesApi::class)
+class TraceRecorderTest {
+
+    // UnconfinedTestDispatcher makes the bus dispatch handlers inline at publish
+    // time, so captured order is deterministic (same pattern as ArcTraceProjectionTest).
+    private val scope = TestScope(UnconfinedTestDispatcher())
+
+    private lateinit var driver: JdbcSqliteDriver
+    private lateinit var bus: EventSerialBus
+    private lateinit var service: TraceService
+    private lateinit var recorder: TraceRecorder
+
+    @BeforeTest
+    fun setUp() {
+        driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        EvalDatabase.Schema.create(driver)
+        bus = EventSerialBus(scope)
+        service = TraceService(EvalDatabase(driver))
+        recorder = TraceRecorder(bus, service)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        driver.close()
+    }
+
+    private val source = EventSource.Agent("agent-1")
+
+    private fun events(n: Int): List<Event> = (1..n).map { i ->
+        Event.TaskCreated(
+            eventId = "e$i",
+            urgency = Urgency.LOW,
+            timestamp = Instant.fromEpochMilliseconds(i.toLong()),
+            eventSource = source,
+            taskId = "T-$i",
+            description = "task $i",
+            assignedTo = null,
+        )
+    }
+
+    @Test
+    fun `records exactly N events in emission order`() = runTest {
+        val handle = recorder.start(runId = "run-1", arcId = "arc-1")
+        val emitted = events(5)
+        emitted.forEach { bus.publish(it) }
+
+        val trace = handle.stop().getOrThrow()
+
+        assertEquals(5, trace.size)
+        assertEquals(emitted.map { it.eventId }, trace.events.map { it.payload.eventId() })
+        assertEquals(listOf(0, 1, 2, 3, 4), trace.events.map { it.index })
+    }
+
+    @Test
+    fun `round-trip record persist load replay yields identical ordered sequence`() = runTest {
+        val handle = recorder.start(runId = "run-2", arcId = "arc-2")
+        val emitted = events(4)
+        emitted.forEach { bus.publish(it) }
+
+        val recorded = handle.stop().getOrThrow()
+
+        // Persisted by stop(); load it back.
+        val loaded = service.load(recorded.id).getOrThrow()
+        assertEquals(recorded, loaded)
+
+        // Replay to the end yields the identical ordered sequence.
+        val replayed = TraceCursor(loaded).replayTo(loaded.size - 1)
+        assertEquals(recorded.events, replayed)
+        assertEquals(emitted.map { it.eventId }, replayed.map { it.payload.eventId() })
+    }
+
+    private fun kotlinx.serialization.json.JsonElement.eventId(): String =
+        DEFAULT_JSON.decodeFromJsonElement(Event.serializer(), this).eventId
+}

--- a/ampere-eval/src/jvmTest/kotlin/link/socket/ampere/eval/trace/TraceServiceTest.kt
+++ b/ampere-eval/src/jvmTest/kotlin/link/socket/ampere/eval/trace/TraceServiceTest.kt
@@ -1,0 +1,91 @@
+package link.socket.ampere.eval.trace
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import kotlinx.serialization.json.encodeToJsonElement
+import link.socket.ampere.agents.domain.Urgency
+import link.socket.ampere.agents.domain.event.Event
+import link.socket.ampere.agents.domain.event.EventSource
+import link.socket.ampere.data.DEFAULT_JSON
+import link.socket.ampere.eval.db.EvalDatabase
+
+/** AMPR-183 task 1.3 validation. */
+class TraceServiceTest {
+
+    private lateinit var driver: JdbcSqliteDriver
+    private lateinit var service: TraceService
+
+    @BeforeTest
+    fun setUp() {
+        driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        EvalDatabase.Schema.create(driver)
+        service = TraceService(EvalDatabase(driver))
+    }
+
+    @AfterTest
+    fun tearDown() {
+        driver.close()
+    }
+
+    private fun sampleTrace(id: String, arcId: String): Trace {
+        val source = EventSource.Agent("agent-1")
+        val events = listOf<Event>(
+            Event.TaskCreated("e1", Urgency.LOW, Instant.fromEpochMilliseconds(10), source, "T-1", "do it", null),
+            Event.QuestionRaised("e2", Urgency.HIGH, Instant.fromEpochMilliseconds(20), source, "why?", "ctx"),
+        ).mapIndexed { index, event ->
+            TraceEvent(
+                index = index,
+                timestamp = event.timestamp.toEpochMilliseconds(),
+                type = event.eventType,
+                payload = DEFAULT_JSON.encodeToJsonElement(Event.serializer(), event),
+            )
+        }
+        return Trace(id = id, runId = "run-$id", arcId = arcId, createdAt = 100L, events = events)
+    }
+
+    @Test
+    fun `save then load returns byte-identical events`() = runTest {
+        val trace = sampleTrace("trace-1", "arc-1")
+
+        service.save(trace).getOrThrow()
+        val loaded = service.load("trace-1").getOrThrow()
+
+        assertEquals(trace, loaded)
+        assertEquals(trace.events, loaded.events)
+        // Payloads decode back to the original events.
+        val decoded = loaded.events.map { DEFAULT_JSON.decodeFromJsonElement(Event.serializer(), it.payload) }
+        assertEquals("e1", decoded[0].eventId)
+        assertEquals("e2", decoded[1].eventId)
+    }
+
+    @Test
+    fun `load fails when the trace is absent`() = runTest {
+        val result = service.load("does-not-exist")
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun `list returns summaries and filters by arcId`() = runTest {
+        service.save(sampleTrace("trace-1", "arc-a")).getOrThrow()
+        service.save(sampleTrace("trace-2", "arc-a")).getOrThrow()
+        service.save(sampleTrace("trace-3", "arc-b")).getOrThrow()
+
+        val all = service.list().getOrThrow()
+        assertEquals(3, all.size)
+        assertEquals(2, all.first { it.id == "trace-1" }.eventCount)
+
+        val arcA = service.list("arc-a").getOrThrow()
+        assertEquals(2, arcA.size)
+        assertTrue(arcA.all { it.arcId == "arc-a" })
+
+        val arcB = service.list("arc-b").getOrThrow()
+        assertEquals(1, arcB.size)
+        assertEquals("trace-3", arcB.single().id)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,6 +6,7 @@ include(":ampere-compose")
 include(":ampere-desktop")
 include(":ampere-cli")
 include(":ampere-phosphor")
+include(":ampere-eval")
 
 pluginManagement {
     repositories {


### PR DESCRIPTION
Adds the `ampere-eval` KMP module — the measurement substrate for the eval set: `Trace`/`TraceEvent` value types, a `TraceRecorder` that captures an `EventSerialBus` run stream, a SQLDelight-backed `TraceService` (save/load/list) over the module's own `EvalDatabase`, and a `TraceCursor` for partial replay-to-index-N plus a branch-point signal; the module is also registered in `settings.gradle.kts`.

Built on the AMPR-188 recon (#536): this corrects the assumed package root to `link.socket.ampere.*`, uses the real `EventSerialBus` (not the docs' `EventSerializerBus`), and keeps the trace schema in eval's own database so production code never depends on `ampere-eval`. 14 tests pass — including a record → persist → load → replay round-trip — and `:ampere-eval:jvmTest`, common-metadata compile, and ktlint are all green.

Closes #530.

🤖 Generated with [Claude Code](https://claude.com/claude-code)