### PR TITLE
Fix AIModel ALL_MODELS class-init cycle (NPE in CognitiveRelayCostTest et al)

### DIFF
--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/capability/ModelDescriptorRegistry.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/capability/ModelDescriptorRegistry.kt
@@ -116,14 +116,13 @@ class InMemoryModelDescriptorRegistry(
          * One descriptor per model across the three bundled cloud providers,
          * each projected from the model's own metadata.
          *
-         * Computed on demand (not as a class-load constant) so the bundled
-         * `AIProvider`/`AIModel` data-object graph is fully initialized before it
-         * is read. The model lists are taken straight from each `AIModel.*`
-         * companion rather than via `AIProvider.availableModels`: reading the
-         * list through a provider data object initializes it reentrantly
-         * (`AIProvider_*.<clinit>` -> `AIModel_*.<clinit>`), which yields null
-         * model entries. Touching the model companions first sidesteps that
-         * cycle.
+         * Computed on demand (not as a class-load constant). The model lists in
+         * each `AIModel.*` companion are declared `by lazy` to break the JVM
+         * class-init cycle: without lazy, if any data object (e.g.
+         * `AIModel_Gemini.Flash_2_5`) were accessed before its companion
+         * finished initializing, `<clinit>` would observe the object's `INSTANCE`
+         * as null and permanently commit a list with null entries — causing an NPE
+         * here. See the `ALL_MODELS` declarations in `AIModel_Claude` et al.
          */
         fun defaultModelDescriptors(): List<ModelDescriptor> {
             val modelsByProvider = listOf(

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/ai/model/AIModel_Claude.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/ai/model/AIModel_Claude.kt
@@ -462,16 +462,22 @@ sealed class AIModel_Claude(
 
         // ---- Models ----
 
-        val ALL_MODELS = listOf(
-            Opus_4_1,
-            Opus_4,
-            Opus_4_5,
-            Sonnet_4,
-            Sonnet_3_7,
-            Sonnet_4_5,
-            Haiku_3_5,
-            Haiku_3,
-            Haiku_4_5,
-        )
+        // Lazy to avoid the JVM class-init cycle: if any data object (Opus_4_1, etc.)
+        // is accessed before this companion finishes initializing, the companion's
+        // <clinit> would see that object's INSTANCE as null and commit a list with
+        // null entries. Lazy defers evaluation until the companion is fully set up.
+        val ALL_MODELS by lazy {
+            listOf(
+                Opus_4_1,
+                Opus_4,
+                Opus_4_5,
+                Sonnet_4,
+                Sonnet_3_7,
+                Sonnet_4_5,
+                Haiku_3_5,
+                Haiku_3,
+                Haiku_4_5,
+            )
+        }
     }
 }

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/ai/model/AIModel_Gemini.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/ai/model/AIModel_Gemini.kt
@@ -417,13 +417,19 @@ sealed class AIModel_Gemini(
 
         // ---- Models ----
 
-        val ALL_MODELS = listOf(
-            Pro_2_5,
-            Flash_2_5,
-            Flash_Lite_2_5,
-            Flash_2_0,
-            Flash_Lite_2_0,
-            Pro_3_0,
-        )
+        // Lazy to avoid the JVM class-init cycle: if any data object (Pro_2_5, etc.)
+        // is accessed before this companion finishes initializing, the companion's
+        // <clinit> would see that object's INSTANCE as null and commit a list with
+        // null entries. Lazy defers evaluation until the companion is fully set up.
+        val ALL_MODELS by lazy {
+            listOf(
+                Pro_2_5,
+                Flash_2_5,
+                Flash_Lite_2_5,
+                Flash_2_0,
+                Flash_Lite_2_0,
+                Pro_3_0,
+            )
+        }
     }
 }

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/ai/model/AIModel_OpenAI.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/ai/model/AIModel_OpenAI.kt
@@ -667,20 +667,26 @@ sealed class AIModel_OpenAI(
 
         // ---- Models ----
 
-        val ALL_MODELS = listOf(
-            GPT_5,
-            GPT_5_mini,
-            GPT_5_nano,
-            GPT_5_1,
-            GPT_5_1_Chat_Latest,
-            GPT_5_1_Codex_Max,
-            GPT_4_1,
-            GPT_4_1_mini,
-            GPT_4o,
-            GPT_4o_mini,
-            o4_mini,
-            o3,
-            o3_mini,
-        )
+        // Lazy to avoid the JVM class-init cycle: if any data object (GPT_4_1, etc.)
+        // is accessed before this companion finishes initializing, the companion's
+        // <clinit> would see that object's INSTANCE as null and commit a list with
+        // null entries. Lazy defers evaluation until the companion is fully set up.
+        val ALL_MODELS by lazy {
+            listOf(
+                GPT_5,
+                GPT_5_mini,
+                GPT_5_nano,
+                GPT_5_1,
+                GPT_5_1_Chat_Latest,
+                GPT_5_1_Codex_Max,
+                GPT_4_1,
+                GPT_4_1_mini,
+                GPT_4o,
+                GPT_4o_mini,
+                o4_mini,
+                o3,
+                o3_mini,
+            )
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Declares `ALL_MODELS` as `by lazy { listOf(...) }` in the companion objects of `AIModel_Claude`, `AIModel_Gemini`, and `AIModel_OpenAI` to break a JVM class-initialization cycle.
- Without lazy, if any `data object` (e.g. `AIModel_Gemini.Flash_2_5`) was accessed before its companion finished initializing, the companion's `<clinit>` would observe that object's `INSTANCE` as `null` and permanently commit a poisoned list — causing `CognitiveRelayCostTest`, `RouteCostReportTest`, and `ModelDescriptorTest` to NPE when run as part of the full suite but pass in isolation.
- Updates the `defaultModelDescriptors()` kdoc in `ModelDescriptorRegistry` to explain the actual fix.

## Why it passed CI

The failures are ordering-dependent: tests pass when run with `--tests` filter (fresh JVM, no prior class contamination) but fail in the full `jvmTest` run when another test class first touches a model `data object` directly and poisons `ALL_MODELS`. If CI was hitting cached Gradle test results from before the new test files were introduced, the failures never surfaced.

## Test plan

- [x] `./gradlew :ampere-core:jvmTest` passes (all 1366 tests, 0 failures)
- [x] `./gradlew ktlintFormat` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)