### PR TITLE
AMPR-184 #531: PlaybackRelay — deterministic model replay

### DIFF
--- a/ampere-eval/src/commonMain/kotlin/link/socket/ampere/eval/relay/PlaybackRelay.kt
+++ b/ampere-eval/src/commonMain/kotlin/link/socket/ampere/eval/relay/PlaybackRelay.kt
@@ -1,0 +1,173 @@
+package link.socket.ampere.eval.relay
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.json.Json
+import link.socket.ampere.agents.domain.routing.CognitiveRelay
+import link.socket.ampere.agents.domain.routing.RelayConfig
+import link.socket.ampere.agents.domain.routing.RoutingContext
+import link.socket.ampere.agents.domain.routing.RoutingResolution
+import link.socket.ampere.data.DEFAULT_JSON
+import link.socket.ampere.domain.ai.configuration.AIConfiguration
+import link.socket.ampere.eval.trace.Trace
+import link.socket.ampere.trace.WattCost
+
+/**
+ * What a [PlaybackRelay] does when an Arc makes a model call for which the
+ * [Trace] holds no recording (the Arc has *diverged* from the recording).
+ *
+ * Resolves the AMPR-184 OPEN DECISION (`miss-as-failure` vs. `miss-as-low-Reading`)
+ * in favour of **miss-as-failure**: a strict miss is a hard, typed [PlaybackMiss]
+ * that turns divergence into a red build. Grading divergence as a low score is a
+ * reward-function concern (RFT/GRPO) that belongs to a later layer, not to the
+ * relay — keeping this seam a clean boolean (replayed exactly, or diverged).
+ */
+sealed interface MissPolicy {
+    /** Strict, eval mode: a miss yields `Result.failure(`[PlaybackMiss]`)`. */
+    data object Error : MissPolicy
+
+    /** Rewind handoff: a miss is routed to the live delegate (failure if none). */
+    data object Delegate : MissPolicy
+}
+
+/**
+ * Typed failure signalling that an Arc diverged from its recording: the
+ * [callIndex]-th model call had no recorded counterpart under [MissPolicy.Error].
+ *
+ * Carried as a `Result.failure` value by [PlaybackRelay.replay] (the Result
+ * boundary) and thrown by the `CognitiveRelay` methods so the divergence
+ * propagates up the call path as a red build.
+ */
+class PlaybackMiss(
+    val callIndex: Int,
+    val recordedCallCount: Int,
+) : Exception(
+    "PlaybackRelay diverged: model call #$callIndex has no recorded response " +
+        "(trace recorded $recordedCallCount model call(s)).",
+)
+
+/**
+ * A relay that replays a [Trace]'s recorded model routing in order, behind the
+ * exact [CognitiveRelay] interface (AMPR-184; interface per RECON-relay §1).
+ *
+ * The same class expresses both eval and rewind-and-correct:
+ * - **Eval** (defaults): no delegate, [MissPolicy.Error], `branchIndex` past the
+ *   end — every model call replays its recording, and a missing recording is a
+ *   [PlaybackMiss] (divergence is itself a finding).
+ * - **Rewind** : a [liveDelegate] plus a [branchIndex] of `k` — the first `k`
+ *   calls replay, then call `k` onward is handed to the live delegate.
+ *
+ * ### What is (and isn't) replayed
+ * `CognitiveRelay` is a **routing-only** seam: it selects an [AIConfiguration];
+ * it never sees the prompt or the completion (RECON-relay Finding A), and the
+ * recorded events carry no content (Finding B). This relay therefore replays the
+ * recorded **routing decision in call order** with `reason = "playback"` and a
+ * zero-Watt guarantee; it does **not** substitute response *content*. Because the
+ * recorded provider/model are plain ids and reconstructing a live [AIConfiguration]
+ * from them needs a provider registry the eval module deliberately does not depend
+ * on, a replay hit returns the supplied `fallbackConfiguration` (the recorded
+ * selection is available for inspection via [recordedCallAt]). Content-faithful
+ * replay belongs to the `UpstreamLlmClient` seam in a later ticket.
+ *
+ * ### Watts
+ * A replayed call performs **no live provider invocation**, so it consumes no
+ * tokens and therefore zero Watts (RECON-relay §2.4). See [replayedWattCost].
+ *
+ * @param trace the recorded run to replay.
+ * @param missPolicy what to do when the Arc makes more (or different) calls than
+ *   were recorded. Defaults to strict [MissPolicy.Error].
+ * @param liveDelegate the relay used for branched/delegated calls. Required for
+ *   [MissPolicy.Delegate] and for any call at/after [branchIndex]; a `null`
+ *   delegate in those cases yields a `Result.failure`.
+ * @param branchIndex the **call** index at which replay stops and the delegate
+ *   takes over: calls `0 until branchIndex` replay, `branchIndex` onward delegate.
+ *   Defaults to `trace.size` — an event count that is always ≥ the model-call
+ *   count, i.e. "never branch" (the degenerate eval case, mirroring
+ *   `TraceCursor.branchAfter(size - 1)`).
+ */
+class PlaybackRelay(
+    private val trace: Trace,
+    private val missPolicy: MissPolicy = MissPolicy.Error,
+    private val liveDelegate: CognitiveRelay? = null,
+    private val branchIndex: Int = trace.size,
+    private val json: Json = DEFAULT_JSON,
+) : CognitiveRelay {
+
+    private val recordedCalls: List<RecordedModelCall> = trace.modelCalls(json)
+    private val mutex = Mutex()
+    private var nextCallIndex: Int = 0
+
+    /** The ordered recorded model calls this relay replays. */
+    val recordedCallCount: Int get() = recordedCalls.size
+
+    /**
+     * The Watt cost charged for a replayed call: **zero**. Replayed calls make no
+     * live provider invocation, so they consume no tokens (RECON-relay §2.4).
+     * Exposed so callers/tests can assert the zero-Watt contract explicitly.
+     */
+    val replayedWattCost: WattCost = WattCost()
+
+    override val config: RelayConfig = RelayConfig()
+
+    override suspend fun resolve(
+        context: RoutingContext,
+        fallbackConfiguration: AIConfiguration,
+    ): AIConfiguration = resolveWithMetadata(context, fallbackConfiguration).configuration
+
+    override suspend fun resolveWithMetadata(
+        context: RoutingContext,
+        fallbackConfiguration: AIConfiguration,
+    ): RoutingResolution = replay(context, fallbackConfiguration).getOrThrow()
+
+    /**
+     * The Result-boundary core of the relay (RECON-relay: "Result boundaries").
+     * For the next call index `i`:
+     * - `i >= branchIndex` → **branch**: route to [liveDelegate] (failure if none).
+     * - `i < recordedCallCount` → **replay hit**: the recorded selection, zero Watts.
+     * - otherwise (`i` within the replay window but past the recordings) → **miss**:
+     *   [MissPolicy.Error] → `failure(`[PlaybackMiss]`)`; [MissPolicy.Delegate] →
+     *   route to [liveDelegate] (failure if none).
+     *
+     * The branch check precedes the replay check so a `branchIndex` inside the
+     * recorded range still hands off live (rewind-and-correct, AMPR-184 task 2.4).
+     */
+    suspend fun replay(
+        context: RoutingContext,
+        fallbackConfiguration: AIConfiguration,
+    ): Result<RoutingResolution> {
+        val index = mutex.withLock { nextCallIndex++ }
+        return when {
+            index >= branchIndex -> delegate(context, fallbackConfiguration, index)
+            index < recordedCalls.size -> Result.success(
+                RoutingResolution(configuration = fallbackConfiguration, reason = PLAYBACK_REASON),
+            )
+            missPolicy == MissPolicy.Delegate -> delegate(context, fallbackConfiguration, index)
+            else -> Result.failure(PlaybackMiss(index, recordedCalls.size))
+        }
+    }
+
+    /** Recorded model call at [index] in replay order, or `null` if out of range. */
+    fun recordedCallAt(index: Int): RecordedModelCall? = recordedCalls.getOrNull(index)
+
+    override suspend fun updateConfig(newConfig: RelayConfig) {
+        // No-op: playback selection is driven by the recorded Trace, not routing rules.
+    }
+
+    private suspend fun delegate(
+        context: RoutingContext,
+        fallbackConfiguration: AIConfiguration,
+        index: Int,
+    ): Result<RoutingResolution> {
+        val delegate = liveDelegate ?: return Result.failure(
+            IllegalStateException(
+                "PlaybackRelay call #$index must be served live, but no liveDelegate was provided.",
+            ),
+        )
+        return Result.success(delegate.resolveWithMetadata(context, fallbackConfiguration))
+    }
+
+    companion object {
+        /** The `RoutingResolution.reason` stamped on every replayed selection. */
+        const val PLAYBACK_REASON: String = "playback"
+    }
+}

--- a/ampere-eval/src/commonMain/kotlin/link/socket/ampere/eval/relay/RecordedModelCall.kt
+++ b/ampere-eval/src/commonMain/kotlin/link/socket/ampere/eval/relay/RecordedModelCall.kt
@@ -1,0 +1,80 @@
+package link.socket.ampere.eval.relay
+
+import kotlinx.serialization.json.Json
+import link.socket.ampere.agents.domain.event.Event
+import link.socket.ampere.agents.domain.event.ProviderCallCompletedEvent
+import link.socket.ampere.agents.domain.event.ProviderCallStartedEvent
+import link.socket.ampere.api.model.TokenUsage
+import link.socket.ampere.data.DEFAULT_JSON
+import link.socket.ampere.domain.ai.provider.ProviderId
+import link.socket.ampere.eval.trace.Trace
+
+/**
+ * One recorded model call, paired from a [Trace]'s telemetry events.
+ *
+ * Per RECON-relay §3.4 (AMPR-189), the model-call events are **metadata only**:
+ * they carry provider, model, routing reason, token usage, latency and success —
+ * but **not** the prompt or the completion text. A `RecordedModelCall` therefore
+ * pins the recorded *routing decision* and its *cost metadata*; deterministic
+ * replay of response *content* is out of scope for the `CognitiveRelay` seam
+ * (RECON-relay Findings A & B) and is left to the `UpstreamLlmClient` seam in a
+ * later ticket.
+ *
+ * @property started the `ProviderCallStartedEvent` for this call, or `null` when
+ *   the trace recorded a completion without a matching start (RECON-relay §3.3
+ *   tolerates a missing start; only [ProviderCallStartedEvent.routingReason] is
+ *   then unavailable).
+ * @property completed the `ProviderCallCompletedEvent` for this call (always
+ *   present — pairing is keyed off completions).
+ */
+data class RecordedModelCall(
+    val started: ProviderCallStartedEvent?,
+    val completed: ProviderCallCompletedEvent,
+) {
+    /** Provider that served the recorded call. */
+    val providerId: ProviderId get() = completed.providerId
+
+    /** Model that served the recorded call. */
+    val modelId: String get() = completed.modelId
+
+    /** Recorded token accounting (the sole input to the Watt formula, RECON-relay §2.3). */
+    val usage: TokenUsage get() = completed.usage
+
+    /** Whether the recorded call succeeded. */
+    val success: Boolean get() = completed.success
+
+    /** The recorded routing reason, or `null` if the start event was not recorded. */
+    val routingReason: String? get() = started?.routingReason
+}
+
+/**
+ * Maps this trace's ordered model-call events into an ordered list of
+ * `(request, response)` pairs (AMPR-184 task 2.1).
+ *
+ * The pairing replicates `ArcTraceProjection.buildModelInvocations` (RECON-relay
+ * §3.3) **verbatim**: each `ProviderCallCompletedEvent` is matched to the first
+ * still-unconsumed `ProviderCallStartedEvent` satisfying the 6-part correlation
+ * key (`timestamp <=`, `workflowId`, `agentId`, `providerId`, `modelId`,
+ * `cognitivePhase`), and that start is then removed so it pairs at most once.
+ * There is no correlation id — ordering is load-bearing (RECON-relay Guideline 5).
+ *
+ * Non-model events are ignored. Calls are enumerated in completion order, which
+ * is call order for the sequential, deterministic runs evals replay.
+ */
+fun Trace.modelCalls(json: Json = DEFAULT_JSON): List<RecordedModelCall> {
+    val decoded = events.map { json.decodeFromJsonElement(Event.serializer(), it.payload) }
+    val starts = decoded.filterIsInstance<ProviderCallStartedEvent>().toMutableList()
+
+    return decoded.filterIsInstance<ProviderCallCompletedEvent>().map { completed ->
+        val start = starts.firstOrNull { candidate ->
+            candidate.timestamp <= completed.timestamp &&
+                candidate.workflowId == completed.workflowId &&
+                candidate.agentId == completed.agentId &&
+                candidate.providerId == completed.providerId &&
+                candidate.modelId == completed.modelId &&
+                candidate.cognitivePhase == completed.cognitivePhase
+        }
+        if (start != null) starts.remove(start)
+        RecordedModelCall(started = start, completed = completed)
+    }
+}

--- a/ampere-eval/src/commonTest/kotlin/link/socket/ampere/eval/relay/PlaybackRelayTest.kt
+++ b/ampere-eval/src/commonTest/kotlin/link/socket/ampere/eval/relay/PlaybackRelayTest.kt
@@ -1,0 +1,282 @@
+package link.socket.ampere.eval.relay
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import kotlinx.serialization.json.encodeToJsonElement
+import link.socket.ampere.agents.domain.Urgency
+import link.socket.ampere.agents.domain.cognition.sparks.CognitivePhase
+import link.socket.ampere.agents.domain.event.Event
+import link.socket.ampere.agents.domain.event.EventSource
+import link.socket.ampere.agents.domain.event.ProviderCallCompletedEvent
+import link.socket.ampere.agents.domain.event.ProviderCallStartedEvent
+import link.socket.ampere.agents.domain.routing.CognitiveRelay
+import link.socket.ampere.agents.domain.routing.RelayConfig
+import link.socket.ampere.agents.domain.routing.RoutingContext
+import link.socket.ampere.agents.domain.routing.RoutingResolution
+import link.socket.ampere.api.model.TokenUsage
+import link.socket.ampere.data.DEFAULT_JSON
+import link.socket.ampere.domain.ai.configuration.AIConfiguration
+import link.socket.ampere.domain.ai.configuration.AIConfiguration_Default
+import link.socket.ampere.domain.ai.model.AIModel_Claude
+import link.socket.ampere.domain.ai.provider.AIProvider_Anthropic
+import link.socket.ampere.eval.trace.Trace
+import link.socket.ampere.eval.trace.TraceEvent
+import link.socket.ampere.trace.WattCost
+
+/** AMPR-184 tasks 2.1–2.4 validation. */
+class PlaybackRelayTest {
+
+    private val source = EventSource.Agent("agent-1")
+    private val fallback: AIConfiguration =
+        AIConfiguration_Default(provider = AIProvider_Anthropic, model = AIModel_Claude.Sonnet_4)
+    private val ctx = RoutingContext(phase = CognitivePhase.PLAN, agentId = "agent-1", workflowId = "wf")
+
+    // region — task 2.1: extraction
+
+    @Test
+    fun `modelCalls enumerates pairs in call order and ignores non-model events`() {
+        val trace = traceOf(
+            taskCreated(ts = 0),
+            startedCall(model = "m1", reason = "r1", ts = 1),
+            completedCall(model = "m1", ts = 2),
+            questionRaised(ts = 3),
+            startedCall(model = "m2", reason = "r2", ts = 4),
+            completedCall(model = "m2", ts = 5),
+        )
+
+        val calls = trace.modelCalls()
+
+        assertEquals(2, calls.size)
+        assertEquals(listOf("m1", "m2"), calls.map { it.modelId })
+        assertEquals(listOf("r1", "r2"), calls.map { it.routingReason })
+    }
+
+    @Test
+    fun `modelCalls tolerates a completion with no recorded start`() {
+        val trace = traceOf(completedCall(model = "m1", ts = 2))
+
+        val calls = trace.modelCalls()
+
+        assertEquals(1, calls.size)
+        assertNull(calls[0].started)
+        assertNull(calls[0].routingReason)
+        assertEquals("m1", calls[0].modelId)
+    }
+
+    // endregion
+
+    // region — task 2.2: ordered replay, zero Watts
+
+    @Test
+    fun `replays recorded selections in order with playback reason`() = runTest {
+        val relay = PlaybackRelay(traceOfCalls(2))
+
+        val first = relay.resolveWithMetadata(ctx, fallback)
+        val second = relay.resolveWithMetadata(ctx, fallback)
+
+        assertEquals(PlaybackRelay.PLAYBACK_REASON, first.reason)
+        assertEquals(PlaybackRelay.PLAYBACK_REASON, second.reason)
+        assertEquals(fallback, first.configuration)
+        assertEquals(2, relay.recordedCallCount)
+        // Recorded selection is preserved in call order for inspection.
+        assertEquals("m1", relay.recordedCallAt(0)?.modelId)
+        assertEquals("m2", relay.recordedCallAt(1)?.modelId)
+    }
+
+    @Test
+    fun `replayed calls charge zero Watts and never touch a delegate`() = runTest {
+        val spy = SpyRelay()
+        // branchIndex defaults past the end, so both calls are pure replays.
+        val relay = PlaybackRelay(traceOfCalls(2), liveDelegate = spy)
+
+        relay.resolveWithMetadata(ctx, fallback)
+        relay.resolveWithMetadata(ctx, fallback)
+
+        assertEquals(WattCost(), relay.replayedWattCost)
+        assertEquals(0, spy.calls)
+    }
+
+    // endregion
+
+    // region — task 2.3: miss policy
+
+    @Test
+    fun `strict miss returns a typed PlaybackMiss`() = runTest {
+        val relay = PlaybackRelay(traceOfCalls(1), missPolicy = MissPolicy.Error)
+
+        assertEquals(PlaybackRelay.PLAYBACK_REASON, relay.replay(ctx, fallback).getOrThrow().reason)
+
+        val miss = relay.replay(ctx, fallback)
+        assertTrue(miss.isFailure)
+        val error = miss.exceptionOrNull()
+        assertTrue(error is PlaybackMiss)
+        assertEquals(1, error.callIndex)
+        assertEquals(1, error.recordedCallCount)
+    }
+
+    @Test
+    fun `strict miss throws PlaybackMiss through the CognitiveRelay interface`() = runTest {
+        val relay = PlaybackRelay(traceOfCalls(1), missPolicy = MissPolicy.Error)
+
+        relay.resolveWithMetadata(ctx, fallback) // call 0 replays
+        assertFailsWith<PlaybackMiss> { relay.resolveWithMetadata(ctx, fallback) } // call 1 diverges
+    }
+
+    @Test
+    fun `delegate miss policy routes the missing call live`() = runTest {
+        val spy = SpyRelay(reason = "live")
+        val relay = PlaybackRelay(traceOfCalls(1), missPolicy = MissPolicy.Delegate, liveDelegate = spy)
+
+        val replayed = relay.resolveWithMetadata(ctx, fallback)
+        val delegated = relay.resolveWithMetadata(ctx, fallback)
+
+        assertEquals(PlaybackRelay.PLAYBACK_REASON, replayed.reason)
+        assertEquals("live", delegated.reason)
+        assertEquals(1, spy.calls)
+    }
+
+    @Test
+    fun `delegate miss policy without a delegate fails`() = runTest {
+        val relay = PlaybackRelay(traceOfCalls(1), missPolicy = MissPolicy.Delegate, liveDelegate = null)
+
+        relay.replay(ctx, fallback).getOrThrow() // call 0 replays
+        val result = relay.replay(ctx, fallback) // call 1 has no delegate to route to
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is IllegalStateException)
+    }
+
+    // endregion
+
+    // region — task 2.4: branch wiring
+
+    @Test
+    fun `branchIndex replays the first k calls then delegates`() = runTest {
+        val spy = SpyRelay(reason = "live")
+        val relay = PlaybackRelay(traceOfCalls(3), liveDelegate = spy, branchIndex = 2)
+
+        val reasons = listOf(
+            relay.resolveWithMetadata(ctx, fallback).reason, // 0 -> replay
+            relay.resolveWithMetadata(ctx, fallback).reason, // 1 -> replay
+            relay.resolveWithMetadata(ctx, fallback).reason, // 2 -> delegate
+        )
+
+        assertEquals(listOf(PlaybackRelay.PLAYBACK_REASON, PlaybackRelay.PLAYBACK_REASON, "live"), reasons)
+        assertEquals(1, spy.calls)
+    }
+
+    @Test
+    fun `branch without a delegate fails`() = runTest {
+        val relay = PlaybackRelay(traceOfCalls(2), branchIndex = 1, liveDelegate = null)
+
+        relay.replay(ctx, fallback).getOrThrow() // call 0 replays
+        val result = relay.replay(ctx, fallback) // call 1 branches, but no delegate
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is IllegalStateException)
+    }
+
+    // endregion
+
+    // region — fixtures
+
+    /** Counts invocations and stamps a fixed reason; stands in for a live relay. */
+    private class SpyRelay(private val reason: String = "live") : CognitiveRelay {
+        var calls: Int = 0
+            private set
+
+        override val config: RelayConfig = RelayConfig()
+
+        override suspend fun resolve(
+            context: RoutingContext,
+            fallbackConfiguration: AIConfiguration,
+        ): AIConfiguration = resolveWithMetadata(context, fallbackConfiguration).configuration
+
+        override suspend fun resolveWithMetadata(
+            context: RoutingContext,
+            fallbackConfiguration: AIConfiguration,
+        ): RoutingResolution {
+            calls++
+            return RoutingResolution(configuration = fallbackConfiguration, reason = reason)
+        }
+
+        override suspend fun updateConfig(newConfig: RelayConfig) = Unit
+    }
+
+    private fun traceOf(vararg events: Event): Trace {
+        val traceEvents = events.mapIndexed { i, event ->
+            TraceEvent(
+                index = i,
+                timestamp = event.timestamp.toEpochMilliseconds(),
+                type = event.eventType,
+                payload = DEFAULT_JSON.encodeToJsonElement(Event.serializer(), event),
+            )
+        }
+        return Trace(id = "t", runId = "r", arcId = "a", createdAt = 0L, events = traceEvents)
+    }
+
+    /** A trace of [n] sequential model calls, models `m1..mn`, reasons `r1..rn`. */
+    private fun traceOfCalls(n: Int): Trace = traceOf(
+        *(0 until n).flatMap { i ->
+            val model = "m${i + 1}"
+            listOf(
+                startedCall(model = model, reason = "r${i + 1}", ts = (2 * i + 1).toLong()),
+                completedCall(model = model, ts = (2 * i + 2).toLong()),
+            )
+        }.toTypedArray(),
+    )
+
+    private fun startedCall(model: String, reason: String, ts: Long): ProviderCallStartedEvent =
+        ProviderCallStartedEvent(
+            eventId = "start-$model-$ts",
+            timestamp = Instant.fromEpochMilliseconds(ts),
+            eventSource = source,
+            workflowId = "wf",
+            agentId = "agent-1",
+            cognitivePhase = CognitivePhase.PLAN,
+            providerId = "anthropic",
+            modelId = model,
+            routingReason = reason,
+        )
+
+    private fun completedCall(model: String, ts: Long): ProviderCallCompletedEvent =
+        ProviderCallCompletedEvent(
+            eventId = "done-$model-$ts",
+            timestamp = Instant.fromEpochMilliseconds(ts),
+            eventSource = source,
+            workflowId = "wf",
+            agentId = "agent-1",
+            cognitivePhase = CognitivePhase.PLAN,
+            providerId = "anthropic",
+            modelId = model,
+            usage = TokenUsage(),
+            latencyMs = 10,
+            success = true,
+        )
+
+    private fun taskCreated(ts: Long): Event = Event.TaskCreated(
+        eventId = "task-$ts",
+        urgency = Urgency.LOW,
+        timestamp = Instant.fromEpochMilliseconds(ts),
+        eventSource = source,
+        taskId = "T-$ts",
+        description = "task",
+        assignedTo = null,
+    )
+
+    private fun questionRaised(ts: Long): Event = Event.QuestionRaised(
+        eventId = "q-$ts",
+        urgency = Urgency.LOW,
+        timestamp = Instant.fromEpochMilliseconds(ts),
+        eventSource = source,
+        questionText = "why?",
+        context = "",
+    )
+
+    // endregion
+}


### PR DESCRIPTION
Adds `PlaybackRelay : CognitiveRelay` to the `ampere-eval` module: it replays a `Trace`'s recorded model routing in call order (`reason="playback"`), charges zero Watts for replays, and applies a configurable `MissPolicy` plus a `branchIndex` for rewind-and-correct. `RecordedModelCall` / `Trace.modelCalls()` pairs the trace's model-call events into ordered `(request, response)` pairs, replicating the AMPR-189 RECON §3.3 pairing (6-part key, first-match-consumed, chronological) and ignoring non-model events. The relay exposes a `Result`-boundary `replay()` core — `MissPolicy.Error` yields a typed `PlaybackMiss` (strict, eval) and `MissPolicy.Delegate` hands off to a live delegate — while the `CognitiveRelay` methods adapt it via `getOrThrow()` so divergence surfaces as a red build. Per the ticket's OPEN DECISION this resolves to miss-as-failure, and per RECON Findings A/B the relay replays the recorded routing decision only (not response content, which stays at the `UpstreamLlmClient` seam for ampere-eval ticket 4); zero Watts holds by construction since replays make no live call. Verified by 10 commonTest cases plus a clean `ktlintFormat` and a successful common (iOS) metadata compile.

Closes #531

🤖 Generated with [Claude Code](https://claude.com/claude-code)