### PR TITLE
Increment version to 0.10.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,4 +26,4 @@ sqldelight.version=2.2.1
 mosaic.version=0.18.0
 
 #Ampere
-ampereVersion=0.9.0
+ampereVersion=0.10.0


### PR DESCRIPTION
Increment the Ampere version from 0.9.0 to 0.10.0 for the next development cycle. Version 0.9.0 has been tagged on the previous commit for release continuity.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>