### PR TITLE
AMPR-215 #571: T2 — Introduce CapabilityRung + minRung requirement predicate

### DIFF
--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/capability/CapabilityRequirement.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/capability/CapabilityRequirement.kt
@@ -19,6 +19,7 @@ import link.socket.ampere.domain.ai.model.AIModelFeatures.SupportedInputs
  * @property minReasoning Minimum reasoning level the model must offer, if any.
  * @property minContextTokens Minimum context window the model must provide, if any.
  * @property inputs Input modalities the model must accept, if any.
+ * @property minRung Minimum capability rung the model must be at, if any.
  */
 @Serializable
 data class CapabilityRequirement(
@@ -26,4 +27,5 @@ data class CapabilityRequirement(
     val minReasoning: RelativeReasoning? = null,
     val minContextTokens: Int? = null,
     val inputs: SupportedInputs? = null,
+    val minRung: CapabilityRung? = null,
 )

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/capability/CapabilityRung.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/capability/CapabilityRung.kt
@@ -1,0 +1,26 @@
+package link.socket.ampere.agents.domain.routing.capability
+
+import kotlin.jvm.JvmInline
+import kotlinx.serialization.Serializable
+
+/**
+ * Ordinal capability tier for a model, independent of billing/quota tiers
+ * ([link.socket.ampere.domain.billing.Tier] et al.). Higher ordinal = higher rung.
+ *
+ * Four rungs are defined as companion constants. Names carry no quality adjectives
+ * so they remain stable as the landscape evolves.
+ */
+@Serializable
+@JvmInline
+value class CapabilityRung(val ordinal: Int) : Comparable<CapabilityRung> {
+
+    override fun compareTo(other: CapabilityRung): Int =
+        ordinal.compareTo(other.ordinal)
+
+    companion object {
+        val ONE = CapabilityRung(1)
+        val TWO = CapabilityRung(2)
+        val THREE = CapabilityRung(3)
+        val FOUR = CapabilityRung(4)
+    }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/capability/ModelDescriptor.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/capability/ModelDescriptor.kt
@@ -48,6 +48,7 @@ data class ModelDescriptor(
     val cost: CostPolicy = CostPolicy.Metered,
     val costPerWatt: Double = DEFAULT_COST_PER_WATT,
     val availabilityGated: Boolean = false,
+    val rung: CapabilityRung = CapabilityRung.ONE,
 ) {
     companion object {
         /**
@@ -76,7 +77,8 @@ fun ModelDescriptor.satisfies(req: CapabilityRequirement): Boolean =
     req.required.all { it in capabilities } &&
         (req.minReasoning == null || reasoning >= req.minReasoning) &&
         (req.minContextTokens == null || maxContextTokens >= req.minContextTokens) &&
-        (req.inputs == null || supportedInputs.covers(req.inputs))
+        (req.inputs == null || supportedInputs.covers(req.inputs)) &&
+        (req.minRung == null || rung >= req.minRung)
 
 /**
  * Whether these inputs cover everything [required] asks for: for each modality

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/routing/capability/ModelDescriptorTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/routing/capability/ModelDescriptorTest.kt
@@ -94,6 +94,49 @@ class ModelDescriptorTest {
     }
 
     @Test
+    fun satisfiesRejectsModelBelowMinRung() {
+        val lowRung = opus.copy(rung = CapabilityRung.TWO)
+        assertFalse(lowRung.satisfies(CapabilityRequirement(minRung = CapabilityRung.THREE)))
+    }
+
+    @Test
+    fun satisfiesAcceptsModelAtMinRung() {
+        val atRung = opus.copy(rung = CapabilityRung.THREE)
+        assertTrue(atRung.satisfies(CapabilityRequirement(minRung = CapabilityRung.THREE)))
+    }
+
+    @Test
+    fun satisfiesAcceptsModelAboveMinRung() {
+        val highRung = opus.copy(rung = CapabilityRung.FOUR)
+        assertTrue(highRung.satisfies(CapabilityRequirement(minRung = CapabilityRung.THREE)))
+    }
+
+    @Test
+    fun absentMinRungMatchesAnyRung() {
+        val lowestRung = opus.copy(rung = CapabilityRung.ONE)
+        assertTrue(lowestRung.satisfies(CapabilityRequirement()))
+    }
+
+    @Test
+    fun rung3ExcludesRung1And2IncludesRung3And4() {
+        val req = CapabilityRequirement(minRung = CapabilityRung.THREE)
+        assertFalse(opus.copy(rung = CapabilityRung.ONE).satisfies(req))
+        assertFalse(opus.copy(rung = CapabilityRung.TWO).satisfies(req))
+        assertTrue(opus.copy(rung = CapabilityRung.THREE).satisfies(req))
+        assertTrue(opus.copy(rung = CapabilityRung.FOUR).satisfies(req))
+    }
+
+    @Test
+    fun capabilityRungRoundTrips() {
+        val withRung = opus.copy(rung = CapabilityRung.THREE)
+        val decoded = json.decodeFromString<ModelDescriptor>(
+            json.encodeToString(ModelDescriptor.serializer(), withRung),
+        )
+        assertEquals(withRung, decoded)
+        assertEquals(CapabilityRung.THREE, decoded.rung)
+    }
+
+    @Test
     fun defaultRegistrySeedsOneDescriptorPerModel() = runTest {
         val registry = InMemoryModelDescriptorRegistry()
 


### PR DESCRIPTION
Closes #571

Introduces `CapabilityRung`, an ordinal capability tier for models independent of the billing/quota `Tier`/`UsageTier` types, and wires it into the model-keyed match predicate added in T1 (AMPR-214).

- **`CapabilityRung.kt`** — `@Serializable @JvmInline value class` with `Comparable` total ordering and four companion constants `ONE`–`FOUR` (no quality adjectives)
- **`ModelDescriptor`** — adds `val rung: CapabilityRung = CapabilityRung.ONE` (non-breaking default to lowest rung)
- **`CapabilityRequirement`** — adds `val minRung: CapabilityRung? = null` (non-breaking; absent `minRung` matches any model)
- **`satisfies()`** — extended with `descriptor.rung >= req.minRung` when `minRung != null`; 6 new tests covering exclusion, inclusion, and serialization round-trip

🤖 Written by Claude Sonnet 4.6 via [Claude Code](https://claude.com/claude-code)