### PR TITLE
AMPR-186 #533: Bench eval harness that runs Probes

### DIFF
--- a/RECON-bench.md
+++ b/RECON-bench.md
@@ -1,0 +1,162 @@
+# RECON-bench: Arc invocation & Link injection seam
+
+**Issue:** AMPR-190 — ampere-eval 4·recon
+**Feeds:** AMPR-186 — ampere-eval 4 (Bench harness)
+**Date:** 2026-07-28
+
+---
+
+## A. Arc invocation entry point
+
+An Arc is not a class with a `run()` method — it's data (`ArcConfig`) driven by an
+orchestrator, `AmpereRuntime`:
+
+- `ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/arc/AmpereRuntime.kt:36-41`
+  ```kotlin
+  class AmpereRuntime(
+      private val arcConfig: ArcConfig,
+      private val projectDir: Path,
+      private val fileSystem: FileSystem = systemFileSystem,
+      private val maxFlowTicks: Int = 100,
+  )
+  ```
+- `AmpereRuntime.kt:54` — `suspend fun execute(userGoal: String): ArcExecutionResult` drives
+  **Charge → Flow → Pulse**:
+  - `executeCharge` (line 97): builds `ChargePhase(arcConfig, projectDir, fileSystem)`,
+    calls `.execute(userGoal)` → spawns agents via `ArcAgentSpawner` (`ChargePhase.kt:290`),
+    which uses a default-constructed `agentFactory: SparkAgentFactory = SparkAgentFactory()`
+    (`ChargePhase.kt:291`).
+  - `executeFlow` (line 106): builds `FlowPhase(arcConfig, agents = chargeResult.agents, goalTree, maxTicks)`,
+    calls `.execute()`.
+  - `executePulse` (line 116): builds `PulsePhase(...)`.
+
+**No parameter in this call chain accepts a `CognitiveRelay`.** `AmpereRuntime`,
+`ChargePhase`, `ArcAgentSpawner`, and `FlowPhase` have zero constructor params/fields for a
+relay. `ArcAgentSpawner.spawn()` (`ChargePhase.kt:293`) calls
+`agentFactory.createAgent(id, affinity)` → `SparkAgentFactory.createAgent`
+(`SparkAgentFactory.kt:165-181`), which builds a bare `SparkBasedAgent` with no
+`_cognitiveRelay` argument — relay stays `null`.
+
+This is a **different factory** from the one wired up in AMPR-219
+(`agents/definition/AgentFactory.kt`), which is not used by the Arc path. The Arc invocation
+path currently has **no relay-injection seam** — it's dormant even for real runs.
+
+## B. CognitiveRelay
+
+Interface: `ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/CognitiveRelay.kt:18-55`
+```kotlin
+interface CognitiveRelay {
+    val config: RelayConfig
+    suspend fun resolve(context: RoutingContext, fallbackConfiguration: AIConfiguration): AIConfiguration
+    suspend fun resolveWithMetadata(context: RoutingContext, fallbackConfiguration: AIConfiguration): RoutingResolution
+    suspend fun updateConfig(newConfig: RelayConfig)
+}
+```
+
+`PlaybackRelay` (`ampere-eval/src/commonMain/kotlin/link/socket/ampere/eval/relay/PlaybackRelay.kt:88-173`)
+implements this interface directly, replaying a recorded `Trace`'s routing decisions in call
+order, with `MissPolicy.Error`/`Delegate` and an optional `liveDelegate: CognitiveRelay?`.
+
+Production wiring (AMPR-219, commit `61c2311b`) is **manual constructor injection**, not DI:
+`agents/definition/AgentFactory.kt:144-145` lazily builds
+`effectiveCognitiveRelay: CognitiveRelay = cognitiveRelay ?: CognitiveRelayImpl(...)`, passed
+only into the `AgentType.CODE` branch of `createAgent` (`AgentFactory.kt:263`). This flows
+through `SparkBasedAgent`'s `_cognitiveRelay` param (`SparkBasedAgent.kt:88-101`) into
+`AgentConfiguration.cognitiveRelay`, used by `AgentLLMService` to resolve LLM calls.
+
+Since the Arc path uses `SparkAgentFactory`, not `AgentFactory`, and
+`SparkAgentFactory.createAgent` has no relay parameter, **Bench cannot inject a
+`PlaybackRelay`/relay into an Arc run today** without either:
+1. Threading an optional `cognitiveRelay: CognitiveRelay?` through
+   `AmpereRuntime → ChargePhase → ArcAgentSpawner → SparkAgentFactory.createAgent →
+   SparkBasedAgent`, mirroring the `AgentFactory`/`SparkBasedAgent._cognitiveRelay` precedent
+   (mechanical, multi-file, low risk since it's purely additive/optional), or
+2. Bypassing `AmpereRuntime` and driving `ChargePhase`/`FlowPhase` manually with agents built
+   via the AMPR-219-style `AgentFactory` instead of `SparkAgentFactory`.
+
+**Recommendation: option 1** — it's additive (new optional constructor param defaulting to
+`null`/current behavior), doesn't fork the Arc execution path, and reuses the exact pattern
+already proven in production by AMPR-219.
+
+## C. Link execution model ("Execute step")
+
+There is no class literally named `Link` in the repo. The "Execute step" referred to in
+AMPR-186 is `ExecuteStep`:
+
+`ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/propel/ExecuteStep.kt:33-80`
+— single entry point for plugin/MCP tool invocation during the PROPEL "Execute" phase:
+```kotlin
+class ExecuteStep(private val context: PluginContext, private val userGrantProvider: ...) {
+    suspend fun execute(toolId: ToolId, arguments: JsonElement?): ExecuteResult
+}
+```
+Dispatches `McpTool` calls through `context.mcpClientFor(tool).callTool(...)` (line 75).
+
+The broader tool abstraction is `Tool`/`FunctionTool`/`McpTool`
+(`agents/execution/tools/`), executed via `ToolExecutionEngine`
+(`agents/execution/ToolExecutionEngine.kt`) → `Executor` interface
+(`agents/execution/executor/Executor.kt`; implementations `FunctionExecutor`, `McpExecutor`).
+Concrete `FunctionTool`s with real side effects: `ToolWriteCodeFile` (writes files),
+`ToolCreateIssues` (creates GitHub issues), `git/GitTools` (shells out to git),
+`ToolRunTests` (runs test processes), `ToolAskHuman` (notifies a human via `Notifier`).
+Read-only tools (`ToolReadCodeFile`, `ToolReadCodebase`, `ToolPlanSteps`,
+`KnowledgeQueryTool`) are already effect-free.
+
+**Existing seam:** `Executor` is already an interface (strategy-pattern-ready via
+`ToolExecutionEngine.registerStrategy`), but **no no-op/dry-run `Executor` implementation
+exists today** and no global dry-run flag exists anywhere in the tool/executor stack.
+
+**Assessment: this is the hard part**, as flagged in the ticket. Cleanest approach: introduce
+a `NoOpExecutor : Executor` in `ampere-eval` that intercepts calls before they reach
+`FunctionExecutor`/`McpExecutor`, records a `Reading`-relevant no-op result, and never invokes
+the real side-effecting code paths. Thread it into `ToolExecutionEngine` per-agent for
+bench-mode runs (mirrors how `Executor` is already selected per tool type). This requires new
+code but no changes to existing `Executor` implementations — a clean boundary, not a fork.
+
+## D. Run lifecycle / event bus
+
+Bus: `EventSerialBus` (`ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/bus/EventSerialBus.kt:29-`),
+`publish(event: Event)` (line 45) dispatches to subscribers by `event.eventType` +
+`parentEventTypes`. Base hierarchy: `agents/domain/event/Event.kt`. Normally published via
+`AgentEventApi.publish(event)` (`agents/events/api/AgentEventApi.kt:71-74`).
+
+Existing lifecycle-style sealed event families to copy the pattern from: `TaskEvent`
+(`TaskStarted`/`TaskProgressed`/`TaskCompleted`, `agents/domain/event/TaskEvent.kt:20+`,
+published via `AgentEventApi.publishTaskStarted` etc., lines 311-368) and `RoutingEvent`
+(`RouteSelected`/`RouteFallback`/`RouteResolved`/`RouteFloorUnmet`,
+`agents/domain/event/RoutingEvent.kt:21+`).
+
+**`AmpereRuntime`, `ChargePhase`, and `FlowPhase` publish no events today** — grep for
+`eventApi|emit|publish|bus\.` across `FlowPhase.kt` returns nothing, and
+`ArcAgentSpawner`'s default `SparkAgentFactory()` leaves `eventApiFactory = null`. An Arc run
+today emits zero bus events by default.
+
+This means Bench isn't overriding existing lifecycle instrumentation — it's adding new
+instrumentation. The `TaskEvent`/`AgentEventApi.publish` pattern is directly copyable for a
+new `BenchEvent` sealed interface (`BenchRunStarted`/`ProbeGraded`/`BenchRunCompleted`) living
+in `ampere-eval`, published by `Bench` itself around each probe run — Bench does not need
+`AmpereRuntime`/`FlowPhase` to emit anything, since Bench wraps the whole `Arc.execute()`
+call and knows start/completion by construction. Per-tick/step events are optional/deferred
+since nothing upstream provides that granularity today.
+
+## Effect-free strategy assessment
+
+Two of three seams need new (additive) code; one is a straightforward reuse:
+
+1. **Relay injection** — moderately painful but low-risk: thread an optional
+   `cognitiveRelay: CognitiveRelay?` through `AmpereRuntime → ChargePhase → ArcAgentSpawner →
+   SparkAgentFactory → SparkBasedAgent`, mirroring the AMPR-219 `AgentFactory` precedent.
+   Purely additive — default `null` preserves current behavior.
+2. **Effect-free Links** — the hard part, as the ticket predicted. No existing dry-run
+   capability. Introduce `NoOpExecutor : Executor` in `ampere-eval`, thread it into
+   `ToolExecutionEngine` for bench-mode agent construction. Clean interface boundary, new
+   code, no changes to existing executors.
+3. **Lifecycle events** — easy: Bench owns its own `BenchEvent` sealed family and publishes
+   around each probe's `Arc.execute()` call via the existing `AgentEventApi`/bus pattern; no
+   upstream instrumentation gap to fill for the ticket's required granularity
+   (start/probe-graded/completion).
+
+**Recommended implementation order for AMPR-186:**
+`4.1` (types) → thread relay injection through the Arc path (prerequisite for `4.3`) →
+`4.2`/`NoOpExecutor` (effect-free Links) → `4.3` (Bench replay mode) → `4.5` (lifecycle events
++ report) → `4.4` (Bench live mode, flag-gated).

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/watch/presentation/EventCategorizer.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/watch/presentation/EventCategorizer.kt
@@ -1,6 +1,7 @@
 package link.socket.ampere.cli.watch.presentation
 
 import link.socket.ampere.agents.domain.event.AgentSurfaceEvent
+import link.socket.ampere.agents.domain.event.BenchEvent
 import link.socket.ampere.agents.domain.event.CognitiveEvent
 import link.socket.ampere.agents.domain.event.CognitivePhaseEvent
 import link.socket.ampere.agents.domain.event.EmissionEvent
@@ -121,9 +122,12 @@ object EventCategorizer {
         is RoutingEvent.RouteSelected,
         is RoutingEvent.RouteResolved,
         is CognitivePhaseEvent,
-        is SparkEvent -> EventSignificance.ROUTINE
+        is SparkEvent,
+        is BenchEvent.BenchRunStarted,
+        is BenchEvent.ProbeGraded -> EventSignificance.ROUTINE
 
-        is RoutingEvent.RouteFallback -> EventSignificance.SIGNIFICANT
+        is RoutingEvent.RouteFallback,
+        is BenchEvent.BenchRunCompleted -> EventSignificance.SIGNIFICANT
 
         // A rung floor with no satisfying model is a terminal routing failure:
         // the call cannot proceed, so it warrants immediate human awareness.

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/renderer/EventRenderer.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/renderer/EventRenderer.kt
@@ -13,6 +13,7 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import link.socket.ampere.agents.domain.Urgency
 import link.socket.ampere.agents.domain.event.AgentSurfaceEvent
+import link.socket.ampere.agents.domain.event.BenchEvent
 import link.socket.ampere.agents.domain.event.CognitiveEvent
 import link.socket.ampere.agents.domain.event.CognitivePhaseEvent
 import link.socket.ampere.agents.domain.event.EmissionEvent
@@ -174,6 +175,8 @@ class EventRenderer(
             // Emission events: the unifying CHI primitive (produced/resolved)
             is EmissionEvent.Produced -> "📡" to magenta
             is EmissionEvent.Resolved -> "📡" to blue
+            // Bench (eval) lifecycle events
+            is BenchEvent -> "🧪" to cyan
         }
     }
 

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/SparkAgentFactory.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/SparkAgentFactory.kt
@@ -11,8 +11,10 @@ import link.socket.ampere.agents.domain.cognition.sparks.ProjectSpark
 import link.socket.ampere.agents.domain.cognition.sparks.RoleSparkIds
 import link.socket.ampere.agents.domain.cognition.sparks.SparkRegistry
 import link.socket.ampere.agents.domain.memory.AgentMemoryService
+import link.socket.ampere.agents.domain.routing.CognitiveRelay
 import link.socket.ampere.agents.events.api.AgentEventApi
 import link.socket.ampere.agents.events.utils.generateUUID
+import link.socket.ampere.agents.execution.executor.Executor
 import link.socket.ampere.domain.ai.configuration.AIConfiguration
 
 /**
@@ -32,6 +34,8 @@ import link.socket.ampere.domain.ai.configuration.AIConfiguration
  * @param memoryServiceFactory Creates per-agent memory services
  * @param defaultAiConfiguration Default AI configuration for agents
  * @param sparkRegistry Optional declarative spark registry; defaults to bundled fixtures
+ * @param cognitiveRelay Optional relay injected into created agents (e.g. a `PlaybackRelay` for eval Bench runs)
+ * @param executor Optional tool executor injected into created agents (e.g. a `NoOpExecutor` for effect-free Bench runs)
  */
 class SparkAgentFactory(
     private val scope: CoroutineScope = CoroutineScope(Dispatchers.Default),
@@ -39,6 +43,8 @@ class SparkAgentFactory(
     private val memoryServiceFactory: ((AgentId) -> AgentMemoryService)? = null,
     private val defaultAiConfiguration: AIConfiguration? = null,
     private val sparkRegistry: SparkRegistry? = null,
+    private val cognitiveRelay: CognitiveRelay? = null,
+    private val executor: Executor? = null,
 ) {
     private val effectiveSparkRegistry: SparkRegistry
         get() = sparkRegistry ?: DefaultSparkCatalog.registry
@@ -177,6 +183,8 @@ class SparkAgentFactory(
             _memoryService = memoryService,
             _aiConfiguration = defaultAiConfiguration,
             _observabilityScope = scope,
+            _cognitiveRelay = cognitiveRelay,
+            _executor = executor,
         )
     }
 

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/SparkBasedAgent.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/SparkBasedAgent.kt
@@ -29,6 +29,7 @@ import link.socket.ampere.agents.domain.state.AgentState
 import link.socket.ampere.agents.domain.task.Task
 import link.socket.ampere.agents.events.api.AgentEventApi
 import link.socket.ampere.agents.events.utils.generateUUID
+import link.socket.ampere.agents.execution.executor.Executor
 import link.socket.ampere.agents.execution.request.ExecutionContext
 import link.socket.ampere.agents.execution.request.ExecutionRequest
 import link.socket.ampere.agents.execution.tools.Tool
@@ -102,6 +103,14 @@ open class SparkBasedAgent<S : AgentState>(
      */
     @Transient
     private val _minimumRung: CapabilityRung? = null,
+    /**
+     * Tool executor seam (AMPR-186). When set, tool calls dispatch through this
+     * [Executor] (e.g. a `NoOpExecutor` for effect-free eval Bench runs) instead
+     * of leaving the tool-execution engine unconfigured. Null preserves the
+     * pre-existing behavior (no executor, tool calls fail as "not configured").
+     */
+    @Transient
+    private val _executor: Executor? = null,
 ) : ObservableAgent<S>(_eventApi, _observabilityScope) {
 
     @Transient
@@ -177,6 +186,7 @@ open class SparkBasedAgent<S : AgentState>(
         ) {
             agentRole = "Spark-Based Agent (${affinity.name})"
             availableTools = requiredTools
+            executor = _executor
         }
     }
 

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/BenchEvent.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/BenchEvent.kt
@@ -1,0 +1,91 @@
+package link.socket.ampere.agents.domain.event
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.Serializable
+import link.socket.ampere.agents.domain.Urgency
+
+/**
+ * Eval `Bench` run lifecycle events flowing through the `EventSerialBus` (AMPR-186 task 4.5).
+ *
+ * Lives alongside [TaskEvent]/[RoutingEvent] rather than in `ampere-eval` because `Event` is a
+ * sealed interface — Kotlin requires sealed subtypes to share both module and package with the
+ * base type. Payloads are kept to primitives (no `ampere-eval` types) to avoid a reverse
+ * dependency from `ampere-core` onto `ampere-eval`.
+ */
+@Serializable
+sealed interface BenchEvent : Event {
+
+    /** The bench run this event pertains to. */
+    val runId: String
+
+    @Serializable
+    data class BenchRunStarted(
+        override val eventId: EventId,
+        override val runId: String,
+        override val eventSource: EventSource,
+        override val timestamp: Instant,
+        /** `RunMode.Replay`/`RunMode.Live`, stringified — `ampere-eval` owns the `RunMode` type. */
+        val mode: String,
+        val probeCount: Int,
+        override val urgency: Urgency = Urgency.LOW,
+    ) : BenchEvent {
+
+        override val eventType: EventType = EVENT_TYPE
+
+        override fun getSummary(
+            formatUrgency: (Urgency) -> String,
+            formatSource: (EventSource) -> String,
+        ): String = "Bench run $runId started ($mode, $probeCount probe(s)) ${formatUrgency(urgency)}"
+
+        companion object {
+            const val EVENT_TYPE: EventType = "BenchRunStarted"
+        }
+    }
+
+    @Serializable
+    data class ProbeGraded(
+        override val eventId: EventId,
+        override val runId: String,
+        override val eventSource: EventSource,
+        override val timestamp: Instant,
+        val probeId: String,
+        val passed: Boolean,
+        val meanScore: Double,
+        override val urgency: Urgency = Urgency.LOW,
+    ) : BenchEvent {
+
+        override val eventType: EventType = EVENT_TYPE
+
+        override fun getSummary(
+            formatUrgency: (Urgency) -> String,
+            formatSource: (EventSource) -> String,
+        ): String = "Probe $probeId graded: passed=$passed meanScore=$meanScore ${formatUrgency(urgency)}"
+
+        companion object {
+            const val EVENT_TYPE: EventType = "ProbeGraded"
+        }
+    }
+
+    @Serializable
+    data class BenchRunCompleted(
+        override val eventId: EventId,
+        override val runId: String,
+        override val eventSource: EventSource,
+        override val timestamp: Instant,
+        val passRate: Double,
+        val probeCount: Int,
+        override val urgency: Urgency = Urgency.MEDIUM,
+    ) : BenchEvent {
+
+        override val eventType: EventType = EVENT_TYPE
+
+        override fun getSummary(
+            formatUrgency: (Urgency) -> String,
+            formatSource: (EventSource) -> String,
+        ): String = "Bench run $runId completed: passRate=$passRate ${formatUrgency(urgency)}"
+
+        companion object {
+            const val EVENT_TYPE: EventType = "BenchRunCompleted"
+        }
+    }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/utils/SignificanceAwareEventLogger.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/utils/SignificanceAwareEventLogger.kt
@@ -3,6 +3,7 @@ package link.socket.ampere.agents.events.utils
 import co.touchlab.kermit.Logger
 import link.socket.ampere.agents.domain.Urgency
 import link.socket.ampere.agents.domain.event.AgentSurfaceEvent
+import link.socket.ampere.agents.domain.event.BenchEvent
 import link.socket.ampere.agents.domain.event.CognitiveEvent
 import link.socket.ampere.agents.domain.event.CognitivePhaseEvent
 import link.socket.ampere.agents.domain.event.EmissionEvent
@@ -178,6 +179,11 @@ class SignificanceAwareEventLogger(
         // human will see; Resolved is the reply travelling back.
         is EmissionEvent.Produced -> EventSignificance.SIGNIFICANT
         is EmissionEvent.Resolved -> EventSignificance.SIGNIFICANT
+
+        // Bench (eval) lifecycle events - routine progress, significant on completion
+        is BenchEvent.BenchRunStarted -> EventSignificance.ROUTINE
+        is BenchEvent.ProbeGraded -> EventSignificance.ROUTINE
+        is BenchEvent.BenchRunCompleted -> EventSignificance.SIGNIFICANT
     }
 
     private fun formatUrgency(urgency: Urgency): String = when (urgency) {

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/execution/executor/NoOpExecutor.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/execution/executor/NoOpExecutor.kt
@@ -1,0 +1,61 @@
+package link.socket.ampere.agents.execution.executor
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.datetime.Clock
+import link.socket.ampere.agents.domain.outcome.ExecutionOutcome
+import link.socket.ampere.agents.domain.status.ExecutionStatus
+import link.socket.ampere.agents.execution.request.ExecutionRequest
+import link.socket.ampere.agents.execution.tools.Tool
+import link.socket.ampere.agents.health.ExecutorSystemHealth
+
+/**
+ * Executor that performs no real work (AMPR-186).
+ *
+ * Every call is answered with a synthetic [ExecutionOutcome.NoChanges.Success] without
+ * dispatching to the tool's actual side-effecting implementation — the tool's `execute`
+ * function is never invoked. This is the effect-free seam the eval `Bench` harness injects
+ * (via [link.socket.ampere.agents.definition.SparkAgentFactory]/`SparkBasedAgent`) so an
+ * Arc run can drive real tool-selection logic while guaranteeing no notification, file
+ * write, git operation, or other side effect actually happens during a bench run.
+ */
+class NoOpExecutor(
+    override val id: ExecutorId = "noop",
+    override val displayName: String = "No-Op Executor (effect-free Bench mode)",
+    override val capabilities: ExecutorCapabilities = ExecutorCapabilities(
+        supportsLanguages = emptySet(),
+        supportsFrameworks = emptySet(),
+    ),
+) : Executor {
+
+    override suspend fun performHealthCheck(): Result<ExecutorSystemHealth> =
+        Result.success(
+            ExecutorSystemHealth(
+                version = null,
+                isAvailable = true,
+                issues = emptyList(),
+            ),
+        )
+
+    override suspend fun execute(
+        request: ExecutionRequest<*>,
+        tool: Tool<*>,
+    ): Flow<ExecutionStatus> = flow {
+        val now = Clock.System.now()
+        emit(ExecutionStatus.Started(executorId = id, timestamp = now))
+        emit(
+            ExecutionStatus.Completed(
+                executorId = id,
+                timestamp = Clock.System.now(),
+                result = ExecutionOutcome.NoChanges.Success(
+                    executorId = id,
+                    ticketId = request.context.ticket.id,
+                    taskId = request.context.task.id,
+                    executionStartTimestamp = now,
+                    executionEndTimestamp = Clock.System.now(),
+                    message = "Skipped by NoOpExecutor: '${tool.name}' was not dispatched (effect-free mode).",
+                ),
+            ),
+        )
+    }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/arc/AmpereRuntime.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/arc/AmpereRuntime.kt
@@ -1,5 +1,7 @@
 package link.socket.ampere.domain.arc
 
+import link.socket.ampere.agents.domain.routing.CognitiveRelay
+import link.socket.ampere.agents.execution.executor.Executor
 import link.socket.ampere.util.systemFileSystem
 import okio.FileSystem
 import okio.Path
@@ -38,6 +40,8 @@ class AmpereRuntime(
     private val projectDir: Path,
     private val fileSystem: FileSystem = systemFileSystem,
     private val maxFlowTicks: Int = 100,
+    private val cognitiveRelay: CognitiveRelay? = null,
+    private val executor: Executor? = null,
 ) {
     private var chargeResult: ChargeResult? = null
     private var flowResult: FlowResult? = null
@@ -90,6 +94,8 @@ class AmpereRuntime(
             arcConfig = arcConfig,
             projectDir = projectDir,
             fileSystem = fileSystem,
+            cognitiveRelay = cognitiveRelay,
+            executor = executor,
         )
         return chargePhase.execute(userGoal)
     }
@@ -99,6 +105,8 @@ class AmpereRuntime(
             arcConfig = arcConfig,
             projectDir = projectDir,
             fileSystem = fileSystem,
+            cognitiveRelay = cognitiveRelay,
+            executor = executor,
         )
         return chargePhase.execute(userGoal)
     }

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/arc/ChargePhase.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/arc/ChargePhase.kt
@@ -11,7 +11,9 @@ import link.socket.ampere.agents.domain.cognition.sparks.LanguageSparkIds
 import link.socket.ampere.agents.domain.cognition.sparks.ProjectSpark
 import link.socket.ampere.agents.domain.cognition.sparks.RoleSparkIds
 import link.socket.ampere.agents.domain.cognition.sparks.SparkRegistry
+import link.socket.ampere.agents.domain.routing.CognitiveRelay
 import link.socket.ampere.agents.events.utils.generateUUID
+import link.socket.ampere.agents.execution.executor.Executor
 import link.socket.ampere.util.systemFileSystem
 import okio.FileSystem
 import okio.Path
@@ -68,6 +70,8 @@ class ChargePhase(
     private val arcConfig: ArcConfig,
     private val projectDir: Path,
     private val fileSystem: FileSystem = systemFileSystem,
+    private val cognitiveRelay: CognitiveRelay? = null,
+    private val executor: Executor? = null,
 ) {
     suspend fun execute(userGoal: String): ChargeResult {
         require(userGoal.isNotBlank()) { "ChargePhase requires a non-empty user goal." }
@@ -82,7 +86,9 @@ class ChargePhase(
             "ChargePhase produced invalid goal tree for goal: $userGoal"
         }
 
-        val agents = ArcAgentSpawner().spawn(arcConfig, projectContext)
+        val agents = ArcAgentSpawner(
+            agentFactory = SparkAgentFactory(cognitiveRelay = cognitiveRelay, executor = executor),
+        ).spawn(arcConfig, projectContext)
 
         return ChargeResult(
             projectContext = projectContext,

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/execution/executor/NoOpExecutorTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/execution/executor/NoOpExecutorTest.kt
@@ -1,0 +1,86 @@
+package link.socket.ampere.agents.execution.executor
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import link.socket.ampere.agents.config.AgentActionAutonomy
+import link.socket.ampere.agents.domain.outcome.ExecutionOutcome
+import link.socket.ampere.agents.domain.status.ExecutionStatus
+import link.socket.ampere.agents.domain.status.TaskStatus
+import link.socket.ampere.agents.domain.status.TicketStatus
+import link.socket.ampere.agents.domain.task.Task
+import link.socket.ampere.agents.events.tickets.Ticket
+import link.socket.ampere.agents.events.tickets.TicketPriority
+import link.socket.ampere.agents.events.tickets.TicketType
+import link.socket.ampere.agents.execution.request.ExecutionConstraints
+import link.socket.ampere.agents.execution.request.ExecutionContext
+import link.socket.ampere.agents.execution.request.ExecutionRequest
+import link.socket.ampere.agents.execution.tools.FunctionTool
+
+/** AMPR-186 task 4.2 validation: effect-free Link execution. */
+class NoOpExecutorTest {
+
+    @Test
+    fun `NoOpExecutor completes without dispatching the tool's real side effect`() = runTest {
+        var dispatched = false
+        val notifyingTool = FunctionTool<ExecutionContext>(
+            id = "notify",
+            name = "notify-human",
+            description = "Would send a real notification if executed",
+            requiredAgentAutonomy = AgentActionAutonomy.FULLY_AUTONOMOUS,
+            executionFunction = {
+                dispatched = true
+                ExecutionOutcome.blank
+            },
+        )
+
+        val executor = NoOpExecutor()
+        val statuses = executor.execute(testRequest(), notifyingTool).toList()
+
+        assertFalse(dispatched, "NoOpExecutor must never invoke the tool's real execute function")
+        assertIs<ExecutionStatus.Completed>(statuses.last())
+        assertIs<ExecutionOutcome.NoChanges.Success>(statuses.last().let { (it as ExecutionStatus.Completed).result })
+    }
+
+    @Test
+    fun `NoOpExecutor performHealthCheck reports available`() = runTest {
+        val result = NoOpExecutor().performHealthCheck()
+
+        assertTrue(result.isSuccess)
+        assertTrue(result.getOrThrow().isAvailable)
+    }
+
+    private fun testRequest(): ExecutionRequest<ExecutionContext> {
+        val now = Clock.System.now()
+        val ticket = Ticket(
+            id = "ticket-1",
+            title = "Test Ticket",
+            description = "Test ticket",
+            type = TicketType.TASK,
+            priority = TicketPriority.MEDIUM,
+            status = TicketStatus.InProgress,
+            assignedAgentId = "test-agent",
+            createdByAgentId = "test-pm-agent",
+            createdAt = now,
+            updatedAt = now,
+        )
+        val task = Task.CodeChange(
+            id = "task-1",
+            description = "Test task",
+            status = TaskStatus.Pending,
+            assignedTo = null,
+        )
+        val context = ExecutionContext.NoChanges(
+            executorId = "test-executor",
+            ticket = ticket,
+            task = task,
+            instructions = "Test instructions",
+            knowledgeFromPastMemory = emptyList(),
+        )
+        return ExecutionRequest(context = context, constraints = ExecutionConstraints())
+    }
+}

--- a/ampere-eval/build.gradle.kts
+++ b/ampere-eval/build.gradle.kts
@@ -86,6 +86,7 @@ kotlin {
                 implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
                 implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.1")
                 implementation("app.cash.sqldelight:runtime:2.2.1")
+                implementation("com.squareup.okio:okio:3.11.0")
             }
         }
         val commonTest by getting {

--- a/ampere-eval/src/commonMain/kotlin/link/socket/ampere/eval/bench/Bench.kt
+++ b/ampere-eval/src/commonMain/kotlin/link/socket/ampere/eval/bench/Bench.kt
@@ -1,0 +1,220 @@
+package link.socket.ampere.eval.bench
+
+import kotlinx.datetime.Clock
+import link.socket.ampere.agents.domain.event.BenchEvent
+import link.socket.ampere.agents.domain.event.EventSource
+import link.socket.ampere.agents.domain.routing.CognitiveRelay
+import link.socket.ampere.agents.events.bus.EventSerialBus
+import link.socket.ampere.agents.events.utils.generateUUID
+import link.socket.ampere.agents.execution.executor.NoOpExecutor
+import link.socket.ampere.domain.arc.AmpereRuntime
+import link.socket.ampere.domain.arc.ArcConfig
+import link.socket.ampere.domain.arc.ArcRegistry
+import link.socket.ampere.eval.meter.Reading
+import link.socket.ampere.eval.relay.MissPolicy
+import link.socket.ampere.eval.relay.PlaybackRelay
+import link.socket.ampere.eval.trace.Trace
+import link.socket.ampere.eval.trace.TraceRecorder
+import okio.Path
+
+/**
+ * Runs a suite of [Probe]s against an Arc, in either [RunMode.Replay] (a golden [Trace] +
+ * `PlaybackRelay`, deterministic and CI-safe) or [RunMode.Live] (the real relay, recording a
+ * fresh trace via [TraceRecorder]; nightly/on-demand only).
+ *
+ * Arcs run with tools in effect-free mode ([NoOpExecutor]) for every probe, regardless of
+ * [RunMode] — a bench run never performs a real tool side effect.
+ *
+ * @param liveModeEnabled explicit opt-in flag for [RunMode.Live] (AMPR-186 task 4.4); defaults
+ *   `false` so [RunMode.Live] is refused unless a caller deliberately enables it. CI wiring
+ *   never sets this, which is what keeps Live mode out of CI (ticket 5, out of scope here).
+ */
+class Bench(
+    private val projectDir: Path,
+    private val eventBus: EventSerialBus,
+    private val liveRelay: CognitiveRelay? = null,
+    private val traceRecorder: TraceRecorder? = null,
+    private val liveModeEnabled: Boolean = false,
+    private val source: EventSource = EventSource.Human,
+    private val maxFlowTicks: Int = 100,
+) {
+
+    suspend fun run(suite: List<Probe>, mode: RunMode): Result<BenchReport> {
+        if (mode is RunMode.Live && !liveModeEnabled) {
+            return Result.failure(
+                IllegalStateException("RunMode.Live requires Bench to be constructed with liveModeEnabled = true."),
+            )
+        }
+
+        val runId = generateUUID("bench-run")
+        eventBus.publish(
+            BenchEvent.BenchRunStarted(
+                eventId = generateUUID("bench-started", runId),
+                runId = runId,
+                eventSource = source,
+                timestamp = Clock.System.now(),
+                mode = mode.toString(),
+                probeCount = suite.size,
+            ),
+        )
+
+        val results = suite.map { probe ->
+            val result = runProbe(runId, probe, mode)
+            eventBus.publish(
+                BenchEvent.ProbeGraded(
+                    eventId = generateUUID("probe-graded", runId, probe.id),
+                    runId = runId,
+                    eventSource = source,
+                    timestamp = Clock.System.now(),
+                    probeId = probe.id,
+                    passed = result.passed,
+                    meanScore = result.readings.map { it.score }.average().takeUnless { it.isNaN() } ?: 0.0,
+                ),
+            )
+            result
+        }
+
+        val passRate = if (results.isEmpty()) 0.0 else results.count { it.passed }.toDouble() / results.size
+        val report = BenchReport(results = results, passRate = passRate)
+
+        eventBus.publish(
+            BenchEvent.BenchRunCompleted(
+                eventId = generateUUID("bench-completed", runId),
+                runId = runId,
+                eventSource = source,
+                timestamp = Clock.System.now(),
+                passRate = report.passRate,
+                probeCount = results.size,
+            ),
+        )
+
+        return Result.success(report)
+    }
+
+    /**
+     * Runs and grades a single probe. A probe-level failure (unresolved arc, missing golden
+     * trace, `PlaybackMiss` divergence, or a runtime exception) degrades to a failing
+     * [ProbeResult] rather than aborting the whole suite, so one probe's divergence doesn't
+     * blank out the report (AMPR-186 task 4.5: "report aggregates all probes").
+     */
+    private suspend fun runProbe(runId: String, probe: Probe, mode: RunMode): ProbeResult {
+        val arcConfig = ArcRegistry.get(probe.arcId)
+            ?: return failingResult(
+                probe,
+                emptyTrace(runId, probe),
+                "No ArcConfig registered for arcId '${probe.arcId}'.",
+            )
+
+        return when (mode) {
+            RunMode.Replay -> runReplay(runId, probe, arcConfig)
+            RunMode.Live -> runLive(runId, probe, arcConfig)
+        }
+    }
+
+    private suspend fun runReplay(runId: String, probe: Probe, arcConfig: ArcConfig): ProbeResult {
+        val goldenTrace = probe.goldenTrace
+            ?: return failingResult(
+                probe,
+                emptyTrace(runId, probe),
+                "Probe '${probe.id}' has no goldenTrace for Replay mode.",
+            )
+
+        val playbackRelay = PlaybackRelay(trace = goldenTrace, missPolicy = MissPolicy.Error)
+
+        val runResult = runCatching {
+            AmpereRuntime(
+                arcConfig = arcConfig,
+                projectDir = projectDir,
+                cognitiveRelay = playbackRelay,
+                executor = NoOpExecutor(),
+                maxFlowTicks = maxFlowTicks,
+            ).execute(probe.seed.userGoal)
+        }
+
+        return runResult.fold(
+            onSuccess = { grade(probe, goldenTrace) },
+            onFailure = { error ->
+                failingResult(probe, goldenTrace, "Arc run diverged from goldenTrace: ${error.message}")
+            },
+        )
+    }
+
+    private suspend fun runLive(runId: String, probe: Probe, arcConfig: ArcConfig): ProbeResult {
+        val relay = liveRelay
+            ?: return failingResult(
+                probe,
+                emptyTrace(runId, probe),
+                "RunMode.Live requires a liveRelay to be configured on Bench.",
+            )
+        val recorder = traceRecorder
+            ?: return failingResult(
+                probe,
+                emptyTrace(runId, probe),
+                "RunMode.Live requires a traceRecorder to be configured on Bench.",
+            )
+
+        val handle = recorder.start(runId = runId, arcId = probe.arcId)
+
+        val runResult = runCatching {
+            AmpereRuntime(
+                arcConfig = arcConfig,
+                projectDir = projectDir,
+                cognitiveRelay = relay,
+                executor = NoOpExecutor(),
+                maxFlowTicks = maxFlowTicks,
+            ).execute(probe.seed.userGoal)
+        }
+
+        val traceResult = handle.stop()
+
+        return when {
+            runResult.isFailure ->
+                failingResult(
+                    probe,
+                    traceResult.getOrNull() ?: emptyTrace(runId, probe),
+                    "Live run failed: ${runResult.exceptionOrNull()?.message}",
+                )
+            traceResult.isFailure ->
+                failingResult(
+                    probe,
+                    emptyTrace(runId, probe),
+                    "Failed to persist recorded trace: ${traceResult.exceptionOrNull()?.message}",
+                )
+            else -> grade(probe, traceResult.getOrThrow())
+        }
+    }
+
+    private suspend fun grade(probe: Probe, trace: Trace): ProbeResult {
+        val readings = probe.meters.map { meter ->
+            meter.measure(trace).getOrElse { error ->
+                Reading(
+                    score = 0.0,
+                    passed = false,
+                    meterId = "error",
+                    detail = mapOf("error" to (error.message ?: "unknown")),
+                )
+            }
+        }
+        val passed = readings.isNotEmpty() && readings.all { probe.tolerance.passes(it.score) }
+        return ProbeResult(probeId = probe.id, readings = readings, passed = passed, trace = trace)
+    }
+
+    private fun failingResult(probe: Probe, trace: Trace, reason: String): ProbeResult =
+        ProbeResult(
+            probeId = probe.id,
+            readings = listOf(
+                Reading(score = 0.0, passed = false, meterId = "bench", detail = mapOf("reason" to reason)),
+            ),
+            passed = false,
+            trace = trace,
+        )
+
+    private fun emptyTrace(runId: String, probe: Probe): Trace =
+        Trace(
+            id = generateUUID("empty-trace"),
+            runId = runId,
+            arcId = probe.arcId,
+            createdAt = 0L,
+            events = emptyList(),
+        )
+}

--- a/ampere-eval/src/commonMain/kotlin/link/socket/ampere/eval/bench/Probe.kt
+++ b/ampere-eval/src/commonMain/kotlin/link/socket/ampere/eval/bench/Probe.kt
@@ -1,0 +1,48 @@
+package link.socket.ampere.eval.bench
+
+import kotlinx.serialization.Serializable
+import link.socket.ampere.eval.meter.Meter
+import link.socket.ampere.eval.meter.Reading
+import link.socket.ampere.eval.meter.Tolerance
+import link.socket.ampere.eval.trace.Trace
+
+/** The seed that triggers an Arc run: the user goal handed to `AmpereRuntime.execute`. */
+data class ProbeSeed(val userGoal: String)
+
+/**
+ * One eval case: a seed that triggers an Arc, plus the meters and tolerance that grade it.
+ *
+ * @property arcId looked up via `ArcRegistry.get` to resolve the `ArcConfig` to run.
+ * @property goldenTrace required for [RunMode.Replay] (injected into a `PlaybackRelay`);
+ *   absent for probes that only ever run in [RunMode.Live].
+ */
+data class Probe(
+    val id: String,
+    val arcId: String,
+    val seed: ProbeSeed,
+    val meters: List<Meter>,
+    val tolerance: Tolerance,
+    val goldenTrace: Trace? = null,
+)
+
+/** Whether a [Bench] run replays a golden [Trace] (CI-safe) or drives the real relay (nightly/on-demand). */
+@Serializable
+sealed interface RunMode {
+    @Serializable
+    data object Replay : RunMode
+
+    @Serializable
+    data object Live : RunMode
+}
+
+data class ProbeResult(
+    val probeId: String,
+    val readings: List<Reading>,
+    val passed: Boolean,
+    val trace: Trace,
+)
+
+data class BenchReport(
+    val results: List<ProbeResult>,
+    val passRate: Double,
+)

--- a/ampere-eval/src/commonMain/kotlin/link/socket/ampere/eval/relay/PlaybackRelay.kt
+++ b/ampere-eval/src/commonMain/kotlin/link/socket/ampere/eval/relay/PlaybackRelay.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.json.Json
 import link.socket.ampere.agents.domain.routing.CognitiveRelay
 import link.socket.ampere.agents.domain.routing.RelayConfig
 import link.socket.ampere.agents.domain.routing.RoutingContext
+import link.socket.ampere.agents.domain.routing.RoutingFloorUnmetException
 import link.socket.ampere.agents.domain.routing.RoutingResolution
 import link.socket.ampere.data.DEFAULT_JSON
 import link.socket.ampere.domain.ai.configuration.AIConfiguration
@@ -112,7 +113,14 @@ class PlaybackRelay(
     override suspend fun resolve(
         context: RoutingContext,
         fallbackConfiguration: AIConfiguration,
-    ): AIConfiguration = resolveWithMetadata(context, fallbackConfiguration).configuration
+    ): AIConfiguration =
+        when (val resolution = resolveWithMetadata(context, fallbackConfiguration)) {
+            is RoutingResolution.Success -> resolution.configuration
+            is RoutingResolution.FloorUnmet -> throw RoutingFloorUnmetException(
+                requestedFloor = resolution.requestedFloor,
+                bestAvailableRung = resolution.bestAvailableRung,
+            )
+        }
 
     override suspend fun resolveWithMetadata(
         context: RoutingContext,
@@ -139,7 +147,7 @@ class PlaybackRelay(
         return when {
             index >= branchIndex -> delegate(context, fallbackConfiguration, index)
             index < recordedCalls.size -> Result.success(
-                RoutingResolution(configuration = fallbackConfiguration, reason = PLAYBACK_REASON),
+                RoutingResolution.Success(configuration = fallbackConfiguration, reason = PLAYBACK_REASON),
             )
             missPolicy == MissPolicy.Delegate -> delegate(context, fallbackConfiguration, index)
             else -> Result.failure(PlaybackMiss(index, recordedCalls.size))

--- a/ampere-eval/src/commonTest/kotlin/link/socket/ampere/eval/bench/ProbeTest.kt
+++ b/ampere-eval/src/commonTest/kotlin/link/socket/ampere/eval/bench/ProbeTest.kt
@@ -1,0 +1,80 @@
+package link.socket.ampere.eval.bench
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import link.socket.ampere.eval.meter.Meter
+import link.socket.ampere.eval.meter.Reading
+import link.socket.ampere.eval.meter.Tolerance
+import link.socket.ampere.eval.trace.Trace
+
+/** AMPR-186 task 4.1 validation. */
+class ProbeTest {
+
+    // region — task 4.1: core types
+
+    @Test
+    fun `Probe constructs with a golden trace`() {
+        val trace = goldenTrace()
+        val probe = Probe(
+            id = "probe-1",
+            arcId = "arc-1",
+            seed = ProbeSeed(userGoal = "Implement user login"),
+            meters = listOf(alwaysPassMeter()),
+            tolerance = Tolerance(minScore = 0.8),
+            goldenTrace = trace,
+        )
+
+        assertEquals("probe-1", probe.id)
+        assertEquals("arc-1", probe.arcId)
+        assertEquals(trace, probe.goldenTrace)
+    }
+
+    @Test
+    fun `Probe goldenTrace defaults to null`() {
+        val probe = Probe(
+            id = "probe-2",
+            arcId = "arc-1",
+            seed = ProbeSeed(userGoal = "goal"),
+            meters = listOf(alwaysPassMeter()),
+            tolerance = Tolerance(minScore = 0.0),
+        )
+
+        assertNull(probe.goldenTrace)
+    }
+
+    @Test
+    fun `RunMode has exactly Replay and Live variants`() {
+        val modes: List<RunMode> = listOf(RunMode.Replay, RunMode.Live)
+        assertTrue(modes.contains(RunMode.Replay))
+        assertTrue(modes.contains(RunMode.Live))
+    }
+
+    @Test
+    fun `BenchReport passRate reflects ProbeResult pass count`() {
+        val trace = goldenTrace()
+        val results = listOf(
+            ProbeResult(probeId = "a", readings = emptyList(), passed = true, trace = trace),
+            ProbeResult(probeId = "b", readings = emptyList(), passed = false, trace = trace),
+        )
+        val report = BenchReport(results = results, passRate = 0.5)
+
+        assertEquals(2, report.results.size)
+        assertEquals(0.5, report.passRate)
+    }
+
+    // endregion
+
+    // region — fixtures
+
+    private fun goldenTrace() = Trace(id = "t", runId = "r", arcId = "arc-1", createdAt = 0L, events = emptyList())
+
+    private fun alwaysPassMeter() = Meter { _ ->
+        Result.success(
+            Reading(score = 1.0, passed = true, meterId = "always-pass"),
+        )
+    }
+
+    // endregion
+}

--- a/ampere-eval/src/commonTest/kotlin/link/socket/ampere/eval/relay/PlaybackRelayTest.kt
+++ b/ampere-eval/src/commonTest/kotlin/link/socket/ampere/eval/relay/PlaybackRelayTest.kt
@@ -185,6 +185,10 @@ class PlaybackRelayTest {
 
     // region — fixtures
 
+    /** All resolutions in this test are [RoutingResolution.Success] — floor-unmet isn't exercised here. */
+    private val RoutingResolution.reason: String get() = (this as RoutingResolution.Success).reason
+    private val RoutingResolution.configuration: AIConfiguration get() = (this as RoutingResolution.Success).configuration
+
     /** Counts invocations and stamps a fixed reason; stands in for a live relay. */
     private class SpyRelay(private val reason: String = "live") : CognitiveRelay {
         var calls: Int = 0
@@ -195,14 +199,14 @@ class PlaybackRelayTest {
         override suspend fun resolve(
             context: RoutingContext,
             fallbackConfiguration: AIConfiguration,
-        ): AIConfiguration = resolveWithMetadata(context, fallbackConfiguration).configuration
+        ): AIConfiguration = (resolveWithMetadata(context, fallbackConfiguration) as RoutingResolution.Success).configuration
 
         override suspend fun resolveWithMetadata(
             context: RoutingContext,
             fallbackConfiguration: AIConfiguration,
         ): RoutingResolution {
             calls++
-            return RoutingResolution(configuration = fallbackConfiguration, reason = reason)
+            return RoutingResolution.Success(configuration = fallbackConfiguration, reason = reason)
         }
 
         override suspend fun updateConfig(newConfig: RelayConfig) = Unit

--- a/ampere-eval/src/commonTest/kotlin/link/socket/ampere/eval/relay/PlaybackRelayTest.kt
+++ b/ampere-eval/src/commonTest/kotlin/link/socket/ampere/eval/relay/PlaybackRelayTest.kt
@@ -186,8 +186,10 @@ class PlaybackRelayTest {
     // region — fixtures
 
     /** All resolutions in this test are [RoutingResolution.Success] — floor-unmet isn't exercised here. */
-    private val RoutingResolution.reason: String get() = (this as RoutingResolution.Success).reason
-    private val RoutingResolution.configuration: AIConfiguration get() = (this as RoutingResolution.Success).configuration
+    private val RoutingResolution.reason: String
+        get() = (this as RoutingResolution.Success).reason
+    private val RoutingResolution.configuration: AIConfiguration
+        get() = (this as RoutingResolution.Success).configuration
 
     /** Counts invocations and stamps a fixed reason; stands in for a live relay. */
     private class SpyRelay(private val reason: String = "live") : CognitiveRelay {
@@ -199,7 +201,8 @@ class PlaybackRelayTest {
         override suspend fun resolve(
             context: RoutingContext,
             fallbackConfiguration: AIConfiguration,
-        ): AIConfiguration = (resolveWithMetadata(context, fallbackConfiguration) as RoutingResolution.Success).configuration
+        ): AIConfiguration =
+            (resolveWithMetadata(context, fallbackConfiguration) as RoutingResolution.Success).configuration
 
         override suspend fun resolveWithMetadata(
             context: RoutingContext,

--- a/ampere-eval/src/jvmTest/kotlin/link/socket/ampere/eval/bench/BenchTest.kt
+++ b/ampere-eval/src/jvmTest/kotlin/link/socket/ampere/eval/bench/BenchTest.kt
@@ -1,0 +1,111 @@
+package link.socket.ampere.eval.bench
+
+import kotlin.io.path.createTempDirectory
+import kotlin.io.path.writeText
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import link.socket.ampere.agents.domain.event.BenchEvent
+import link.socket.ampere.agents.domain.event.Event
+import link.socket.ampere.agents.events.api.EventHandler
+import link.socket.ampere.agents.events.bus.EventSerialBus
+import link.socket.ampere.agents.events.subscription.Subscription
+import link.socket.ampere.eval.meter.Meter
+import link.socket.ampere.eval.meter.Reading
+import link.socket.ampere.eval.meter.Tolerance
+import link.socket.ampere.eval.trace.Trace
+import okio.Path.Companion.toPath
+
+/** AMPR-186 tasks 4.3 and 4.5 validation. */
+class BenchTest {
+
+    @Test
+    fun `2-probe suite runs green and deterministic in Replay mode`() = runTest {
+        val bus = EventSerialBus(scope = CoroutineScope(Dispatchers.Unconfined))
+        val observed = mutableListOf<BenchEvent>()
+        subscribeToBenchEvents(bus) { observed.add(it) }
+
+        val bench = Bench(
+            projectDir = testProjectDir(),
+            eventBus = bus,
+            maxFlowTicks = 1,
+        )
+
+        val suite = listOf(
+            probe(id = "probe-1", arcId = "startup-saas", tolerance = Tolerance(minScore = 0.5)),
+            probe(id = "probe-2", arcId = "devops-pipeline", tolerance = Tolerance(minScore = 0.5)),
+        )
+
+        val report = bench.run(suite, RunMode.Replay).getOrThrow()
+
+        assertEquals(2, report.results.size)
+        assertEquals(1.0, report.passRate)
+        assertTrue(report.results.all { it.passed })
+
+        assertTrue(observed.any { it is BenchEvent.BenchRunStarted })
+        assertEquals(2, observed.count { it is BenchEvent.ProbeGraded })
+        assertTrue(observed.any { it is BenchEvent.BenchRunCompleted })
+    }
+
+    @Test
+    fun `tightening a probe's Tolerance flips it red deterministically`() = runTest {
+        val bus = EventSerialBus(scope = CoroutineScope(Dispatchers.Unconfined))
+        val bench = Bench(
+            projectDir = testProjectDir(),
+            eventBus = bus,
+            maxFlowTicks = 1,
+        )
+
+        val goodSuite = listOf(probe(id = "probe-1", arcId = "startup-saas", tolerance = Tolerance(minScore = 0.5)))
+        val greenReport = bench.run(goodSuite, RunMode.Replay).getOrThrow()
+        assertTrue(greenReport.results.single().passed)
+
+        val strictSuite = listOf(probe(id = "probe-1", arcId = "startup-saas", tolerance = Tolerance(minScore = 1.1)))
+        val redReport = bench.run(strictSuite, RunMode.Replay).getOrThrow()
+        assertTrue(!redReport.results.single().passed)
+        assertTrue(redReport.passRate < 1.0)
+    }
+
+    private fun subscribeToBenchEvents(bus: EventSerialBus, onEvent: (BenchEvent) -> Unit) {
+        val handler = EventHandler<Event, Subscription> { event, _ -> onEvent(event as BenchEvent) }
+        bus.subscribe("bench-test-observer", BenchEvent.BenchRunStarted.EVENT_TYPE, handler)
+        bus.subscribe("bench-test-observer", BenchEvent.ProbeGraded.EVENT_TYPE, handler)
+        bus.subscribe("bench-test-observer", BenchEvent.BenchRunCompleted.EVENT_TYPE, handler)
+    }
+
+    private fun probe(id: String, arcId: String, tolerance: Tolerance): Probe {
+        val trace = Trace(id = "t-$id", runId = "r-$id", arcId = arcId, createdAt = 0L, events = emptyList())
+        val meter = Meter { _ -> Result.success(Reading(score = 1.0, passed = true, meterId = "always-pass")) }
+        return Probe(
+            id = id,
+            arcId = arcId,
+            seed = ProbeSeed(userGoal = "Implement a small feature"),
+            meters = listOf(meter),
+            tolerance = tolerance,
+            goldenTrace = trace,
+        )
+    }
+
+    private fun testProjectDir(): okio.Path {
+        val tempDir = createTempDirectory("bench-test")
+        tempDir.resolve("README.md").writeText("# BenchTestProject\n\nA test project for Bench integration.")
+        tempDir.resolve("AGENTS.md").writeText(
+            """
+            # AGENTS
+
+            ## Dependencies
+            - Kotlin
+
+            ## Conventions
+            - Use suspend functions
+
+            ## Architecture
+            - Clean architecture
+            """.trimIndent(),
+        )
+        return tempDir.toString().toPath()
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `Probe`/`RunMode`/`ProbeResult`/`BenchReport` and `Bench.run()` supporting Replay mode (`PlaybackRelay` + golden `Trace`, deterministic/CI-safe) and flag-gated Live mode (real relay + `TraceRecorder`)
- Adds `NoOpExecutor` for effect-free Link execution, threaded through `AmpereRuntime -> ChargePhase -> ArcAgentSpawner -> SparkAgentFactory -> SparkBasedAgent` alongside optional `cognitiveRelay` injection, plus `BenchEvent` lifecycle events on the bus
- `RECON-bench.md` documents the Arc-invocation/relay/Link-injection seam this was built against (AMPR-190's recon was marked Done in Linear but never actually committed)
- Fixes a pre-existing `ampere-eval` compile break: `PlaybackRelay` still used `RoutingResolution`'s old flat constructor after AMPR-216 turned it into a sealed `Success`/`FloorUnmet` type

Closes #533

## Test plan
- [x] `:ampere-core:jvmTest` and `:ampere-eval:jvmTest` pass, including a 2-probe Bench suite that runs green and deterministic in Replay mode (no network) and a tolerance-tightening test that flips a probe red
- [x] `:ampere-core:compileCommonMainKotlinMetadata` and `:ampere-eval:compileCommonMainKotlinMetadata` pass
- [x] `ktlintFormat` clean on both modules

I (Claude, an AI agent) wrote this commit and PR on Miley's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)