### PR TITLE
AMPR-209 #560: T6 — LocalUpstreamLlmClient + injected LocalInferenceEngine

### DIFF
--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/reasoning/AgentLLMService.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/reasoning/AgentLLMService.kt
@@ -84,6 +84,13 @@ class AgentLLMService(
      * for direct-construction tests that don't want to round-trip through
      * the config.
      *
+     * Local, on-device execution flows through this same seam: a
+     * [link.socket.ampere.llm.DispatchingUpstreamLlmClient] supplied here (or on
+     * the config) routes a relay-selected local configuration to a
+     * [link.socket.ampere.llm.LocalUpstreamLlmClient], or to the bundled cloud
+     * path otherwise — so [call] is unchanged whether the resolved provider is
+     * local or cloud.
+     *
      * Note: a custom [link.socket.ampere.domain.llm.LlmProvider] configured
      * on [AgentConfiguration] short-circuits before this client runs.
      */

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/local/LocalCapacity.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/local/LocalCapacity.kt
@@ -1,0 +1,28 @@
+package link.socket.ampere.agents.domain.routing.local
+
+import kotlinx.serialization.Serializable
+
+/**
+ * A snapshot of what an on-device [LocalInferenceEngine] can serve right now.
+ *
+ * Returned by [LocalInferenceEngine.probe] so callers can decide whether a
+ * device-gated provider is currently usable without attempting a generation.
+ * Kept deliberately small and SDK-free: the only thing routing needs today is
+ * whether the engine is [available] at all; the optional fields are advisory
+ * hints a richer availability gate (T4) can read.
+ *
+ * @property available Whether the engine can serve a generation right now.
+ * @property modelId Identifier of the loaded on-device model, if any.
+ * @property maxContextTokens Largest prompt the engine can accept, if known.
+ */
+@Serializable
+data class LocalCapacity(
+    val available: Boolean,
+    val modelId: String? = null,
+    val maxContextTokens: Int? = null,
+) {
+    companion object {
+        /** Convenience for an engine that cannot currently serve generations. */
+        val Unavailable: LocalCapacity = LocalCapacity(available = false)
+    }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/local/LocalInferenceEngine.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/local/LocalInferenceEngine.kt
@@ -1,0 +1,52 @@
+package link.socket.ampere.agents.domain.routing.local
+
+/**
+ * On-device inference contract for local, 0-Watt generation.
+ *
+ * This is the platform seam for AMPR-203's local execution surface. It is
+ * intentionally **SDK-free** (no `com.aallam.openai` types) and text-shaped —
+ * prompt in, text out — which is the Android floor for v1. Apple's guided
+ * generation can be used *inside* its `actual` implementation without widening
+ * this contract.
+ *
+ * ## Binding
+ *
+ * The local engine is **not** `expect`/`actual`: the real implementations live
+ * in sibling platform modules (`:ampere-relay-local-android`,
+ * `:ampere-relay-local-apple`), and `expect`/`actual` cannot cross module
+ * boundaries. Instead it is a `commonMain` interface bound per platform (the
+ * `:phosphor-lumos-{platform}` pattern). `:ampere-core` binds **no** engine;
+ * the dispatching seam ([link.socket.ampere.llm.DispatchingUpstreamLlmClient])
+ * therefore receives `null` here and routes every call to the bundled cloud
+ * path until a platform module supplies a real engine.
+ *
+ * ## Relationship to the LLM seam
+ *
+ * [link.socket.ampere.llm.LocalUpstreamLlmClient] adapts this text-shaped
+ * contract onto Ampere's
+ * [UpstreamLlmClient][link.socket.ampere.llm.UpstreamLlmClient] seam, flattening
+ * a `ChatCompletionRequest` to a prompt and wrapping the returned text back into
+ * a `ChatCompletion`. Keeping the SDK types out of this interface is what lets
+ * platform modules implement it without depending on the OpenAI client.
+ */
+interface LocalInferenceEngine {
+
+    /**
+     * Report whether the engine can serve a generation right now (model loaded,
+     * device not thermally throttled, etc.). Cheap and side-effect-free; callers
+     * may invoke it per-route to gate a device-gated provider.
+     */
+    suspend fun probe(): LocalCapacity
+
+    /**
+     * Generate a completion for [prompt].
+     *
+     * Returns a [Result] rather than throwing so the caller can decide how to
+     * surface failure. In v1 there is **no silent fallback**: a
+     * [Result.failure] is surfaced as an error by
+     * [link.socket.ampere.llm.LocalUpstreamLlmClient] (it does not retry on the
+     * cloud grid). Execution-failure → grid retry is a deliberate future
+     * decision kept out of this seam.
+     */
+    suspend fun generate(prompt: String): Result<String>
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/llm/DispatchingUpstreamLlmClient.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/llm/DispatchingUpstreamLlmClient.kt
@@ -1,0 +1,71 @@
+package link.socket.ampere.llm
+
+import com.aallam.openai.api.chat.ChatCompletion
+import com.aallam.openai.api.chat.ChatCompletionRequest
+import link.socket.ampere.agents.domain.routing.capability.CostPolicy
+import link.socket.ampere.agents.domain.routing.capability.ProviderDescriptor
+import link.socket.ampere.agents.domain.routing.capability.ProviderDescriptorRegistry
+import link.socket.ampere.agents.domain.routing.local.LocalInferenceEngine
+import link.socket.ampere.api.AmpereStableApi
+import link.socket.ampere.domain.ai.configuration.AIConfiguration
+
+/**
+ * [UpstreamLlmClient] that dispatches each call to either a [LocalUpstreamLlmClient]
+ * or the [BundledUpstreamLlmClient] (cloud) path, based on the relay-selected
+ * configuration's [ProviderDescriptor].
+ *
+ * This is the composition root of AMPR-203's execution surface. The relay has
+ * already *selected* a configuration (post-`RouteSelected`); this client decides
+ * *how* to execute it:
+ *
+ * - If the selected provider's descriptor declares [CostPolicy.Free] **or** is
+ *   [availabilityGated][ProviderDescriptor.availabilityGated] — the markers of a
+ *   local, on-device provider — and a [localEngine] is bound, the call runs
+ *   through the [LocalUpstreamLlmClient].
+ * - Otherwise it runs through [bundled], i.e. the existing per-provider OpenAI
+ *   client. This includes the case where no descriptor is registered, preserving
+ *   today's cloud behavior for every existing provider.
+ *
+ * Because the descriptor lookup keys on the *resolved* configuration, this works
+ * end-to-end with relay capability routing ([RoutingRule.ByCapability]
+ * [link.socket.ampere.agents.domain.routing.RoutingRule.ByCapability]): the relay
+ * picks the local config, and this client honors that selection at execution.
+ *
+ * ## Binding seam
+ *
+ * [localEngine] is the per-platform binding point. In `:ampere-core` it is
+ * `null` — no engine is bound — so every call routes to [bundled] and behavior
+ * is byte-equivalent to before. Platform modules
+ * (`:ampere-relay-local-android` / `-apple`) supply a real
+ * [LocalInferenceEngine]; tests supply a fake.
+ */
+@AmpereStableApi
+class DispatchingUpstreamLlmClient(
+    private val registry: ProviderDescriptorRegistry,
+    localEngine: LocalInferenceEngine?,
+    private val bundled: UpstreamLlmClient = BundledUpstreamLlmClient,
+) : UpstreamLlmClient {
+
+    private val local: LocalUpstreamLlmClient? = localEngine?.let(::LocalUpstreamLlmClient)
+
+    override suspend fun call(
+        request: ChatCompletionRequest,
+        configuration: AIConfiguration,
+    ): ChatCompletion {
+        val localClient = local
+        val descriptor = registry.descriptorFor(configuration.provider.id)
+
+        return if (localClient != null && descriptor != null && descriptor.prefersLocalExecution()) {
+            localClient.call(request, configuration)
+        } else {
+            bundled.call(request, configuration)
+        }
+    }
+
+    /**
+     * Whether this descriptor designates a provider that should execute locally:
+     * a free (0-Watt) cost policy or a device-gated availability flag.
+     */
+    private fun ProviderDescriptor.prefersLocalExecution(): Boolean =
+        cost is CostPolicy.Free || availabilityGated
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/llm/LocalUpstreamLlmClient.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/llm/LocalUpstreamLlmClient.kt
@@ -1,0 +1,105 @@
+package link.socket.ampere.llm
+
+import com.aallam.openai.api.chat.ChatChoice
+import com.aallam.openai.api.chat.ChatCompletion
+import com.aallam.openai.api.chat.ChatCompletionRequest
+import com.aallam.openai.api.chat.ChatMessage
+import com.aallam.openai.api.chat.ChatRole
+import link.socket.ampere.agents.domain.routing.local.LocalInferenceEngine
+import link.socket.ampere.api.AmpereStableApi
+import link.socket.ampere.domain.ai.configuration.AIConfiguration
+
+/**
+ * [UpstreamLlmClient] that executes a relay-selected **local** configuration
+ * through an on-device [LocalInferenceEngine].
+ *
+ * This is the local counterpart to [BundledUpstreamLlmClient]: where the bundled
+ * client performs an HTTP/OpenAI round-trip via `configuration.provider.client`,
+ * this client adapts the same [ChatCompletionRequest] onto the text-shaped local
+ * engine. It is the execution half of AMPR-203's local surface — local routes
+ * through the observable [UpstreamLlmClient] seam (D1), never the
+ * [LlmProvider][link.socket.ampere.domain.llm.LlmProvider] bypass.
+ *
+ * ## Adaptation
+ *
+ * - **Request → prompt:** the request's messages are flattened to a single
+ *   `Role: content` block per message (see [flattenToPrompt]). v1 is text-only;
+ *   structured output and tool-calling over the local seam are out of scope.
+ * - **Text → response:** the engine's text is wrapped in a minimal
+ *   [ChatCompletion] matching [BundledUpstreamLlmClient]'s return shape — one
+ *   assistant choice carrying the text. No `usage` is attached: a local call has
+ *   no token-billing meaning, and its 0-Watt accounting is anchored by the
+ *   provider's `CostPolicy.Free` descriptor (T5), not by token counts.
+ *
+ * ## Errors
+ *
+ * On [Result.failure] from the engine, this client throws a
+ * [LocalInferenceException] rather than silently falling back to the cloud grid
+ * — v1 surfaces local failure (no silent fallback). The exception propagates to
+ * [link.socket.ampere.agents.domain.reasoning.AgentLLMService], which emits
+ * failure telemetry from its catch site, exactly as the [UpstreamLlmClient]
+ * contract specifies for transport errors.
+ */
+@AmpereStableApi
+class LocalUpstreamLlmClient(
+    private val engine: LocalInferenceEngine,
+) : UpstreamLlmClient {
+
+    override suspend fun call(
+        request: ChatCompletionRequest,
+        configuration: AIConfiguration,
+    ): ChatCompletion {
+        val text = engine.generate(request.flattenToPrompt()).getOrElse { cause ->
+            throw LocalInferenceException(
+                "Local inference engine failed to generate a completion for " +
+                    "provider '${configuration.provider.id}'",
+                cause,
+            )
+        }
+
+        return ChatCompletion(
+            id = LOCAL_COMPLETION_ID,
+            created = 0L,
+            model = request.model,
+            choices = listOf(
+                ChatChoice(
+                    index = 0,
+                    message = ChatMessage(
+                        role = ChatRole.Assistant,
+                        content = text,
+                    ),
+                ),
+            ),
+        )
+    }
+
+    companion object {
+        /** Synthetic completion id for locally generated responses. */
+        const val LOCAL_COMPLETION_ID: String = "local-inference"
+
+        /**
+         * Flatten a [ChatCompletionRequest] to a single prompt string for the
+         * text-shaped local engine. Each message becomes a `Role: content` line,
+         * separated by blank lines — mirroring the system/user layout that
+         * [link.socket.ampere.agents.domain.reasoning.AgentLLMService] uses for
+         * the [LlmProvider][link.socket.ampere.domain.llm.LlmProvider] bypass, so
+         * a local engine sees a familiar shape.
+         */
+        internal fun ChatCompletionRequest.flattenToPrompt(): String =
+            messages.joinToString(separator = "\n\n") { message ->
+                val label = message.role.role.replaceFirstChar { it.uppercaseChar() }
+                "$label: ${message.content.orEmpty()}"
+            }
+    }
+}
+
+/**
+ * Raised by [LocalUpstreamLlmClient] when the on-device engine fails to produce
+ * a completion. Carries the engine's failure as its [cause] so
+ * [link.socket.ampere.agents.domain.reasoning.AgentLLMService] can record a
+ * meaningful `errorType` in its completion telemetry.
+ */
+class LocalInferenceException(
+    message: String,
+    cause: Throwable? = null,
+) : Exception(message, cause)

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/routing/local/FakeLocalInferenceEngine.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/routing/local/FakeLocalInferenceEngine.kt
@@ -1,0 +1,30 @@
+package link.socket.ampere.agents.domain.routing.local
+
+/**
+ * Test [LocalInferenceEngine] that records the prompts it is asked to generate
+ * and returns a scripted [Result]. Stands in for the per-platform engine bound
+ * in `:ampere-relay-local-*` modules (Phase 2).
+ */
+class FakeLocalInferenceEngine(
+    private val capacity: LocalCapacity = LocalCapacity(available = true, modelId = "fake-local"),
+    private val respond: (prompt: String) -> Result<String> = { Result.success("LOCAL::$it") },
+) : LocalInferenceEngine {
+
+    var probeCount: Int = 0
+        private set
+    var generateCount: Int = 0
+        private set
+    var lastPrompt: String? = null
+        private set
+
+    override suspend fun probe(): LocalCapacity {
+        probeCount++
+        return capacity
+    }
+
+    override suspend fun generate(prompt: String): Result<String> {
+        generateCount++
+        lastPrompt = prompt
+        return respond(prompt)
+    }
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/llm/DispatchingUpstreamLlmClientTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/llm/DispatchingUpstreamLlmClientTest.kt
@@ -83,7 +83,7 @@ class DispatchingUpstreamLlmClientTest {
     }
 
     @Test
-    fun `routes to bundled when no engine is bound, even for a free provider`() = runTest {
+    fun `routes to bundled when no engine is bound even for a free provider`() = runTest {
         val bundled = RecordingClient("cloud-answer")
         val client = DispatchingUpstreamLlmClient(registry(), localEngine = null, bundled = bundled)
 

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/llm/DispatchingUpstreamLlmClientTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/llm/DispatchingUpstreamLlmClientTest.kt
@@ -1,0 +1,156 @@
+package link.socket.ampere.llm
+
+import com.aallam.openai.api.chat.ChatChoice
+import com.aallam.openai.api.chat.ChatCompletion
+import com.aallam.openai.api.chat.ChatCompletionRequest
+import com.aallam.openai.api.chat.ChatMessage
+import com.aallam.openai.api.chat.ChatRole
+import com.aallam.openai.api.model.ModelId
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+import link.socket.ampere.agents.domain.routing.capability.CostPolicy
+import link.socket.ampere.agents.domain.routing.capability.InMemoryProviderDescriptorRegistry
+import link.socket.ampere.agents.domain.routing.capability.ProviderDescriptor
+import link.socket.ampere.agents.domain.routing.local.FakeLocalInferenceEngine
+import link.socket.ampere.domain.ai.configuration.AIConfiguration
+import link.socket.ampere.domain.ai.configuration.AIConfiguration_Default
+import link.socket.ampere.domain.ai.model.AIModelFeatures.RelativeReasoning
+import link.socket.ampere.domain.ai.model.AIModelFeatures.SupportedInputs
+import link.socket.ampere.domain.ai.model.AIModel_Claude
+import link.socket.ampere.domain.ai.model.AIModel_Gemini
+import link.socket.ampere.domain.ai.model.AIModel_OpenAI
+import link.socket.ampere.domain.ai.provider.AIProvider_Anthropic
+import link.socket.ampere.domain.ai.provider.AIProvider_Google
+import link.socket.ampere.domain.ai.provider.AIProvider_OpenAI
+
+class DispatchingUpstreamLlmClientTest {
+
+    // Anthropic stands in for a free, device-gated local provider.
+    private val localConfig = AIConfiguration_Default(AIProvider_Anthropic, AIModel_Claude.Sonnet_4)
+
+    // Google stands in for a metered cloud provider.
+    private val cloudConfig = AIConfiguration_Default(AIProvider_Google, AIModel_Gemini.Flash_2_5)
+
+    // OpenAI stands in for a gated-but-metered provider (availability flag alone routes local).
+    private val gatedConfig = AIConfiguration_Default(AIProvider_OpenAI, AIModel_OpenAI.GPT_4_1)
+
+    private fun registry() = InMemoryProviderDescriptorRegistry(
+        seed = listOf(
+            descriptor(AIProvider_Anthropic.id, cost = CostPolicy.Free, gated = true),
+            descriptor(AIProvider_Google.id, cost = CostPolicy.Metered, gated = false),
+            descriptor(AIProvider_OpenAI.id, cost = CostPolicy.Metered, gated = true),
+        ),
+    )
+
+    @Test
+    fun `routes free local provider to the local engine`() = runTest {
+        val engine = FakeLocalInferenceEngine(respond = { Result.success("local-answer") })
+        val bundled = RecordingClient("cloud-answer")
+        val client = DispatchingUpstreamLlmClient(registry(), engine, bundled)
+
+        val response = client.call(request(), localConfig)
+
+        assertEquals("local-answer", response.choices.single().message.content)
+        assertEquals(1, engine.generateCount)
+        assertEquals(0, bundled.callCount, "Free local provider must not touch the cloud path")
+    }
+
+    @Test
+    fun `routes availability-gated provider to the local engine even when metered`() = runTest {
+        val engine = FakeLocalInferenceEngine(respond = { Result.success("local-answer") })
+        val bundled = RecordingClient("cloud-answer")
+        val client = DispatchingUpstreamLlmClient(registry(), engine, bundled)
+
+        val response = client.call(request(), gatedConfig)
+
+        assertEquals("local-answer", response.choices.single().message.content)
+        assertEquals(1, engine.generateCount)
+        assertEquals(0, bundled.callCount)
+    }
+
+    @Test
+    fun `routes metered cloud provider to the bundled client`() = runTest {
+        val engine = FakeLocalInferenceEngine()
+        val bundled = RecordingClient("cloud-answer")
+        val client = DispatchingUpstreamLlmClient(registry(), engine, bundled)
+
+        val response = client.call(request(), cloudConfig)
+
+        assertEquals("cloud-answer", response.choices.single().message.content)
+        assertEquals(0, engine.generateCount)
+        assertEquals(1, bundled.callCount)
+    }
+
+    @Test
+    fun `routes to bundled when no engine is bound, even for a free provider`() = runTest {
+        val bundled = RecordingClient("cloud-answer")
+        val client = DispatchingUpstreamLlmClient(registry(), localEngine = null, bundled = bundled)
+
+        val response = client.call(request(), localConfig)
+
+        assertEquals("cloud-answer", response.choices.single().message.content)
+        assertEquals(1, bundled.callCount)
+    }
+
+    @Test
+    fun `routes to bundled when the provider has no descriptor`() = runTest {
+        val engine = FakeLocalInferenceEngine()
+        val bundled = RecordingClient("cloud-answer")
+        // Empty registry: descriptorFor() returns null for everything.
+        val client = DispatchingUpstreamLlmClient(
+            InMemoryProviderDescriptorRegistry(seed = emptyList()),
+            engine,
+            bundled,
+        )
+
+        client.call(request(), localConfig)
+
+        assertEquals(0, engine.generateCount)
+        assertEquals(1, bundled.callCount)
+    }
+
+    private fun descriptor(
+        providerId: String,
+        cost: CostPolicy,
+        gated: Boolean,
+    ) = ProviderDescriptor(
+        providerId = providerId,
+        capabilities = emptySet(),
+        reasoning = RelativeReasoning.LOW,
+        maxContextTokens = 8_192,
+        supportedInputs = SupportedInputs.TEXT,
+        cost = cost,
+        availabilityGated = gated,
+    )
+
+    private fun request(): ChatCompletionRequest = ChatCompletionRequest(
+        model = ModelId("test-model"),
+        messages = listOf(ChatMessage(role = ChatRole.User, content = "hello")),
+    )
+
+    private class RecordingClient(
+        private val cannedResponse: String,
+    ) : UpstreamLlmClient {
+        var callCount: Int = 0
+            private set
+
+        override suspend fun call(
+            request: ChatCompletionRequest,
+            configuration: AIConfiguration,
+        ): ChatCompletion {
+            callCount++
+            return ChatCompletion(
+                id = "cloud",
+                created = 0L,
+                model = ModelId(configuration.model.name),
+                choices = listOf(
+                    ChatChoice(
+                        index = 0,
+                        message = ChatMessage(role = ChatRole.Assistant, content = cannedResponse),
+                    ),
+                ),
+            )
+        }
+    }
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/llm/LocalUpstreamLlmClientTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/llm/LocalUpstreamLlmClientTest.kt
@@ -62,7 +62,7 @@ class LocalUpstreamLlmClientTest {
     }
 
     @Test
-    fun `engine failure surfaces as LocalInferenceException, no silent fallback`() = runTest {
+    fun `engine failure surfaces as LocalInferenceException without silent fallback`() = runTest {
         val boom = IllegalStateException("model-not-loaded")
         val engine = FakeLocalInferenceEngine(
             respond = { Result.failure(boom) },

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/llm/LocalUpstreamLlmClientTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/llm/LocalUpstreamLlmClientTest.kt
@@ -1,0 +1,83 @@
+package link.socket.ampere.llm
+
+import com.aallam.openai.api.chat.ChatCompletionRequest
+import com.aallam.openai.api.chat.ChatMessage
+import com.aallam.openai.api.chat.ChatRole
+import com.aallam.openai.api.model.ModelId
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import link.socket.ampere.agents.domain.routing.local.FakeLocalInferenceEngine
+import link.socket.ampere.domain.ai.configuration.AIConfiguration_Default
+import link.socket.ampere.domain.ai.model.AIModel_Claude
+import link.socket.ampere.domain.ai.provider.AIProvider_Anthropic
+
+class LocalUpstreamLlmClientTest {
+
+    private val configuration = AIConfiguration_Default(
+        provider = AIProvider_Anthropic,
+        model = AIModel_Claude.Sonnet_4,
+    )
+
+    private fun request(): ChatCompletionRequest = ChatCompletionRequest(
+        model = ModelId(AIModel_Claude.Sonnet_4.name),
+        messages = listOf(
+            ChatMessage(role = ChatRole.System, content = "You are a calculator."),
+            ChatMessage(role = ChatRole.User, content = "What is 2 + 2?"),
+        ),
+    )
+
+    @Test
+    fun `flattens request messages to a role-labelled prompt and wraps engine text`() = runTest {
+        val engine = FakeLocalInferenceEngine(
+            respond = { Result.success("four") },
+        )
+        val client = LocalUpstreamLlmClient(engine)
+
+        val completion = client.call(request(), configuration)
+
+        // Engine output is surfaced as the single assistant choice.
+        assertEquals("four", completion.choices.single().message.content)
+        assertEquals(ChatRole.Assistant, completion.choices.single().message.role)
+        assertEquals(LocalUpstreamLlmClient.LOCAL_COMPLETION_ID, completion.id)
+
+        // The request was flattened to a System:/User: prompt.
+        val prompt = assertNotNull(engine.lastPrompt)
+        assertContains(prompt, "System: You are a calculator.")
+        assertContains(prompt, "User: What is 2 + 2?")
+        assertTrue(prompt.indexOf("System:") < prompt.indexOf("User:"))
+    }
+
+    @Test
+    fun `local generation has no token usage`() = runTest {
+        val client = LocalUpstreamLlmClient(FakeLocalInferenceEngine())
+
+        val completion = client.call(request(), configuration)
+
+        // No billing meaning for a local call; 0W is anchored by CostPolicy.Free.
+        assertEquals(null, completion.usage)
+    }
+
+    @Test
+    fun `engine failure surfaces as LocalInferenceException, no silent fallback`() = runTest {
+        val boom = IllegalStateException("model-not-loaded")
+        val engine = FakeLocalInferenceEngine(
+            respond = { Result.failure(boom) },
+        )
+        val client = LocalUpstreamLlmClient(engine)
+
+        val thrown = try {
+            client.call(request(), configuration)
+            null
+        } catch (e: LocalInferenceException) {
+            e
+        }
+
+        val error = assertNotNull(thrown, "Local failure must surface, not silently fall back")
+        assertEquals(boom, error.cause)
+        assertContains(error.message ?: "", AIProvider_Anthropic.id)
+    }
+}

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/llm/LocalInferenceRelayIntegrationTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/llm/LocalInferenceRelayIntegrationTest.kt
@@ -1,0 +1,242 @@
+package link.socket.ampere.llm
+
+import com.aallam.openai.api.chat.ChatChoice
+import com.aallam.openai.api.chat.ChatCompletion
+import com.aallam.openai.api.chat.ChatCompletionRequest
+import com.aallam.openai.api.chat.ChatMessage
+import com.aallam.openai.api.chat.ChatRole
+import com.aallam.openai.api.model.ModelId
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import link.socket.ampere.agents.config.AgentConfiguration
+import link.socket.ampere.agents.config.CognitiveConfig
+import link.socket.ampere.agents.domain.event.Event
+import link.socket.ampere.agents.domain.event.RoutingEvent
+import link.socket.ampere.agents.domain.reasoning.AgentLLMService
+import link.socket.ampere.agents.domain.routing.CognitiveRelayImpl
+import link.socket.ampere.agents.domain.routing.RelayConfig
+import link.socket.ampere.agents.domain.routing.RoutingContext
+import link.socket.ampere.agents.domain.routing.RoutingRule
+import link.socket.ampere.agents.domain.routing.capability.CapabilityRequirement
+import link.socket.ampere.agents.domain.routing.capability.CostPolicy
+import link.socket.ampere.agents.domain.routing.capability.InMemoryProviderDescriptorRegistry
+import link.socket.ampere.agents.domain.routing.capability.ProviderCapability
+import link.socket.ampere.agents.domain.routing.capability.ProviderDescriptor
+import link.socket.ampere.agents.domain.routing.local.FakeLocalInferenceEngine
+import link.socket.ampere.agents.events.api.EventHandler
+import link.socket.ampere.agents.events.bus.EventSerialBus
+import link.socket.ampere.domain.agent.bundled.WriteCodeAgent
+import link.socket.ampere.domain.ai.configuration.AIConfiguration
+import link.socket.ampere.domain.ai.configuration.AIConfiguration_Default
+import link.socket.ampere.domain.ai.model.AIModelFeatures.RelativeReasoning
+import link.socket.ampere.domain.ai.model.AIModelFeatures.SupportedInputs
+import link.socket.ampere.domain.ai.model.AIModel_Claude
+import link.socket.ampere.domain.ai.model.AIModel_Gemini
+import link.socket.ampere.domain.ai.model.AIModel_OpenAI
+import link.socket.ampere.domain.ai.provider.AIProvider_Anthropic
+import link.socket.ampere.domain.ai.provider.AIProvider_Google
+import link.socket.ampere.domain.ai.provider.AIProvider_OpenAI
+
+/**
+ * End-to-end integration test for AMPR-209's local execution surface.
+ *
+ * Mirrors [CustomLlmProviderIntegrationTest], but instead of the
+ * [link.socket.ampere.domain.llm.LlmProvider] *bypass*, the local configuration
+ * is selected **by the relay** ([RoutingRule.ByCapability]) and executed through
+ * the observable [UpstreamLlmClient] seam via a
+ * [DispatchingUpstreamLlmClient] → [LocalUpstreamLlmClient] → fake engine. This
+ * is the path AMPR-203 (D1) requires: selection *and* execution stay observable.
+ */
+class LocalInferenceRelayIntegrationTest {
+
+    // Anthropic stands in for the device-gated local provider: free, text-only,
+    // no world knowledge.
+    private val localConfig = AIConfiguration_Default(AIProvider_Anthropic, AIModel_Claude.Sonnet_4)
+
+    // Google stands in for the cloud "grid" provider: metered, full capabilities.
+    private val gridConfig = AIConfiguration_Default(AIProvider_Google, AIModel_Gemini.Flash_2_5)
+
+    // The agent's static fallback, used only when no rule matches.
+    private val agentFallback = AIConfiguration_Default(AIProvider_OpenAI, AIModel_OpenAI.GPT_4_1)
+
+    private fun registry() = InMemoryProviderDescriptorRegistry(
+        seed = listOf(
+            ProviderDescriptor(
+                providerId = AIProvider_Anthropic.id,
+                capabilities = emptySet(),
+                reasoning = RelativeReasoning.LOW,
+                maxContextTokens = 8_192,
+                supportedInputs = SupportedInputs.TEXT,
+                cost = CostPolicy.Free,
+                availabilityGated = true,
+            ),
+            ProviderDescriptor(
+                providerId = AIProvider_Google.id,
+                capabilities = setOf(
+                    ProviderCapability.WORLD_KNOWLEDGE,
+                    ProviderCapability.TOOL_CALLING,
+                    ProviderCapability.LONG_CONTEXT,
+                ),
+                reasoning = RelativeReasoning.HIGH,
+                maxContextTokens = 200_000,
+                supportedInputs = SupportedInputs.TEXT_AND_IMAGE,
+                cost = CostPolicy.Metered,
+            ),
+        ),
+    )
+
+    @Test
+    fun `text requirement selects local provider and executes through the local engine`() = runBlocking {
+        val registry = registry()
+        val eventBus = EventSerialBus(CoroutineScope(Dispatchers.Default))
+        val routeSelections = subscribeToRouteSelected(eventBus)
+
+        val engine = FakeLocalInferenceEngine(respond = { Result.success(LOCAL_RESPONSE) })
+        val cloud = RecordingUpstreamClient("cloud-response")
+
+        val relay = CognitiveRelayImpl(
+            initialConfig = RelayConfig(
+                // Local-first ordering: first capable provider wins.
+                rules = listOf(
+                    RoutingRule.ByCapability(localConfig),
+                    RoutingRule.ByCapability(gridConfig),
+                ),
+            ),
+            eventBus = eventBus,
+            registry = registry,
+        )
+
+        val service = AgentLLMService(
+            agentConfiguration = AgentConfiguration(
+                agentDefinition = WriteCodeAgent,
+                aiConfiguration = agentFallback,
+                cognitiveConfig = CognitiveConfig(),
+                cognitiveRelay = relay,
+                upstreamLlmClient = DispatchingUpstreamLlmClient(registry, engine, cloud),
+            ),
+        )
+
+        val response = service.call(
+            prompt = "Rewrite this sentence.",
+            systemMessage = "You are a text transformer.",
+            routingContext = RoutingContext(
+                requirements = CapabilityRequirement(inputs = SupportedInputs.TEXT),
+            ),
+        )
+
+        // Response is the local engine's output, executed via LocalUpstreamLlmClient.
+        assertEquals(LOCAL_RESPONSE, response)
+        assertEquals(1, engine.generateCount, "Local engine must have executed exactly once")
+        assertEquals(0, cloud.callCount, "Cloud path must not be touched for a free local route")
+
+        // The engine saw the flattened system + user prompt (the request shape).
+        assertContains(engine.lastPrompt ?: "", "System: You are a text transformer.")
+        assertContains(engine.lastPrompt ?: "", "User: Rewrite this sentence.")
+
+        // RouteSelected fired on the relay path (NOT the LlmProvider short-circuit).
+        delay(EVENT_DELIVERY_MS)
+        assertEquals(1, routeSelections.size, "Expected exactly one RouteSelected event")
+        val decision = (routeSelections.first() as RoutingEvent.RouteSelected).decision
+        assertEquals(AIProvider_Anthropic.name, decision.providerName)
+        assertEquals(AIModel_Claude.Sonnet_4.name, decision.modelName)
+        assertEquals("capability:${AIProvider_Anthropic.id}", decision.matchedRule)
+    }
+
+    @Test
+    fun `world-knowledge requirement falls through to grid and executes on the cloud client`() = runBlocking {
+        val registry = registry()
+        val eventBus = EventSerialBus(CoroutineScope(Dispatchers.Default))
+        val routeSelections = subscribeToRouteSelected(eventBus)
+
+        val engine = FakeLocalInferenceEngine(respond = { Result.success(LOCAL_RESPONSE) })
+        val cloud = RecordingUpstreamClient("cloud-response")
+
+        val relay = CognitiveRelayImpl(
+            initialConfig = RelayConfig(
+                rules = listOf(
+                    RoutingRule.ByCapability(localConfig),
+                    RoutingRule.ByCapability(gridConfig),
+                ),
+            ),
+            eventBus = eventBus,
+            registry = registry,
+        )
+
+        val service = AgentLLMService(
+            agentConfiguration = AgentConfiguration(
+                agentDefinition = WriteCodeAgent,
+                aiConfiguration = agentFallback,
+                cognitiveConfig = CognitiveConfig(),
+                cognitiveRelay = relay,
+                upstreamLlmClient = DispatchingUpstreamLlmClient(registry, engine, cloud),
+            ),
+        )
+
+        val response = service.call(
+            prompt = "Who won the 1998 World Cup?",
+            systemMessage = "You answer factual questions.",
+            routingContext = RoutingContext(
+                requirements = CapabilityRequirement(
+                    required = setOf(ProviderCapability.WORLD_KNOWLEDGE),
+                    inputs = SupportedInputs.TEXT,
+                ),
+            ),
+        )
+
+        // The metered grid provider executes via the bundled/cloud client, not local.
+        assertEquals("cloud-response", response)
+        assertEquals(0, engine.generateCount, "Local engine must not run for a metered grid route")
+        assertEquals(1, cloud.callCount)
+
+        delay(EVENT_DELIVERY_MS)
+        val decision = (routeSelections.first() as RoutingEvent.RouteSelected).decision
+        assertEquals(AIProvider_Google.name, decision.providerName)
+        assertTrue(routeSelections.isNotEmpty(), "RouteSelected must fire on the relay path")
+    }
+
+    private fun subscribeToRouteSelected(eventBus: EventSerialBus): MutableList<Event> {
+        val received = mutableListOf<Event>()
+        eventBus.subscribe(
+            agentId = "route-subscriber",
+            eventType = RoutingEvent.RouteSelected.EVENT_TYPE,
+            handler = EventHandler { event, _ -> received.add(event) },
+        )
+        return received
+    }
+
+    private class RecordingUpstreamClient(
+        private val cannedResponse: String,
+    ) : UpstreamLlmClient {
+        var callCount: Int = 0
+            private set
+
+        override suspend fun call(
+            request: ChatCompletionRequest,
+            configuration: AIConfiguration,
+        ): ChatCompletion {
+            callCount++
+            return ChatCompletion(
+                id = "cloud",
+                created = 0L,
+                model = ModelId(configuration.model.name),
+                choices = listOf(
+                    ChatChoice(
+                        index = 0,
+                        message = ChatMessage(role = ChatRole.Assistant, content = cannedResponse),
+                    ),
+                ),
+            )
+        }
+    }
+
+    companion object {
+        private const val LOCAL_RESPONSE = "Generated on-device."
+        private const val EVENT_DELIVERY_MS = 100L
+    }
+}


### PR DESCRIPTION
## What

Implements **T6 · AMPR-209** — the local execution surface for AMPR-203's 0-Watt, capability-routed on-device inference. Local routes through the observable `UpstreamLlmClient` seam (decision **D1** — never the `LlmProvider` bypass). Builds on T2's `ProviderDescriptor`/`CostPolicy`/registry and integrates with T3's `RoutingRule.ByCapability`.

## Changes

| File | Role |
|---|---|
| `routing/local/LocalInferenceEngine.kt` | SDK-free contract: `probe(): LocalCapacity` + `generate(prompt): Result<String>`. Text-shaped (Android floor); bound per platform (lumos pattern), **not** `expect`/`actual`. |
| `routing/local/LocalCapacity.kt` | Minimal availability snapshot. T4 isn't merged, so T6 defines the type it needs. |
| `llm/LocalUpstreamLlmClient.kt` | Flattens `ChatCompletionRequest` → prompt, calls the engine, wraps text in a minimal `ChatCompletion` matching `BundledUpstreamLlmClient`'s shape. On `Result.failure` throws `LocalInferenceException` — **no silent fallback in v1** — so `AgentLLMService` emits failure telemetry from its catch site. |
| `llm/DispatchingUpstreamLlmClient.kt` | Routes a relay-selected config to the local engine when its descriptor is `CostPolicy.Free` or `availabilityGated` **and** an engine is bound; otherwise the bundled cloud path (also when no descriptor/engine), preserving existing behavior. |
| `agents/domain/reasoning/AgentLLMService.kt` | KDoc only: documents that local execution flows through the existing `upstreamLlmClient` seam via the dispatching client. |

### Binding seam
The repo uses **no Koin**, so the ticket's "Koin definition exposing `LocalInferenceEngine?`" maps to the nullable `localEngine` constructor parameter on `DispatchingUpstreamLlmClient` — `:ampere-core` binds none (routes everything to cloud), platform modules T7/T8 supply the real engine, tests supply a fake.

## Tests

- `LocalUpstreamLlmClientTest` — flattening, text wrapping, no token usage, failure → `LocalInferenceException` with cause preserved.
- `DispatchingUpstreamLlmClientTest` — local for Free, local for gated-but-metered, bundled for metered cloud, bundled when no engine bound, bundled when no descriptor.
- `LocalInferenceRelayIntegrationTest` (jvmTest) — mirrors `CustomLlmProviderIntegrationTest` but the local config is selected **by the relay** (`ByCapability` + satisfiable `requirements`) and executed via `LocalUpstreamLlmClient` with a fake engine. Asserts: response is the engine's output, `RouteSelected` fired on the relay path (not the `LlmProvider` short-circuit), and the cloud path is untouched; a second case proves a world-knowledge requirement falls through to the metered grid via the bundled client.

## Notes for reviewers

- **Not built/tested locally.** This session's network policy blocks `maven.google.com`/`dl.google.com` (Android Gradle Plugin) and JetBrains maven (Compose), so Gradle can't configure this KMP module here. Every API surface the code touches was verified against existing repo usages; CI is the real check.
- **0-Watt assertion deferred.** The ticket's validation notes "0 Watts (*with T5 merged*)". T5 (AMPR-208) isn't merged, so that assertion is intentionally omitted; the `CostPolicy.Free` descriptor that anchors it is already wired.

## Out of scope (per ticket)

Real Apple/Android engines (Phase 2), structured-output/tool-calling over the local seam, execution-failure → grid retry.

https://claude.ai/code/session_01Hb8NQboF4dN9GU2szvKf5v