### PR TITLE
AMPR-208 #559: T5 — WattCostAggregator honors CostPolicy.Free (0 Watts)

### DIFF
--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/trace/ArcTraceProjection.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/trace/ArcTraceProjection.kt
@@ -13,6 +13,8 @@ import link.socket.ampere.agents.domain.event.RoutingEvent
 import link.socket.ampere.agents.domain.event.SparkAppliedEvent
 import link.socket.ampere.agents.domain.event.SparkRemovedEvent
 import link.socket.ampere.agents.domain.event.ToolEvent
+import link.socket.ampere.agents.domain.routing.capability.CostPolicy
+import link.socket.ampere.agents.domain.routing.capability.ProviderDescriptorRegistry
 import link.socket.ampere.data.DEFAULT_JSON
 import link.socket.ampere.db.Database
 import link.socket.ampere.db.events.EventStore
@@ -24,6 +26,7 @@ class ArcTraceProjection(
     private val database: Database,
     private val json: Json = DEFAULT_JSON,
     private val wattCostAggregator: WattCostAggregator = WattCostAggregator(),
+    private val providerDescriptorRegistry: ProviderDescriptorRegistry? = null,
 ) {
     suspend fun project(runId: ArcRunId): Result<ArcRunTrace> =
         project(runId = runId, arcId = runId)
@@ -49,7 +52,8 @@ class ArcTraceProjection(
                 error("No trace data found for runId=$runId")
             }
 
-            val modelInvocations = buildModelInvocations(events)
+            val costByProvider = resolveCostPolicies(events)
+            val modelInvocations = buildModelInvocations(events, costByProvider)
             val toolCalls = buildToolCalls(events)
             val memoryWrites = buildMemoryWrites(events, knowledgeRows, outcomeRows)
             val phases = buildPhases(events, modelInvocations, memoryWrites, toolCalls)
@@ -84,7 +88,30 @@ class ArcTraceProjection(
         }
     }
 
-    private fun buildModelInvocations(events: List<DecodedEvent>): List<ModelInvocationTrace> {
+    /**
+     * Resolves each completed call's provider to its declared [CostPolicy] via
+     * the [providerDescriptorRegistry]. Providers without a registered
+     * descriptor (or when no registry is wired) fall back to
+     * [CostPolicy.Metered], preserving the existing token×tier accounting.
+     */
+    private suspend fun resolveCostPolicies(events: List<DecodedEvent>): Map<String, CostPolicy> {
+        val registry = providerDescriptorRegistry ?: return emptyMap()
+        val providerIds = events
+            .map { it.event }
+            .filterIsInstance<ProviderCallCompletedEvent>()
+            .map { it.providerId }
+            .distinct()
+        return buildMap {
+            for (providerId in providerIds) {
+                put(providerId, registry.descriptorFor(providerId)?.cost ?: CostPolicy.Metered)
+            }
+        }
+    }
+
+    private fun buildModelInvocations(
+        events: List<DecodedEvent>,
+        costByProvider: Map<String, CostPolicy>,
+    ): List<ModelInvocationTrace> {
         val starts = events
             .map { it.event }
             .filterIsInstance<ProviderCallStartedEvent>()
@@ -126,7 +153,8 @@ class ArcTraceProjection(
                     errorType = completed.errorType,
                 )
 
-                invocation.copy(wattCost = wattCostAggregator.costFor(invocation))
+                val cost = costByProvider[completed.providerId] ?: CostPolicy.Metered
+                invocation.copy(wattCost = wattCostAggregator.costFor(invocation, cost))
             }
     }
 

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/trace/WattCostAggregator.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/trace/WattCostAggregator.kt
@@ -1,5 +1,6 @@
 package link.socket.ampere.trace
 
+import link.socket.ampere.agents.domain.routing.capability.CostPolicy
 import link.socket.ampere.api.model.TokenUsage
 import link.socket.ampere.domain.ai.UsageTier
 
@@ -12,26 +13,46 @@ import link.socket.ampere.domain.ai.UsageTier
 class WattCostAggregator(
     private val usageTier: UsageTier = UsageTier.TIER_1,
 ) {
-    fun costFor(usage: TokenUsage): WattCost {
+    /**
+     * Watt cost for [usage] under the provider's [cost] policy.
+     *
+     * A [CostPolicy.Free] provider (e.g. local on-device inference) accrues no
+     * Watts regardless of how many tokens it reports — the declared cost is
+     * honored before the token×tier path. [CostPolicy.Metered] (the default)
+     * keeps the existing token accounting unchanged.
+     */
+    fun costFor(
+        usage: TokenUsage,
+        cost: CostPolicy = CostPolicy.Metered,
+    ): WattCost {
         val inputTokens = usage.inputTokens ?: 0
         val outputTokens = usage.outputTokens ?: 0
-        val totalTokens = inputTokens + outputTokens
+
+        val watts = if (cost is CostPolicy.Free) {
+            0.0
+        } else {
+            (inputTokens + outputTokens).toDouble() / TOKENS_PER_WATT * multiplierFor(usageTier)
+        }
 
         return WattCost(
             inputTokens = inputTokens,
             outputTokens = outputTokens,
             estimatedUsd = usage.estimatedCost,
-            watts = totalTokens.toDouble() / TOKENS_PER_WATT * multiplierFor(usageTier),
+            watts = watts,
         )
     }
 
-    fun costFor(invocation: ModelInvocationTrace): WattCost =
+    fun costFor(
+        invocation: ModelInvocationTrace,
+        cost: CostPolicy = CostPolicy.Metered,
+    ): WattCost =
         costFor(
             TokenUsage(
                 inputTokens = invocation.inputTokens,
                 outputTokens = invocation.outputTokens,
                 estimatedCost = invocation.estimatedUsd,
             ),
+            cost,
         )
 
     fun aggregate(invocations: List<ModelInvocationTrace>): WattCost =

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/trace/WattCostAggregatorTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/trace/WattCostAggregatorTest.kt
@@ -3,6 +3,7 @@ package link.socket.ampere.trace
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import link.socket.ampere.agents.domain.routing.capability.CostPolicy
 import link.socket.ampere.api.model.TokenUsage
 import link.socket.ampere.domain.ai.UsageTier
 
@@ -24,5 +25,37 @@ class WattCostAggregatorTest {
         assertEquals(500, cost.outputTokens)
         assertEquals(0.006, assertNotNull(cost.estimatedUsd), absoluteTolerance = 0.0000001)
         assertEquals(2.25, cost.watts, absoluteTolerance = 0.0000001)
+    }
+
+    @Test
+    fun `Free cost policy records zero Watts while preserving token accounting`() {
+        val aggregator = WattCostAggregator(UsageTier.TIER_2)
+        val usage = TokenUsage(
+            inputTokens = 1_000,
+            outputTokens = 500,
+            estimatedCost = 0.006,
+        )
+
+        val cost = aggregator.costFor(usage, CostPolicy.Free)
+
+        assertEquals(0.0, cost.watts, absoluteTolerance = 0.0000001)
+        assertEquals(1_000, cost.inputTokens)
+        assertEquals(500, cost.outputTokens)
+        assertEquals(0.006, assertNotNull(cost.estimatedUsd), absoluteTolerance = 0.0000001)
+    }
+
+    @Test
+    fun `Metered cost policy matches the default token times tier computation`() {
+        val aggregator = WattCostAggregator(UsageTier.TIER_2)
+        val usage = TokenUsage(
+            inputTokens = 1_000,
+            outputTokens = 500,
+            estimatedCost = 0.006,
+        )
+
+        val metered = aggregator.costFor(usage, CostPolicy.Metered)
+
+        assertEquals(aggregator.costFor(usage), metered)
+        assertEquals(2.25, metered.watts, absoluteTolerance = 0.0000001)
     }
 }

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/trace/ArcTraceProjectionTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/trace/ArcTraceProjectionTest.kt
@@ -25,11 +25,17 @@ import link.socket.ampere.agents.domain.knowledge.KnowledgeRepositoryImpl
 import link.socket.ampere.agents.domain.knowledge.KnowledgeType
 import link.socket.ampere.agents.domain.outcome.ExecutionOutcome
 import link.socket.ampere.agents.domain.outcome.OutcomeMemoryRepositoryImpl
+import link.socket.ampere.agents.domain.routing.capability.CostPolicy
+import link.socket.ampere.agents.domain.routing.capability.InMemoryProviderDescriptorRegistry
+import link.socket.ampere.agents.domain.routing.capability.ProviderCapability
+import link.socket.ampere.agents.domain.routing.capability.ProviderDescriptor
 import link.socket.ampere.agents.events.EventRepository
 import link.socket.ampere.agents.execution.results.ExecutionResult
 import link.socket.ampere.api.model.TokenUsage
 import link.socket.ampere.data.DEFAULT_JSON
 import link.socket.ampere.db.Database
+import link.socket.ampere.domain.ai.model.AIModelFeatures.RelativeReasoning
+import link.socket.ampere.domain.ai.model.AIModelFeatures.SupportedInputs
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ArcTraceProjectionTest {
@@ -82,6 +88,56 @@ class ArcTraceProjectionTest {
         assertEquals(1, learn.memoryWrites.size)
         assertEquals("knowledge-1", learn.memoryWrites.single().id)
         assertEquals("Use trace projections", learn.memoryWrites.single().approach)
+    }
+
+    @Test
+    fun `call routed to a Free descriptor records zero Watts`() = runTest {
+        val runId = "run-free-provider"
+        val registry = InMemoryProviderDescriptorRegistry(
+            seed = listOf(
+                ProviderDescriptor(
+                    providerId = "local",
+                    capabilities = setOf(ProviderCapability.WORLD_KNOWLEDGE),
+                    reasoning = RelativeReasoning.NORMAL,
+                    maxContextTokens = 8_000,
+                    supportedInputs = SupportedInputs.TEXT,
+                    cost = CostPolicy.Free,
+                    availabilityGated = true,
+                ),
+            ),
+        )
+        val freeAwareProjection = ArcTraceProjection(
+            database = database,
+            providerDescriptorRegistry = registry,
+        )
+
+        eventRepository.saveEvent(
+            ProviderCallCompletedEvent(
+                eventId = "free-complete",
+                timestamp = Instant.fromEpochMilliseconds(1_000),
+                eventSource = EventSource.Agent("planner-agent"),
+                workflowId = runId,
+                agentId = "planner-agent",
+                cognitivePhase = CognitivePhase.PLAN,
+                providerId = "local",
+                modelId = "local-llm",
+                usage = TokenUsage(
+                    inputTokens = 1_000,
+                    outputTokens = 500,
+                ),
+                latencyMs = 250,
+                success = true,
+            ),
+        ).getOrThrow()
+
+        val trace = freeAwareProjection.project(runId).getOrThrow()
+        val plan = assertNotNull(trace.phases.firstOrNull { it.name == "PLAN" })
+
+        val invocation = plan.modelInvocations.single()
+        assertEquals(0.0, invocation.wattCost.watts, absoluteTolerance = 0.0000001)
+        assertEquals(1_000, invocation.wattCost.inputTokens)
+        assertEquals(500, invocation.wattCost.outputTokens)
+        assertEquals(0.0, plan.wattCost.watts, absoluteTolerance = 0.0000001)
     }
 
     @Test


### PR DESCRIPTION
## Context

`WattCostAggregator` computes Watts from `tokens / TOKENS_PER_WATT × multiplierFor(usageTier)`. A local model emits tokens too, so it would naïvely accrue Watts. Per D4, a `CostPolicy.Free` provider (e.g. local on-device inference) must record **0 Watts**.

This is about the provider **cost policy** `Free`, not `UsageTier.FREE`. Blocked only by T2 (AMPR-205), which is already merged — `CostPolicy`, `ProviderDescriptor`, and `ProviderDescriptorRegistry` are present.

## Call site (quoted)

The ticket expected the `costFor` call site near `AgentLLMService.kt:383`. It isn't there — Watts are **not** computed at the LLM call. `ProviderCallCompletedEvent` only carries `TokenUsage`; Watts are derived post-hoc in the trace projection. The actual call site is `ArcTraceProjection.buildModelInvocations`:

```kotlin
invocation.copy(wattCost = wattCostAggregator.costFor(invocation))
```

That is where the cost is now threaded.

## Changes

- **`WattCostAggregator.costFor(usage, cost = CostPolicy.Metered)`** (and the `invocation` overload): `CostPolicy.Free` short-circuits to `watts = 0.0` while preserving the token/USD shape; `Metered` keeps the exact pre-change token×tier computation. The defaulted parameter is backward compatible.
- **`ArcTraceProjection`** takes an optional `ProviderDescriptorRegistry`, resolves each completed call's provider to its declared `CostPolicy` (`descriptorFor(providerId)?.cost ?: CostPolicy.Metered`), and passes it to `costFor`. No registry / unregistered provider falls back to `Metered`, so existing behavior is untouched.

## Tests

- Unit: `costFor(usage, CostPolicy.Free).watts == 0.0` (tokens preserved); `costFor(usage, CostPolicy.Metered)` equals the default (regression).
- Integration: a call routed to a `Free` descriptor records 0 W on the projected invocation and phase total.

## Out of scope

USD / `ProviderPricingCalculator` changes; UI surfacing of 0 W (Socket, Phase 3).

## Verification caveat

Gradle was not run in this environment: the network policy blocks Google's Maven (`dl.google.com` → 403, Maven Central works), so the Android Gradle Plugin can't resolve and the root build fails before reaching `:ampere-core`. Changes were verified by review. To confirm locally:

```
./gradlew :ampere-core:jvmTest --tests "*WattCostAggregatorTest" --tests "*ArcTraceProjectionTest"
```

Closes AMPR-208.

https://claude.ai/code/session_01S3uoiGLvnpyATfzUZAQX6s