### PR TITLE
AMPR-219: T6 — Activate the relay in the CODE production agent path

### DIFF
--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/watch/presentation/EventCategorizer.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/watch/presentation/EventCategorizer.kt
@@ -124,6 +124,10 @@ object EventCategorizer {
         is SparkEvent -> EventSignificance.ROUTINE
 
         is RoutingEvent.RouteFallback -> EventSignificance.SIGNIFICANT
+
+        // A rung floor with no satisfying model is a terminal routing failure:
+        // the call cannot proceed, so it warrants immediate human awareness.
+        is RoutingEvent.RouteFloorUnmet -> EventSignificance.CRITICAL
     }.let { significance ->
         if (event is ProviderCallCompletedEvent && !event.success) {
             EventSignificance.SIGNIFICANT

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/renderer/EventRenderer.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/renderer/EventRenderer.kt
@@ -162,6 +162,7 @@ class EventRenderer(
             is RoutingEvent.RouteSelected -> "🔀" to cyan
             is RoutingEvent.RouteFallback -> "🔀" to yellow
             is RoutingEvent.RouteResolved -> "🔀" to green
+            is RoutingEvent.RouteFloorUnmet -> "🔀" to red
             // Spark events have distinct icons based on type
             is SparkAppliedEvent -> SparkColors.SparkIcons.APPLIED to cyan
             is SparkRemovedEvent -> SparkColors.SparkIcons.REMOVED to gray

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/AgentFactory.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/AgentFactory.kt
@@ -12,6 +12,12 @@ import link.socket.ampere.agents.domain.cognition.sparks.LanguageSparkIds
 import link.socket.ampere.agents.domain.cognition.sparks.PhaseSparkLibrary
 import link.socket.ampere.agents.domain.cognition.sparks.ProjectSpark
 import link.socket.ampere.agents.domain.memory.AgentMemoryService
+import link.socket.ampere.agents.domain.routing.CapabilityRoutingDefaults
+import link.socket.ampere.agents.domain.routing.CognitiveRelay
+import link.socket.ampere.agents.domain.routing.CognitiveRelayImpl
+import link.socket.ampere.agents.domain.routing.RelayConfig
+import link.socket.ampere.agents.domain.routing.capability.CapabilityRung
+import link.socket.ampere.agents.domain.routing.capability.InMemoryModelDescriptorRegistry
 import link.socket.ampere.agents.domain.state.AgentState
 import link.socket.ampere.agents.events.api.AgentEventApi
 import link.socket.ampere.agents.events.bus.EventSerialBus
@@ -80,6 +86,20 @@ class AgentFactory(
     private val cognitiveConfig: CognitiveConfig = CognitiveConfig(),
     private val llmProvider: LlmProvider? = null,
     private val eventSerialBus: EventSerialBus? = null,
+    /**
+     * Relay override for the activated CODE path (AMPR-219). Null builds the
+     * default cloud relay ([effectiveCognitiveRelay]); tests inject a custom
+     * relay (e.g. one whose catalog tops out below the floor) to exercise the
+     * floor-unmet path without standing up the full bundled catalog.
+     */
+    private val cognitiveRelay: CognitiveRelay? = null,
+    /**
+     * Capability-rung floor declared on the activated CODE agent (AMPR-219).
+     * Defaults to [DEFAULT_CODE_AGENT_RUNG]; pass an unsatisfiable rung to
+     * verify the relay returns a typed floor-unmet failure rather than
+     * downgrading.
+     */
+    private val codeAgentMinimumRung: CapabilityRung? = DEFAULT_CODE_AGENT_RUNG,
 ) {
     private val toolWriteCodeFile: Tool<ExecutionContext.Code.WriteCode> =
         toolWriteCodeFileOverride ?: ToolWriteCodeFile(AgentActionAutonomy.ASK_BEFORE_ACTION)
@@ -107,6 +127,27 @@ class AgentFactory(
 
     private val effectiveAiConfiguration: AIConfiguration
         get() = aiConfiguration ?: AIConfigurationFactory.getDefaultConfiguration()
+
+    /**
+     * The live [CognitiveRelay] wired into the activated CODE path (AMPR-219).
+     *
+     * This is the production seam the relay was built for: a real
+     * [CognitiveRelayImpl] over the bundled cloud catalog
+     * ([CapabilityRoutingDefaults.cloudCapabilityRules] +
+     * [InMemoryModelDescriptorRegistry]'s default seed), publishing routing
+     * events on the shared [eventSerialBus]. Selection stays cost-aware; the
+     * agent's declared [codeAgentMinimumRung] is the floor it must clear.
+     *
+     * Built lazily and cached so a single relay (and registry) is shared across
+     * every CODE agent this factory makes. Tests override it via [cognitiveRelay].
+     */
+    private val effectiveCognitiveRelay: CognitiveRelay by lazy {
+        cognitiveRelay ?: CognitiveRelayImpl(
+            initialConfig = RelayConfig(rules = CapabilityRoutingDefaults.cloudCapabilityRules()),
+            eventBus = eventSerialBus,
+            registry = InMemoryModelDescriptorRegistry(),
+        )
+    }
 
     private val agentConfiguration: AgentConfiguration
         get() = AgentConfiguration(
@@ -216,6 +257,11 @@ class AgentFactory(
                 memoryService = memoryService,
                 llmProvider = llmProvider,
                 observabilityScope = scope,
+                // AMPR-219: the CODE path is the one activated production agent.
+                // Only this branch wires the relay + rung floor; PRODUCT,
+                // PROJECT, and QUALITY keep the dormant (null relay) behavior.
+                cognitiveRelay = effectiveCognitiveRelay,
+                minimumRung = codeAgentMinimumRung,
                 tools = buildSet {
                     add(toolWriteCodeFile)
                     add(ToolReadCodeFile(AgentActionAutonomy.FULLY_AUTONOMOUS))
@@ -311,4 +357,14 @@ class AgentFactory(
     private fun requireLanguageSpark(id: String): Spark =
         phaseSparkLibrary.languageSparkById(id)
             ?: error("Bundled language spark '$id' is missing from DefaultPhaseSparkLibrary")
+
+    companion object {
+        /**
+         * Default capability-rung floor for the activated CODE agent (AMPR-219).
+         * THREE ("advanced") keeps code work off entry/standard tiers while
+         * staying satisfiable by the bundled cloud catalog (e.g. Gemini 2.5 Pro,
+         * Claude Sonnet, GPT-4.1 all sit at THREE or above).
+         */
+        val DEFAULT_CODE_AGENT_RUNG: CapabilityRung = CapabilityRung.THREE
+    }
 }

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/SparkBasedAgent.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/SparkBasedAgent.kt
@@ -23,6 +23,8 @@ import link.socket.ampere.agents.domain.reasoning.Idea
 import link.socket.ampere.agents.domain.reasoning.Perception
 import link.socket.ampere.agents.domain.reasoning.Plan
 import link.socket.ampere.agents.domain.reasoning.StepResult
+import link.socket.ampere.agents.domain.routing.CognitiveRelay
+import link.socket.ampere.agents.domain.routing.capability.CapabilityRung
 import link.socket.ampere.agents.domain.state.AgentState
 import link.socket.ampere.agents.domain.task.Task
 import link.socket.ampere.agents.events.api.AgentEventApi
@@ -83,6 +85,23 @@ open class SparkBasedAgent<S : AgentState>(
     private val _observabilityScope: CoroutineScope = CoroutineScope(Dispatchers.Default),
     @Transient
     private val _reasoningOverride: AgentReasoning? = null,
+    /**
+     * Provider-agnostic routing seam (AMPR-219). When set, the agent's
+     * [AgentConfiguration.cognitiveRelay] is populated so every LLM call routes
+     * through the relay's capability/cost-aware selection rather than using the
+     * static [AIConfiguration] directly. Null keeps the pre-activation behavior
+     * (no relay), which is the default for callers that don't opt in.
+     */
+    @Transient
+    private val _cognitiveRelay: CognitiveRelay? = null,
+    /**
+     * Per-agent capability-rung floor (AMPR-219). Threaded onto the agent's
+     * [AgentDefinition] so [AgentLLMService][link.socket.ampere.agents.domain.reasoning.AgentLLMService]
+     * merges it into the [RoutingContext][link.socket.ampere.agents.domain.routing.RoutingContext]
+     * and the relay refuses to route below it. Null declares no floor.
+     */
+    @Transient
+    private val _minimumRung: CapabilityRung? = null,
 ) : ObservableAgent<S>(_eventApi, _observabilityScope) {
 
     @Transient
@@ -132,9 +151,11 @@ open class SparkBasedAgent<S : AgentState>(
                 name = "SparkBasedAgent-$id",
                 description = "A Spark-based agent with affinity: ${affinity.name}",
                 prompt = currentSystemPrompt,
+                minimumRung = _minimumRung,
             ),
             aiConfiguration = effectiveAiConfiguration,
             llmProvider = _llmProvider,
+            cognitiveRelay = _cognitiveRelay,
             upstreamLlmClient = _upstreamLlmClient,
         )
 
@@ -375,6 +396,8 @@ open class SparkBasedAgent<S : AgentState>(
             observabilityScope: CoroutineScope = CoroutineScope(Dispatchers.Default),
             tools: Set<Tool<*>> = emptySet(),
             reasoningOverride: AgentReasoning? = null,
+            cognitiveRelay: CognitiveRelay? = null,
+            minimumRung: CapabilityRung? = null,
         ): SparkBasedAgent<CodeState> {
             val roleSpark = resolveRequiredRoleSpark(
                 registry = sparkRegistry,
@@ -393,6 +416,8 @@ open class SparkBasedAgent<S : AgentState>(
                 _upstreamLlmClient = upstreamLlmClient,
                 _observabilityScope = observabilityScope,
                 _reasoningOverride = reasoningOverride,
+                _cognitiveRelay = cognitiveRelay,
+                _minimumRung = minimumRung,
             )
             agent.spark<SparkBasedAgent<CodeState>>(roleSpark)
             return agent

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/CapabilityRoutingDefaults.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/CapabilityRoutingDefaults.kt
@@ -1,0 +1,46 @@
+package link.socket.ampere.agents.domain.routing
+
+import link.socket.ampere.agents.domain.routing.capability.InMemoryModelDescriptorRegistry
+import link.socket.ampere.domain.ai.configuration.AIConfiguration_Default
+import link.socket.ampere.domain.ai.model.AIModel_Claude
+import link.socket.ampere.domain.ai.model.AIModel_Gemini
+import link.socket.ampere.domain.ai.model.AIModel_OpenAI
+import link.socket.ampere.domain.ai.provider.AIProvider_Anthropic
+import link.socket.ampere.domain.ai.provider.AIProvider_Google
+import link.socket.ampere.domain.ai.provider.AIProvider_OpenAI
+
+/**
+ * Default [RoutingRule.ByCapability] set over the bundled cloud catalog.
+ *
+ * Activating the relay in a production agent path (AMPR-219) needs a real,
+ * non-empty rule list: with no capability rules a declared rung floor can never
+ * be met (the relay has nothing to satisfy it with) and every call would fail
+ * [RoutingResolution.FloorUnmet]. These rules give the relay one
+ * [RoutingRule.ByCapability] per bundled cloud model so cost-aware selection
+ * (AMPR-210) can pick the cheapest model that clears the floor.
+ *
+ * The model lists are pulled from the same `AIModel.*.ALL_MODELS` companions the
+ * [InMemoryModelDescriptorRegistry] seeds from, so rules and descriptors stay in
+ * lockstep — every rule's model has a descriptor (with a rung) to evaluate
+ * against. Rule order is irrelevant to the winner: the first capability match
+ * only flips the relay into cost-aware mode, after which the cheapest capable
+ * candidate wins regardless of position.
+ */
+object CapabilityRoutingDefaults {
+
+    /**
+     * One [RoutingRule.ByCapability] per bundled cloud model, across the three
+     * bundled providers. Pair this with an [InMemoryModelDescriptorRegistry]
+     * (its default seed) so each rule's model resolves to a descriptor.
+     */
+    fun cloudCapabilityRules(): List<RoutingRule.ByCapability> =
+        listOf(
+            Pair(AIProvider_Google, AIModel_Gemini.ALL_MODELS),
+            Pair(AIProvider_Anthropic, AIModel_Claude.ALL_MODELS),
+            Pair(AIProvider_OpenAI, AIModel_OpenAI.ALL_MODELS),
+        ).flatMap { (provider, models) ->
+            models.map { model ->
+                RoutingRule.ByCapability(AIConfiguration_Default(provider, model))
+            }
+        }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/agent/bundled/AgentDefinition.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/agent/bundled/AgentDefinition.kt
@@ -51,6 +51,12 @@ sealed interface AgentDefinition {
     companion object {
         /**
          * Creates a custom agent definition with minimal configuration.
+         *
+         * @param minimumRung Optional capability-rung floor for this agent. When
+         *   set, [AgentLLMService][link.socket.ampere.agents.domain.reasoning.AgentLLMService]
+         *   threads it into the [RoutingContext][link.socket.ampere.agents.domain.routing.RoutingContext]
+         *   so the relay refuses to route below it (AMPR-219). Defaults to `null`
+         *   (no floor), preserving the prior behavior for existing callers.
          */
         fun Custom(
             name: String,
@@ -58,6 +64,7 @@ sealed interface AgentDefinition {
             prompt: String,
             requiredInputs: List<AgentInput> = emptyList(),
             optionalInputs: List<AgentInput> = emptyList(),
+            minimumRung: CapabilityRung? = null,
             aiConfigurationBuilder: (AIConfigurationFactory) -> AIConfiguration = { it.getDefaultConfiguration() },
         ): AgentDefinition = object : Custom(
             name = name,
@@ -66,6 +73,8 @@ sealed interface AgentDefinition {
             prompt = prompt,
             requiredInputs = requiredInputs,
             optionalInputs = optionalInputs,
-        ) {}
+        ) {
+            override val minimumRung: CapabilityRung? = minimumRung
+        }
     }
 }

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/definition/SparkBasedAgentRelayActivationTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/definition/SparkBasedAgentRelayActivationTest.kt
@@ -1,0 +1,217 @@
+package link.socket.ampere.agents.definition
+
+import com.aallam.openai.api.chat.ChatChoice
+import com.aallam.openai.api.chat.ChatCompletion
+import com.aallam.openai.api.chat.ChatCompletionRequest
+import com.aallam.openai.api.chat.ChatMessage
+import com.aallam.openai.api.chat.ChatRole
+import com.aallam.openai.api.model.ModelId
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import link.socket.ampere.agents.config.AgentConfiguration
+import link.socket.ampere.agents.domain.cognition.sparks.DefaultPhaseSparkLibrary
+import link.socket.ampere.agents.domain.cognition.sparks.PhaseSparkLibrary
+import link.socket.ampere.agents.domain.event.Event
+import link.socket.ampere.agents.domain.event.RoutingEvent
+import link.socket.ampere.agents.domain.routing.CapabilityRoutingDefaults
+import link.socket.ampere.agents.domain.routing.CognitiveRelay
+import link.socket.ampere.agents.domain.routing.CognitiveRelayImpl
+import link.socket.ampere.agents.domain.routing.RelayConfig
+import link.socket.ampere.agents.domain.routing.RoutingFloorUnmetException
+import link.socket.ampere.agents.domain.routing.capability.CapabilityRung
+import link.socket.ampere.agents.domain.routing.capability.InMemoryModelDescriptorRegistry
+import link.socket.ampere.agents.events.api.EventHandler
+import link.socket.ampere.agents.events.bus.EventSerialBus
+import link.socket.ampere.domain.ai.configuration.AIConfiguration
+import link.socket.ampere.domain.ai.configuration.AIConfiguration_Default
+import link.socket.ampere.domain.ai.model.AIModel_Gemini
+import link.socket.ampere.domain.ai.model.AIModel_OpenAI
+import link.socket.ampere.domain.ai.provider.AIProvider_Google
+import link.socket.ampere.domain.ai.provider.AIProvider_OpenAI
+import link.socket.ampere.llm.UpstreamLlmClient
+
+/**
+ * AMPR-219 (T6): end-to-end activation of the [CognitiveRelay] in the one
+ * production agent path it was built for — the `SparkBasedAgent.Code` factory
+ * (the agent `AgentFactory` builds for [AgentType.CODE]).
+ *
+ * Unlike the lower-level relay unit tests, these drive a **real bundled agent**
+ * (`SparkBasedAgent.Code`) end to end through its own `callLLM` seam, so the full
+ * chain executes live: `AgentDefinition.minimumRung` floor → `RoutingContext` →
+ * `CognitiveRelayImpl.resolveWithMetadata` → model-keyed cost-aware selection →
+ * the outbound client. This is exactly the "tier system with a live consumer"
+ * the ticket exists to validate.
+ *
+ * The relay + registry mirror what `AgentFactory` wires for the CODE path:
+ * [CapabilityRoutingDefaults.cloudCapabilityRules] over the default
+ * [InMemoryModelDescriptorRegistry] seed.
+ */
+class SparkBasedAgentRelayActivationTest {
+
+    private val sparkLibrary: PhaseSparkLibrary = runBlocking { DefaultPhaseSparkLibrary.load() }
+
+    // The agent's static fallback, used only if the relay matches no rule. With
+    // the full cloud catalog and a satisfiable floor a capability rule always
+    // matches, so this is never the selected route in the happy-path test.
+    private val agentFallback = AIConfiguration_Default(AIProvider_OpenAI, AIModel_OpenAI.GPT_4_1)
+
+    private fun productionLikeRelay(eventBus: EventSerialBus): CognitiveRelay =
+        CognitiveRelayImpl(
+            initialConfig = RelayConfig(rules = CapabilityRoutingDefaults.cloudCapabilityRules()),
+            eventBus = eventBus,
+            registry = InMemoryModelDescriptorRegistry(),
+        )
+
+    @Test
+    fun `Code factory wires the relay and rung floor onto its AgentConfiguration`() {
+        val eventBus = EventSerialBus(CoroutineScope(Dispatchers.Default))
+        val relay = productionLikeRelay(eventBus)
+
+        val agent = SparkBasedAgent.Code(
+            sparkRegistry = sparkLibrary,
+            agentId = "code-relay-wiring",
+            aiConfiguration = agentFallback,
+            cognitiveRelay = relay,
+            minimumRung = CapabilityRung.THREE,
+        )
+
+        val config: AgentConfiguration = agent.agentConfiguration
+        assertNotNull(config.cognitiveRelay, "Code factory must set the cognitive relay on the config")
+        assertEquals(
+            CapabilityRung.THREE,
+            config.agentDefinition.minimumRung,
+            "Code factory must declare the rung floor on the agent definition",
+        )
+    }
+
+    @Test
+    fun `a real Code-agent run resolves through the relay, respects the floor, and emits route events`() {
+        val eventBus = EventSerialBus(CoroutineScope(Dispatchers.Default))
+        val routeSelected = subscribe(eventBus, RoutingEvent.RouteSelected.EVENT_TYPE)
+        val routeResolved = subscribe(eventBus, RoutingEvent.RouteResolved.EVENT_TYPE)
+        val client = RecordingUpstreamClient("code-response")
+
+        val agent = SparkBasedAgent.Code(
+            sparkRegistry = sparkLibrary,
+            agentId = "code-relay-run",
+            aiConfiguration = agentFallback,
+            upstreamLlmClient = client,
+            cognitiveRelay = productionLikeRelay(eventBus),
+            minimumRung = CapabilityRung.THREE,
+        )
+
+        // A genuine call through the agent's own LLM path (not the relay directly).
+        val response = agent.callLLM("Refactor this function.")
+
+        assertEquals("code-response", response)
+
+        // Floor respected: the relay selected the cheapest catalog model whose
+        // rung clears THREE — Gemini 2.5 Pro (Google, the cheapest provider,
+        // rung THREE). It must NOT have downgraded to a sub-floor model.
+        val selectedConfig = client.lastConfig.get()
+        assertNotNull(selectedConfig, "the outbound client must have been called with a resolved config")
+        assertEquals(
+            AIModel_Gemini.Pro_2_5.name,
+            selectedConfig.model.name,
+            "relay should resolve to the cheapest rung>=THREE model in the catalog",
+        )
+
+        runBlocking { delay(EVENT_DELIVERY_MS) }
+
+        assertEquals(1, routeSelected.size, "exactly one RouteSelected must fire on the live relay path")
+        val decision = (routeSelected.first() as RoutingEvent.RouteSelected).decision
+        assertEquals(AIProvider_Google.name, decision.providerName)
+        assertEquals(AIModel_Gemini.Pro_2_5.name, decision.modelName)
+
+        assertTrue(
+            routeResolved.isNotEmpty(),
+            "cost-aware capability selection must emit RouteResolved",
+        )
+        val resolved = routeResolved.first() as RoutingEvent.RouteResolved
+        assertEquals(AIModel_Gemini.Pro_2_5.name, resolved.decision.modelName)
+        assertTrue(resolved.candidateCount > 1, "multiple catalog models clear THREE, so >1 candidate")
+    }
+
+    @Test
+    fun `an unsatisfiable floor yields a typed failure and RouteFloorUnmet rather than a downgrade`() {
+        val eventBus = EventSerialBus(CoroutineScope(Dispatchers.Default))
+        val floorUnmet = subscribe(eventBus, RoutingEvent.RouteFloorUnmet.EVENT_TYPE)
+        val client = RecordingUpstreamClient("must-not-be-called")
+
+        // A rung above anything in the bundled catalog (which tops out at FOUR):
+        // no model can satisfy it, so the relay must fail terminally.
+        val unsatisfiableFloor = CapabilityRung(CapabilityRung.FOUR.ordinal + 1)
+
+        val agent = SparkBasedAgent.Code(
+            sparkRegistry = sparkLibrary,
+            agentId = "code-relay-floor-unmet",
+            aiConfiguration = agentFallback,
+            upstreamLlmClient = client,
+            cognitiveRelay = productionLikeRelay(eventBus),
+            minimumRung = unsatisfiableFloor,
+        )
+
+        val failure = assertFailsWith<RoutingFloorUnmetException> {
+            agent.callLLM("Refactor this function.")
+        }
+        assertEquals(unsatisfiableFloor, failure.requestedFloor)
+        assertEquals(CapabilityRung.FOUR, failure.bestAvailableRung)
+
+        // No downgrade: the outbound client must never have been invoked.
+        assertNull(client.lastConfig.get(), "an unmet floor must not fall through to any model")
+
+        runBlocking { delay(EVENT_DELIVERY_MS) }
+        assertEquals(1, floorUnmet.size, "exactly one RouteFloorUnmet must fire")
+        val event = floorUnmet.first() as RoutingEvent.RouteFloorUnmet
+        assertEquals(unsatisfiableFloor, event.requestedFloor)
+        assertEquals(CapabilityRung.FOUR, event.bestAvailableRung)
+    }
+
+    private fun subscribe(eventBus: EventSerialBus, eventType: String): MutableList<Event> {
+        val received = CopyOnWriteArrayList<Event>()
+        eventBus.subscribe(
+            agentId = "test-subscriber-$eventType",
+            eventType = eventType,
+            handler = EventHandler { event, _ -> received.add(event) },
+        )
+        return received
+    }
+
+    private class RecordingUpstreamClient(
+        private val cannedResponse: String,
+    ) : UpstreamLlmClient {
+        val lastConfig = AtomicReference<AIConfiguration?>(null)
+
+        override suspend fun call(
+            request: ChatCompletionRequest,
+            configuration: AIConfiguration,
+        ): ChatCompletion {
+            lastConfig.set(configuration)
+            return ChatCompletion(
+                id = "rec",
+                created = 0L,
+                model = ModelId(configuration.model.name),
+                choices = listOf(
+                    ChatChoice(
+                        index = 0,
+                        message = ChatMessage(role = ChatRole.Assistant, content = cannedResponse),
+                    ),
+                ),
+            )
+        }
+    }
+
+    companion object {
+        private const val EVENT_DELIVERY_MS = 150L
+    }
+}


### PR DESCRIPTION
## Summary

Activates the capability/cost-aware `CognitiveRelay` in **one** real bundled agent path — `SparkBasedAgent.Code` (the agent `AgentFactory` builds for `AgentType.CODE`) — so the full selection seam runs live at least once: `AgentDefinition.minimumRung` floor → `RoutingContext` → `CognitiveRelayImpl.resolveWithMetadata` → model-keyed cost-aware selection → outbound client. Manual constructor injection, **no Koin**.

Closes the antipattern AMPR-219 targets: the tier system is no longer assertion-only — it has a live consumer, validated end-to-end, with a recorded go/no-go verdict.

Resolves AMPR-219 / #575.

## Changes

- **`SparkBasedAgent.kt`** — new `_cognitiveRelay` / `_minimumRung` constructor params, threaded into the `agentConfiguration` getter (`cognitiveRelay`, `AgentDefinition.Custom(minimumRung = …)`) and exposed on the `Code` factory.
- **`CapabilityRoutingDefaults.kt`** (new) — one `ByCapability` rule per bundled cloud model, in lockstep with the `InMemoryModelDescriptorRegistry` seed. Without it any declared floor would always be `FloorUnmet`.
- **`AgentFactory.kt`** — builds a real `CognitiveRelayImpl` + `InMemoryModelDescriptorRegistry` over the shared `eventSerialBus`, wired into the **CODE path only** (`DEFAULT_CODE_AGENT_RUNG = THREE`). PRODUCT / PROJECT / QUALITY stay dormant (null relay).
- **`AgentDefinition.kt`** — `Custom` factory now carries `minimumRung` (defaults `null` → non-breaking for existing callers).

## Validation (end-to-end, not unit-only)

`SparkBasedAgentRelayActivationTest` drives a **real `SparkBasedAgent.Code`** through its own `callLLM` seam:

1. **Wiring** — `Code(...)` sets `cognitiveRelay` and declares `minimumRung = THREE`.
2. **Live resolution + floor respected** — resolves to **Gemini 2.5 Pro** (cheapest rung-≥THREE catalog model); no downgrade. Emits `RouteSelected` + `RouteResolved` (cost-aware, candidateCount > 1).
3. **Unsatisfiable floor → typed failure** — a floor above the catalog (rung 5) throws `RoutingFloorUnmetException` + emits `RouteFloorUnmet`; the outbound client is never invoked.

`./gradlew :ampere-core:jvmTest` (new test + existing `AgentDefinitionRungThreadingTest` / `SparkBasedAgentCodeFactoryTest`), `:ampere-core:compileCommonMainKotlinMetadata`, and `ktlintFormat` pass.

> Pre-existing, unrelated NPE failures in `ModelDescriptorTest` / `ModelDescriptorRegistryRungTest` (model-graph class-init reentrancy) exist on `main` and are out of scope here.

## Out of scope

- Activating all agents — only CODE, by design.
- Consent/metering interplay — flagged for the metering epic, not solved here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)