### PR TITLE
AMPR-218 #574: T5 — Seed rung assignments for the static model catalog

### DIFF
--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/capability/ModelDescriptorRegistry.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/capability/ModelDescriptorRegistry.kt
@@ -90,10 +90,57 @@ class InMemoryModelDescriptorRegistry(
         private const val ANTHROPIC_USD_PER_WATT: Double = 0.026
 
         /**
+         * Rung assignments for every model in the bundled cloud catalogs.
+         * Update this map when a new frontier model ships — no other file needs to change.
+         *
+         * Rungs are assigned by generation and capability tier, consistent with
+         * each model's [AIModelFeatures.reasoningLevel] (no LOW-reasoning model
+         * exceeds TWO; no FOUR-rung model is below HIGH).
+         *
+         * ONE  — entry/cheap (LOW reasoning, nano/lite variants)
+         * TWO  — standard (NORMAL reasoning, fast mid-tier)
+         * THREE — advanced (capable HIGH or premium NORMAL)
+         * FOUR — frontier (flagship HIGH, latest generation)
+         */
+        private val MODEL_RUNGS: Map<String, CapabilityRung> = mapOf(
+            // ── Anthropic / Claude ────────────────────────────────────────────
+            "claude-3-haiku-20240307" to CapabilityRung.ONE,
+            "claude-3-5-haiku-latest" to CapabilityRung.TWO,
+            "claude-haiku-4-5" to CapabilityRung.TWO,
+            "claude-sonnet-4-0" to CapabilityRung.THREE,
+            "claude-3-7-sonnet-latest" to CapabilityRung.THREE,
+            "claude-sonnet-4-5-20250929" to CapabilityRung.THREE,
+            "claude-opus-4-0" to CapabilityRung.FOUR,
+            "claude-opus-4-1" to CapabilityRung.FOUR,
+            "claude-opus-4-5-20251101" to CapabilityRung.FOUR,
+            // ── OpenAI / GPT ──────────────────────────────────────────────────
+            "gpt-5-nano" to CapabilityRung.ONE,
+            "gpt-4o-mini" to CapabilityRung.ONE,
+            "gpt-5-mini" to CapabilityRung.TWO,
+            "gpt-4.1-mini" to CapabilityRung.TWO,
+            "gpt-4o" to CapabilityRung.TWO,
+            "o3-mini" to CapabilityRung.TWO,
+            "gpt-4.1" to CapabilityRung.THREE,
+            "o4-mini" to CapabilityRung.THREE,
+            "gpt-5" to CapabilityRung.FOUR,
+            "gpt-5.1" to CapabilityRung.FOUR,
+            "gpt-5.1-chat-latest" to CapabilityRung.FOUR,
+            "gpt-5.1-codex-max" to CapabilityRung.FOUR,
+            "o3" to CapabilityRung.FOUR,
+            // ── Google / Gemini ───────────────────────────────────────────────
+            "gemini-2.0-flash-lite" to CapabilityRung.ONE,
+            "gemini-2.5-flash-lite" to CapabilityRung.ONE,
+            "gemini-2.0-flash" to CapabilityRung.TWO,
+            "gemini-2.5-flash" to CapabilityRung.TWO,
+            "gemini-2.5-pro" to CapabilityRung.THREE,
+            "gemini-3-pro-latest" to CapabilityRung.FOUR,
+        )
+
+        /**
          * Projects an [AIModel] into a [ModelDescriptor] from its own metadata:
          * reasoning and inputs come from [AIModelFeatures][link.socket.ampere.domain.ai.model.AIModelFeatures],
          * the context window from [ModelLimits][link.socket.ampere.domain.limits.ModelLimits],
-         * and cost from the owning provider.
+         * cost from the owning provider, and the rung from [MODEL_RUNGS].
          */
         private fun AIModel.toModelDescriptor(
             providerId: ProviderId,
@@ -110,6 +157,7 @@ class InMemoryModelDescriptorRegistry(
             cost = CostPolicy.Metered,
             costPerWatt = costPerWatt,
             availabilityGated = false,
+            rung = MODEL_RUNGS[name] ?: CapabilityRung.ONE,
         )
 
         /**

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/routing/capability/ModelDescriptorRegistryRungTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/routing/capability/ModelDescriptorRegistryRungTest.kt
@@ -1,0 +1,111 @@
+package link.socket.ampere.agents.domain.routing.capability
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Validates rung seeding for the bundled cloud model catalog (AMPR-218).
+ */
+class ModelDescriptorRegistryRungTest {
+
+    private val descriptors: Map<String, ModelDescriptor> =
+        InMemoryModelDescriptorRegistry.defaultModelDescriptors()
+            .associateBy { it.modelName }
+
+    @Test
+    fun everyModelHasARung() {
+        val models = descriptors.keys
+        assertTrue(models.isNotEmpty(), "descriptor list must not be empty")
+        models.forEach { name ->
+            assertNotNull(descriptors[name]?.rung, "missing rung for $name")
+        }
+    }
+
+    // ── Spot-checks by rung ───────────────────────────────────────────────────
+
+    @Test
+    fun rungOneModels() {
+        val expected = listOf(
+            "claude-3-haiku-20240307",
+            "gpt-5-nano",
+            "gpt-4o-mini",
+            "gemini-2.0-flash-lite",
+            "gemini-2.5-flash-lite",
+        )
+        expected.forEach { name ->
+            assertEquals(CapabilityRung.ONE, descriptors[name]?.rung, "$name should be rung ONE")
+        }
+    }
+
+    @Test
+    fun rungTwoModels() {
+        val expected = listOf(
+            "claude-3-5-haiku-latest",
+            "claude-haiku-4-5",
+            "gpt-5-mini",
+            "gpt-4.1-mini",
+            "gpt-4o",
+            "o3-mini",
+            "gemini-2.0-flash",
+            "gemini-2.5-flash",
+        )
+        expected.forEach { name ->
+            assertEquals(CapabilityRung.TWO, descriptors[name]?.rung, "$name should be rung TWO")
+        }
+    }
+
+    @Test
+    fun rungThreeModels() {
+        val expected = listOf(
+            "claude-sonnet-4-0",
+            "claude-3-7-sonnet-latest",
+            "claude-sonnet-4-5-20250929",
+            "gpt-4.1",
+            "o4-mini",
+            "gemini-2.5-pro",
+        )
+        expected.forEach { name ->
+            assertEquals(CapabilityRung.THREE, descriptors[name]?.rung, "$name should be rung THREE")
+        }
+    }
+
+    @Test
+    fun rungFourModels() {
+        val expected = listOf(
+            "claude-opus-4-0",
+            "claude-opus-4-1",
+            "claude-opus-4-5-20251101",
+            "gpt-5",
+            "gpt-5.1",
+            "gpt-5.1-chat-latest",
+            "gpt-5.1-codex-max",
+            "o3",
+            "gemini-3-pro-latest",
+        )
+        expected.forEach { name ->
+            assertEquals(CapabilityRung.FOUR, descriptors[name]?.rung, "$name should be rung FOUR")
+        }
+    }
+
+    // ── Sanity-order: rung must be consistent with reasoningLevel ────────────
+
+    @Test
+    fun noLowReasoningModelExceedsRungTwo() {
+        val violations = descriptors.values.filter { d ->
+            d.reasoning == link.socket.ampere.domain.ai.model.AIModelFeatures.RelativeReasoning.LOW &&
+                d.rung > CapabilityRung.TWO
+        }
+        assertTrue(violations.isEmpty(), "LOW-reasoning models above rung TWO: ${violations.map { it.modelName }}")
+    }
+
+    @Test
+    fun noRungFourModelIsBelowHighReasoning() {
+        val violations = descriptors.values.filter { d ->
+            d.rung == CapabilityRung.FOUR &&
+                d.reasoning != link.socket.ampere.domain.ai.model.AIModelFeatures.RelativeReasoning.HIGH
+        }
+        assertTrue(violations.isEmpty(), "FOUR-rung models without HIGH reasoning: ${violations.map { it.modelName }}")
+    }
+}


### PR DESCRIPTION
Assigns every model in the bundled cloud catalog (28 models across Claude, OpenAI, and Gemini) to one of the four `CapabilityRung` tiers introduced in T2 (AMPR-215). Assignments live in a single `MODEL_RUNGS` map in `ModelDescriptorRegistry.kt` so re-runging when a new frontier model ships is a one-file change. The `toModelDescriptor()` projection reads from this map; all sanity-order invariants hold (no LOW-reasoning model exceeds rung TWO, no rung-FOUR model is below HIGH reasoning). Includes a `ModelDescriptorRegistryRungTest` with per-rung spot-checks and invariant assertions.

Closes #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)