### PR TITLE
AMPR-216: T3 — Typed failure + RoutingEvent when no model meets the floor

### DIFF
--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/RoutingEvent.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/RoutingEvent.kt
@@ -7,6 +7,7 @@ import link.socket.ampere.agents.definition.AgentId
 import link.socket.ampere.agents.domain.Urgency
 import link.socket.ampere.agents.domain.cognition.sparks.CognitivePhase
 import link.socket.ampere.agents.domain.routing.RoutingDecision
+import link.socket.ampere.agents.domain.routing.capability.CapabilityRung
 import link.socket.ampere.domain.ai.model.AIModelFeatures.RelativeReasoning
 
 /**
@@ -150,6 +151,49 @@ sealed interface RoutingEvent : Event {
 
         companion object {
             const val EVENT_TYPE: EventType = "RouteResolved"
+        }
+    }
+
+    /**
+     * Emitted when the routing requirement specifies a [CapabilityRung] floor
+     * that no registered model meets. This is a terminal routing failure: no
+     * [AIConfiguration] is produced and the resolution must not silently
+     * downgrade to a sub-floor model.
+     *
+     * @property requestedFloor The minimum rung declared by the requirement.
+     * @property bestAvailableRung The highest rung present in the registry among
+     *   the configured [RoutingRule.ByCapability] rules, or null if none could be
+     *   looked up. Surfaced for diagnostics so the operator can see the gap.
+     */
+    @Serializable
+    @SerialName("RoutingEvent.RouteFloorUnmet")
+    data class RouteFloorUnmet(
+        override val eventId: EventId,
+        override val timestamp: Instant,
+        override val eventSource: EventSource,
+        override val urgency: Urgency = Urgency.HIGH,
+        override val agentId: AgentId?,
+        override val phase: CognitivePhase?,
+        val requestedFloor: CapabilityRung,
+        val bestAvailableRung: CapabilityRung?,
+    ) : RoutingEvent {
+
+        override val eventType: EventType = EVENT_TYPE
+
+        override fun getSummary(
+            formatUrgency: (Urgency) -> String,
+            formatSource: (EventSource) -> String,
+        ): String = buildString {
+            append("FloorUnmet: requested rung ${requestedFloor.ordinal}")
+            bestAvailableRung?.let { append(", best available ${it.ordinal}") }
+                ?: append(", no capable model found")
+            phase?.let { append(" [${it.name}]") }
+            append(" ${formatUrgency(urgency)}")
+            append(" from ${formatSource(eventSource)}")
+        }
+
+        companion object {
+            const val EVENT_TYPE: EventType = "RouteFloorUnmet"
         }
     }
 }

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/reasoning/AgentLLMService.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/reasoning/AgentLLMService.kt
@@ -13,6 +13,7 @@ import link.socket.ampere.agents.domain.event.EventSource
 import link.socket.ampere.agents.domain.event.ProviderCallCompletedEvent
 import link.socket.ampere.agents.domain.event.ProviderCallStartedEvent
 import link.socket.ampere.agents.domain.routing.RoutingContext
+import link.socket.ampere.agents.domain.routing.RoutingFloorUnmetException
 import link.socket.ampere.agents.domain.routing.RoutingResolution
 import link.socket.ampere.agents.events.api.AgentEventApi
 import link.socket.ampere.agents.events.utils.generateUUID
@@ -174,17 +175,23 @@ class AgentLLMService(
             agentConfiguration.cognitiveRelay?.resolveWithMetadata(
                 context = routingContext,
                 fallbackConfiguration = agentConfiguration.aiConfiguration,
-            ) ?: RoutingResolution(
+            ) ?: RoutingResolution.Success(
                 configuration = agentConfiguration.aiConfiguration,
                 reason = "agent_configuration",
             )
         } else {
-            RoutingResolution(
+            RoutingResolution.Success(
                 configuration = agentConfiguration.aiConfiguration,
                 reason = "agent_configuration",
             )
         }
-        val effectiveConfig = routingResolution.configuration
+        val effectiveConfig = when (routingResolution) {
+            is RoutingResolution.Success -> routingResolution.configuration
+            is RoutingResolution.FloorUnmet -> throw RoutingFloorUnmetException(
+                requestedFloor = routingResolution.requestedFloor,
+                bestAvailableRung = routingResolution.bestAvailableRung,
+            )
+        }
 
         val model = effectiveConfig.model
 

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/CognitiveRelay.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/CognitiveRelay.kt
@@ -1,5 +1,6 @@
 package link.socket.ampere.agents.domain.routing
 
+import link.socket.ampere.agents.domain.routing.capability.CapabilityRung
 import link.socket.ampere.domain.ai.configuration.AIConfiguration
 
 /**
@@ -40,7 +41,7 @@ interface CognitiveRelay {
     suspend fun resolveWithMetadata(
         context: RoutingContext,
         fallbackConfiguration: AIConfiguration,
-    ): RoutingResolution = RoutingResolution(
+    ): RoutingResolution = RoutingResolution.Success(
         configuration = resolve(context, fallbackConfiguration),
         reason = "relay",
     )
@@ -53,7 +54,21 @@ interface CognitiveRelay {
     suspend fun updateConfig(newConfig: RelayConfig)
 }
 
-data class RoutingResolution(
-    val configuration: AIConfiguration,
-    val reason: String,
-)
+sealed interface RoutingResolution {
+
+    /** Routing succeeded; [configuration] is ready for use. */
+    data class Success(
+        val configuration: AIConfiguration,
+        val reason: String,
+    ) : RoutingResolution
+
+    /**
+     * Routing failed because no registered model meets the declared rung floor.
+     * This is a terminal result — callers must not silently downgrade to a
+     * sub-floor model.
+     */
+    data class FloorUnmet(
+        val requestedFloor: CapabilityRung,
+        val bestAvailableRung: CapabilityRung?,
+    ) : RoutingResolution
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/CognitiveRelayImpl.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/CognitiveRelayImpl.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.datetime.Clock
 import link.socket.ampere.agents.domain.event.EventSource
 import link.socket.ampere.agents.domain.event.RoutingEvent
+import link.socket.ampere.agents.domain.routing.capability.CapabilityRung
 import link.socket.ampere.agents.domain.routing.capability.CheapestCapableFirst
 import link.socket.ampere.agents.domain.routing.capability.ModelDescriptor
 import link.socket.ampere.agents.domain.routing.capability.ModelDescriptorRegistry
@@ -56,7 +57,13 @@ class CognitiveRelayImpl(
         context: RoutingContext,
         fallbackConfiguration: AIConfiguration,
     ): AIConfiguration =
-        resolveWithMetadata(context, fallbackConfiguration).configuration
+        when (val resolution = resolveWithMetadata(context, fallbackConfiguration)) {
+            is RoutingResolution.Success -> resolution.configuration
+            is RoutingResolution.FloorUnmet -> throw RoutingFloorUnmetException(
+                requestedFloor = resolution.requestedFloor,
+                bestAvailableRung = resolution.bestAvailableRung,
+            )
+        }
 
     override suspend fun resolveWithMetadata(
         context: RoutingContext,
@@ -85,6 +92,20 @@ class CognitiveRelayImpl(
         // unavailability — the local-preferred route the relay routed around.
         val skip = firstAvailabilitySkip(currentConfig.rules, context)
 
+        // Floor-unmet check: when a rung floor is requested but no ByCapability
+        // rule's model meets it, resolution is terminal — never silently downgrade.
+        val minRung = context.requirements?.minRung
+        if (matchedRule == null && minRung != null) {
+            val bestAvailableRung = bestRungAmongCapabilityRules(currentConfig.rules)
+            if (bestAvailableRung == null || bestAvailableRung < minRung) {
+                emitRouteFloorUnmet(context, minRung, bestAvailableRung)
+                return RoutingResolution.FloorUnmet(
+                    requestedFloor = minRung,
+                    bestAvailableRung = bestAvailableRung,
+                )
+            }
+        }
+
         val selectedConfig = matchedRule?.configuration
             ?: currentConfig.defaultConfiguration
             ?: fallbackConfiguration
@@ -108,10 +129,25 @@ class CognitiveRelayImpl(
         emitRouteSelected(context, decision)
         costSelection?.let { emitRouteResolved(context, decision, it) }
 
-        return RoutingResolution(
+        return RoutingResolution.Success(
             configuration = selectedConfig,
             reason = ruleDescription,
         )
+    }
+
+    /**
+     * The highest [CapabilityRung] among all [RoutingRule.ByCapability] rules
+     * whose model can be looked up in the registry, or null if none exist. Used
+     * to populate [RoutingEvent.RouteFloorUnmet.bestAvailableRung] for diagnostics.
+     */
+    private suspend fun bestRungAmongCapabilityRules(
+        rules: List<RoutingRule>,
+    ): CapabilityRung? {
+        val reg = registry ?: return null
+        return rules
+            .filterIsInstance<RoutingRule.ByCapability>()
+            .mapNotNull { reg.descriptorFor(it.configuration.model.name)?.rung }
+            .maxOrNull()
     }
 
     /** The first rule whose registry-aware predicate matches [context], if any. */
@@ -220,6 +256,25 @@ class CognitiveRelayImpl(
                 failedModel = skippedConfig.model.name,
                 fallbackDecision = fallbackDecision,
                 failureReason = failureReason,
+            ),
+        )
+    }
+
+    private suspend fun emitRouteFloorUnmet(
+        context: RoutingContext,
+        requestedFloor: CapabilityRung,
+        bestAvailableRung: CapabilityRung?,
+    ) {
+        eventBus?.publish(
+            RoutingEvent.RouteFloorUnmet(
+                eventId = generateUUID("routing"),
+                timestamp = Clock.System.now(),
+                eventSource = context.agentId?.let { EventSource.Agent(it) }
+                    ?: EventSource.Human,
+                agentId = context.agentId,
+                phase = context.phase,
+                requestedFloor = requestedFloor,
+                bestAvailableRung = bestAvailableRung,
             ),
         )
     }

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/CognitiveRelayPassthrough.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/CognitiveRelayPassthrough.kt
@@ -20,7 +20,7 @@ object CognitiveRelayPassthrough : CognitiveRelay {
     override suspend fun resolveWithMetadata(
         context: RoutingContext,
         fallbackConfiguration: AIConfiguration,
-    ): RoutingResolution = RoutingResolution(
+    ): RoutingResolution = RoutingResolution.Success(
         configuration = fallbackConfiguration,
         reason = "passthrough",
     )

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/RoutingFloorUnmetException.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/RoutingFloorUnmetException.kt
@@ -1,0 +1,18 @@
+package link.socket.ampere.agents.domain.routing
+
+import link.socket.ampere.agents.domain.routing.capability.CapabilityRung
+
+/**
+ * Thrown by [CognitiveRelay.resolve] when the routing requirement declares a
+ * [CapabilityRung] floor that no registered model satisfies.
+ *
+ * Callers that need structured failure metadata should use
+ * [CognitiveRelay.resolveWithMetadata] and handle [RoutingResolution.FloorUnmet].
+ */
+class RoutingFloorUnmetException(
+    val requestedFloor: CapabilityRung,
+    val bestAvailableRung: CapabilityRung?,
+) : Exception(
+    "No model meets rung floor ${requestedFloor.ordinal}" +
+        (bestAvailableRung?.let { "; best available: ${it.ordinal}" } ?: "; no capable model found"),
+)

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/utils/SignificanceAwareEventLogger.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/utils/SignificanceAwareEventLogger.kt
@@ -168,6 +168,7 @@ class SignificanceAwareEventLogger(
         is RoutingEvent.RouteSelected -> EventSignificance.ROUTINE
         is RoutingEvent.RouteResolved -> EventSignificance.ROUTINE
         is RoutingEvent.RouteFallback -> EventSignificance.SIGNIFICANT
+        is RoutingEvent.RouteFloorUnmet -> EventSignificance.SIGNIFICANT
 
         // AgentSurface events - significant; users see them directly via the renderer
         is AgentSurfaceEvent.Requested -> EventSignificance.SIGNIFICANT

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/event/RoutingEventTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/event/RoutingEventTest.kt
@@ -144,6 +144,7 @@ class RoutingEventTest {
             is RoutingEvent.RouteSelected -> "selected"
             is RoutingEvent.RouteFallback -> "fallback"
             is RoutingEvent.RouteResolved -> "resolved"
+            is RoutingEvent.RouteFloorUnmet -> "floor-unmet"
         }
 
         val decision = RoutingDecision("P", "M", "rule")

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/routing/CognitiveRelayCapabilityTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/routing/CognitiveRelayCapabilityTest.kt
@@ -104,7 +104,7 @@ class CognitiveRelayCapabilityTest {
             localCapacity = localAvailable,
         )
 
-        val result = relay().resolveWithMetadata(context, agentFallback)
+        val result = relay().resolveWithMetadata(context, agentFallback) as RoutingResolution.Success
 
         assertEquals(AIModel_Claude.Sonnet_4, result.configuration.model)
         assertEquals("capability:${AIProvider_Anthropic.id}", result.reason)
@@ -121,7 +121,7 @@ class CognitiveRelayCapabilityTest {
             ),
         )
 
-        val result = relay().resolveWithMetadata(context, agentFallback)
+        val result = relay().resolveWithMetadata(context, agentFallback) as RoutingResolution.Success
 
         assertEquals(AIModel_Gemini.Flash_2_5, result.configuration.model)
         assertEquals("capability:${AIProvider_Google.id}", result.reason)
@@ -134,7 +134,7 @@ class CognitiveRelayCapabilityTest {
             requirements = CapabilityRequirement(inputs = SupportedInputs.TEXT),
         )
 
-        val result = relay().resolveWithMetadata(context, agentFallback)
+        val result = relay().resolveWithMetadata(context, agentFallback) as RoutingResolution.Success
 
         assertEquals(AIModel_Gemini.Flash_2_5, result.configuration.model)
         assertEquals("capability:${AIProvider_Google.id}", result.reason)
@@ -149,7 +149,7 @@ class CognitiveRelayCapabilityTest {
             ),
         )
 
-        val result = relay().resolveWithMetadata(context, agentFallback)
+        val result = relay().resolveWithMetadata(context, agentFallback) as RoutingResolution.Success
 
         assertEquals(AIModel_Gemini.Flash_2_5, result.configuration.model)
         assertEquals("capability:${AIProvider_Google.id}", result.reason)
@@ -158,7 +158,7 @@ class CognitiveRelayCapabilityTest {
     @Test
     fun `no requirements falls back to agent config`() = runTest {
         // ByCapability never matches without requirements, so no rule applies.
-        val result = relay().resolveWithMetadata(RoutingContext(), agentFallback)
+        val result = relay().resolveWithMetadata(RoutingContext(), agentFallback) as RoutingResolution.Success
 
         assertEquals(AIModel_OpenAI.GPT_4_1, result.configuration.model)
         assertEquals("default", result.reason)
@@ -215,7 +215,7 @@ class CognitiveRelayCapabilityTest {
                 requirements = CapabilityRequirement(minReasoning = RelativeReasoning.HIGH),
             ),
             fallbackConfiguration = agentFallback,
-        )
+        ) as RoutingResolution.Success
 
         assertEquals(AIModel_Claude.Opus_4_5, result.configuration.model)
         assertFalse(result.configuration.model == AIModel_Claude.Haiku_3)

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/routing/CognitiveRelayCostTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/routing/CognitiveRelayCostTest.kt
@@ -70,7 +70,7 @@ class CognitiveRelayCostTest {
         val result = defaultRelay().resolveWithMetadata(
             context = RoutingContext(requirements = worldKnowledge),
             fallbackConfiguration = anthropicConfig,
-        )
+        ) as RoutingResolution.Success
 
         assertEquals(AIModel_Gemini.Flash_2_5, result.configuration.model)
         assertEquals("capability:${AIProvider_Google.id}", result.reason)
@@ -100,7 +100,7 @@ class CognitiveRelayCostTest {
         val result = relay.resolveWithMetadata(
             context = RoutingContext(requirements = worldKnowledge),
             fallbackConfiguration = openaiConfig,
-        )
+        ) as RoutingResolution.Success
 
         assertEquals(AIModel_Claude.Sonnet_4, result.configuration.model)
         assertEquals("capability:${AIProvider_Anthropic.id}", result.reason)
@@ -155,7 +155,7 @@ class CognitiveRelayCostTest {
         val result = relay.resolveWithMetadata(
             context = RoutingContext(requirements = worldKnowledge),
             fallbackConfiguration = openaiConfig,
-        )
+        ) as RoutingResolution.Success
 
         assertEquals(AIModel_Gemini.Flash_2_5, result.configuration.model)
         assertEquals("capability:${AIProvider_Google.id}", result.reason)
@@ -180,7 +180,7 @@ class CognitiveRelayCostTest {
                 requirements = worldKnowledge,
             ),
             fallbackConfiguration = openaiConfig,
-        )
+        ) as RoutingResolution.Success
 
         assertEquals(AIModel_Claude.Sonnet_4, result.configuration.model)
         assertEquals("phase:PERCEIVE", result.reason)

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/routing/CognitiveRelayFloorTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/routing/CognitiveRelayFloorTest.kt
@@ -1,0 +1,247 @@
+package link.socket.ampere.agents.domain.routing
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import link.socket.ampere.agents.domain.event.RoutingEvent
+import link.socket.ampere.agents.domain.routing.capability.CapabilityRequirement
+import link.socket.ampere.agents.domain.routing.capability.CapabilityRung
+import link.socket.ampere.agents.domain.routing.capability.CostPolicy
+import link.socket.ampere.agents.domain.routing.capability.InMemoryModelDescriptorRegistry
+import link.socket.ampere.agents.domain.routing.capability.ModelDescriptor
+import link.socket.ampere.agents.events.api.EventHandler
+import link.socket.ampere.agents.events.bus.EventSerialBus
+import link.socket.ampere.domain.ai.configuration.AIConfiguration_Default
+import link.socket.ampere.domain.ai.model.AIModelFeatures.RelativeReasoning
+import link.socket.ampere.domain.ai.model.AIModelFeatures.SupportedInputs
+import link.socket.ampere.domain.ai.model.AIModel_Claude
+import link.socket.ampere.domain.ai.model.AIModel_Gemini
+import link.socket.ampere.domain.ai.model.AIModel_OpenAI
+import link.socket.ampere.domain.ai.provider.AIProvider_Anthropic
+import link.socket.ampere.domain.ai.provider.AIProvider_Google
+import link.socket.ampere.domain.ai.provider.AIProvider_OpenAI
+
+class CognitiveRelayFloorTest {
+
+    private val lowRungConfig = AIConfiguration_Default(
+        provider = AIProvider_Anthropic,
+        model = AIModel_Claude.Sonnet_4,
+    )
+
+    private val highRungConfig = AIConfiguration_Default(
+        provider = AIProvider_Google,
+        model = AIModel_Gemini.Flash_2_5,
+    )
+
+    private val agentFallback = AIConfiguration_Default(
+        provider = AIProvider_OpenAI,
+        model = AIModel_OpenAI.GPT_4_1,
+    )
+
+    // Registry where all models are rung ONE — no model can satisfy a floor >= TWO.
+    private val lowRungRegistry = InMemoryModelDescriptorRegistry(
+        seed = listOf(
+            ModelDescriptor(
+                modelName = AIModel_Claude.Sonnet_4.name,
+                providerId = AIProvider_Anthropic.id,
+                capabilities = emptySet(),
+                reasoning = RelativeReasoning.LOW,
+                maxContextTokens = 8_192,
+                supportedInputs = SupportedInputs.TEXT,
+                cost = CostPolicy.Free,
+                rung = CapabilityRung.ONE,
+            ),
+            ModelDescriptor(
+                modelName = AIModel_Gemini.Flash_2_5.name,
+                providerId = AIProvider_Google.id,
+                capabilities = emptySet(),
+                reasoning = RelativeReasoning.NORMAL,
+                maxContextTokens = 200_000,
+                supportedInputs = SupportedInputs.TEXT,
+                cost = CostPolicy.Metered,
+                rung = CapabilityRung.TWO,
+            ),
+        ),
+    )
+
+    // Registry with a rung THREE model.
+    private val highRungRegistry = InMemoryModelDescriptorRegistry(
+        seed = listOf(
+            ModelDescriptor(
+                modelName = AIModel_Claude.Sonnet_4.name,
+                providerId = AIProvider_Anthropic.id,
+                capabilities = emptySet(),
+                reasoning = RelativeReasoning.LOW,
+                maxContextTokens = 8_192,
+                supportedInputs = SupportedInputs.TEXT,
+                cost = CostPolicy.Free,
+                rung = CapabilityRung.ONE,
+            ),
+            ModelDescriptor(
+                modelName = AIModel_Gemini.Flash_2_5.name,
+                providerId = AIProvider_Google.id,
+                capabilities = emptySet(),
+                reasoning = RelativeReasoning.HIGH,
+                maxContextTokens = 200_000,
+                supportedInputs = SupportedInputs.TEXT,
+                cost = CostPolicy.Metered,
+                rung = CapabilityRung.THREE,
+            ),
+        ),
+    )
+
+    private fun relayWith(registry: InMemoryModelDescriptorRegistry, eventBus: EventSerialBus? = null) =
+        CognitiveRelayImpl(
+            initialConfig = RelayConfig(
+                rules = listOf(
+                    RoutingRule.ByCapability(lowRungConfig),
+                    RoutingRule.ByCapability(highRungConfig),
+                ),
+            ),
+            eventBus = eventBus,
+            registry = registry,
+        )
+
+    @Test
+    fun `resolveWithMetadata returns FloorUnmet when no model meets the floor`() = runTest {
+        val result = relayWith(lowRungRegistry).resolveWithMetadata(
+            context = RoutingContext(requirements = CapabilityRequirement(minRung = CapabilityRung.THREE)),
+            fallbackConfiguration = agentFallback,
+        )
+
+        assertIs<RoutingResolution.FloorUnmet>(result)
+        assertEquals(CapabilityRung.THREE, result.requestedFloor)
+        // Best available is rung TWO (from Gemini entry in lowRungRegistry).
+        assertEquals(CapabilityRung.TWO, result.bestAvailableRung)
+    }
+
+    @Test
+    fun `resolveWithMetadata returns Success when a model meets the floor`() = runTest {
+        val result = relayWith(highRungRegistry).resolveWithMetadata(
+            context = RoutingContext(requirements = CapabilityRequirement(minRung = CapabilityRung.THREE)),
+            fallbackConfiguration = agentFallback,
+        )
+
+        assertIs<RoutingResolution.Success>(result)
+        assertEquals(AIModel_Gemini.Flash_2_5, result.configuration.model)
+    }
+
+    @Test
+    fun `floor-unmet is terminal — does not silently downgrade to sub-floor agent config`() = runTest {
+        // Without the fix, this would fall through to agentFallback (rung ONE).
+        val result = relayWith(lowRungRegistry).resolveWithMetadata(
+            context = RoutingContext(requirements = CapabilityRequirement(minRung = CapabilityRung.THREE)),
+            fallbackConfiguration = agentFallback,
+        )
+
+        assertIs<RoutingResolution.FloorUnmet>(result)
+    }
+
+    @Test
+    fun `resolve throws RoutingFloorUnmetException when floor is unmet`() = runTest {
+        val ex = assertFailsWith<RoutingFloorUnmetException> {
+            relayWith(lowRungRegistry).resolve(
+                context = RoutingContext(requirements = CapabilityRequirement(minRung = CapabilityRung.THREE)),
+                fallbackConfiguration = agentFallback,
+            )
+        }
+
+        assertEquals(CapabilityRung.THREE, ex.requestedFloor)
+        assertEquals(CapabilityRung.TWO, ex.bestAvailableRung)
+    }
+
+    @Test
+    fun `no minRung requirement resolves normally without triggering floor-unmet`() = runTest {
+        // A requirement with no minRung must not produce FloorUnmet regardless of which
+        // model wins — floor-unmet detection must only fire when minRung is set.
+        val result = relayWith(lowRungRegistry).resolveWithMetadata(
+            context = RoutingContext(requirements = CapabilityRequirement()),
+            fallbackConfiguration = agentFallback,
+        )
+
+        assertIs<RoutingResolution.Success>(result)
+    }
+
+    @Test
+    fun `emits RouteFloorUnmet event when floor is unmet`() = runBlocking {
+        val scope = CoroutineScope(Dispatchers.Default)
+        val eventBus = EventSerialBus(scope)
+        val received = mutableListOf<RoutingEvent.RouteFloorUnmet>()
+
+        eventBus.subscribe(
+            agentId = "floor-subscriber",
+            eventType = RoutingEvent.RouteFloorUnmet.EVENT_TYPE,
+            handler = EventHandler { event, _ ->
+                received.add(event as RoutingEvent.RouteFloorUnmet)
+            },
+        )
+
+        relayWith(lowRungRegistry, eventBus).resolveWithMetadata(
+            context = RoutingContext(
+                requirements = CapabilityRequirement(minRung = CapabilityRung.THREE),
+                agentId = "test-agent",
+            ),
+            fallbackConfiguration = agentFallback,
+        )
+
+        delay(100)
+
+        val event = received.single()
+        assertEquals(CapabilityRung.THREE, event.requestedFloor)
+        assertEquals(CapabilityRung.TWO, event.bestAvailableRung)
+        assertEquals("test-agent", event.agentId)
+    }
+
+    @Test
+    fun `floor-unmet does not emit RouteSelected`() = runBlocking {
+        val scope = CoroutineScope(Dispatchers.Default)
+        val eventBus = EventSerialBus(scope)
+        val selected = mutableListOf<RoutingEvent.RouteSelected>()
+
+        eventBus.subscribe(
+            agentId = "selected-subscriber",
+            eventType = RoutingEvent.RouteSelected.EVENT_TYPE,
+            handler = EventHandler { event, _ ->
+                selected.add(event as RoutingEvent.RouteSelected)
+            },
+        )
+
+        relayWith(lowRungRegistry, eventBus).resolveWithMetadata(
+            context = RoutingContext(requirements = CapabilityRequirement(minRung = CapabilityRung.THREE)),
+            fallbackConfiguration = agentFallback,
+        )
+
+        delay(100)
+
+        assertEquals(0, selected.size, "RouteSelected must not be emitted when floor is unmet")
+    }
+
+    @Test
+    fun `FloorUnmet carries null bestAvailableRung when registry has no descriptors for rules`() = runTest {
+        val emptyRegistry = InMemoryModelDescriptorRegistry(seed = emptyList())
+        val relay = CognitiveRelayImpl(
+            initialConfig = RelayConfig(
+                rules = listOf(RoutingRule.ByCapability(lowRungConfig)),
+            ),
+            registry = emptyRegistry,
+        )
+
+        // No descriptors → bestRungAmongCapabilityRules returns null; no match fires floor-unmet.
+        // However without a descriptor, ByCapability rules evaluate as NoMatch, which means
+        // no rule matches and minRung is set → detect floor-unmet with null best rung.
+        val result = relay.resolveWithMetadata(
+            context = RoutingContext(requirements = CapabilityRequirement(minRung = CapabilityRung.TWO)),
+            fallbackConfiguration = agentFallback,
+        )
+
+        assertIs<RoutingResolution.FloorUnmet>(result)
+        assertNull(result.bestAvailableRung)
+    }
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/routing/CognitiveRelayImplTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/routing/CognitiveRelayImplTest.kt
@@ -233,7 +233,7 @@ class CognitiveRelayImplTest {
         val result = relay.resolveWithMetadata(
             context = RoutingContext(phase = CognitivePhase.PERCEIVE),
             fallbackConfiguration = openaiConfig,
-        )
+        ) as RoutingResolution.Success
 
         assertEquals(AIModel_Gemini.Flash_2_5, result.configuration.model)
         assertEquals("phase:PERCEIVE", result.reason)


### PR DESCRIPTION
## Summary

- Makes `RoutingResolution` a sealed interface (`Success` | `FloorUnmet`) so a rung floor that no registered model satisfies is a typed, terminal result — not a silent downgrade
- Adds `RoutingEvent.RouteFloorUnmet` (HIGH urgency) emitted on `EventSerialBus` alongside existing routing events, carrying `requestedFloor` and `bestAvailableRung` for diagnostics
- `CognitiveRelayImpl.resolve` throws `RoutingFloorUnmetException`; `resolveWithMetadata` returns `FloorUnmet` — callers choose which API surface to use
- `AgentLLMService` throws `RoutingFloorUnmetException` rather than silently falling through to a sub-floor config

## Changes

- `RoutingResolution` → sealed interface (`Success`, `FloorUnmet`) in `CognitiveRelay.kt`
- `RouteFloorUnmet` data class added to `RoutingEvent.kt`
- `RoutingFloorUnmetException` (new file) for the `resolve()` throw path
- `CognitiveRelayImpl`: floor-unmet detection + `emitRouteFloorUnmet` + `bestRungAmongCapabilityRules` helper
- `SignificanceAwareEventLogger`: `RouteFloorUnmet` → `SIGNIFICANT`
- `AgentLLMService`: handles `FloorUnmet` sealed variant
- `CognitiveRelayPassthrough`, `CognitiveRelayCapabilityTest`, `CognitiveRelayCostTest`, `CognitiveRelayImplTest`, `RoutingEventTest`: updated for sealed `RoutingResolution`
- `CognitiveRelayFloorTest` (new): 8 tests covering all validation criteria from the ticket

## Test plan

- [ ] `FloorUnmet` returned when `minRung = THREE` and best available is rung TWO
- [ ] `Success` returned when a rung THREE model exists and matches
- [ ] Floor-unmet is terminal — no sub-floor `AIConfiguration` produced
- [ ] `resolve()` throws `RoutingFloorUnmetException` with correct `requestedFloor` / `bestAvailableRung`
- [ ] `RouteFloorUnmet` event emitted on `EventSerialBus` with correct fields
- [ ] `RouteSelected` NOT emitted when floor is unmet
- [ ] `null` `bestAvailableRung` when registry has no descriptors for the configured rules
- [ ] No regression: `no minRung` requirement resolves to `Success` normally

**Closes:** AMPR-216 · **Depends on:** #577 (T2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)