### PR TITLE
AMPR-233 #598: T4 — MODEL_RUNGS drift guard + unrated distinct from ONE

### DIFF
--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/capability/ModelDescriptor.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/capability/ModelDescriptor.kt
@@ -36,6 +36,10 @@ import link.socket.ampere.domain.ai.provider.ProviderId
  *   minimises (AMPR-210). Ignored for [CostPolicy.Free] models, which always
  *   route at 0 — see [routingCostPerWatt].
  * @property availabilityGated `true` for device-gated local models (read in T4).
+ * @property rung The model's capability tier, or `null` if the model has not
+ *   been rated (AMPR-233). Unrated is distinct from [CapabilityRung.ONE]: a
+ *   `ONE` rung is a deliberate assignment, `null` means nobody has rated the
+ *   model yet. See [satisfies] for the gate policy this implies.
  */
 @Serializable
 data class ModelDescriptor(
@@ -48,7 +52,7 @@ data class ModelDescriptor(
     val cost: CostPolicy = CostPolicy.Metered,
     val costPerWatt: Double = DEFAULT_COST_PER_WATT,
     val availabilityGated: Boolean = false,
-    val rung: CapabilityRung = CapabilityRung.ONE,
+    val rung: CapabilityRung? = null,
 ) {
     companion object {
         /**
@@ -72,13 +76,17 @@ val ModelDescriptor.routingCostPerWatt: Double
 /**
  * Whether this descriptor can serve the given [req]. A null/empty constraint
  * imposes nothing; every present constraint must hold.
+ *
+ * Gate policy for an unrated model ([rung] is `null`): it does not silently
+ * satisfy a declared floor (an unrated model is not known to meet it) and does
+ * not silently fail when no floor is declared (there is nothing to fail).
  */
 fun ModelDescriptor.satisfies(req: CapabilityRequirement): Boolean =
     req.required.all { it in capabilities } &&
         (req.minReasoning == null || reasoning >= req.minReasoning) &&
         (req.minContextTokens == null || maxContextTokens >= req.minContextTokens) &&
         (req.inputs == null || supportedInputs.covers(req.inputs)) &&
-        (req.minRung == null || rung >= req.minRung)
+        (req.minRung == null || (rung != null && rung >= req.minRung))
 
 /**
  * Whether these inputs cover everything [required] asks for: for each modality

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/capability/ModelDescriptorRegistry.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/capability/ModelDescriptorRegistry.kt
@@ -46,8 +46,14 @@ class InMemoryModelDescriptorRegistry(
 ) : ModelDescriptorRegistry {
 
     private val mutex = Mutex()
-    private val descriptors: MutableMap<String, ModelDescriptor> =
+    private val descriptors: MutableMap<String, ModelDescriptor> = run {
+        val duplicates = seed.groupingBy { it.modelName }.eachCount().filterValues { it > 1 }.keys
+        require(duplicates.isEmpty()) {
+            "Duplicate modelName(s) in registry seed (two providers exposing the same model " +
+                "name would silently drop one): $duplicates"
+        }
         seed.associateByTo(mutableMapOf()) { it.modelName }
+    }
 
     override suspend fun descriptorFor(modelName: String): ModelDescriptor? =
         mutex.withLock { descriptors[modelName] }
@@ -101,8 +107,14 @@ class InMemoryModelDescriptorRegistry(
          * TWO  — standard (NORMAL reasoning, fast mid-tier)
          * THREE — advanced (capable HIGH or premium NORMAL)
          * FOUR — frontier (flagship HIGH, latest generation)
+         *
+         * A model in `AIModel_*.ALL_MODELS` with no entry here projects with
+         * `rung = null` (unrated), not a silent `ONE` — see
+         * [ModelDescriptorRegistryDriftGuardTest] for the guard against this map
+         * drifting out of sync with `ALL_MODELS` in either direction. `internal`
+         * so that test can check both directions of drift directly.
          */
-        private val MODEL_RUNGS: Map<String, CapabilityRung> = mapOf(
+        internal val MODEL_RUNGS: Map<String, CapabilityRung> = mapOf(
             // ── Anthropic / Claude ────────────────────────────────────────────
             "claude-3-haiku-20240307" to CapabilityRung.ONE,
             "claude-3-5-haiku-latest" to CapabilityRung.TWO,
@@ -140,7 +152,8 @@ class InMemoryModelDescriptorRegistry(
          * Projects an [AIModel] into a [ModelDescriptor] from its own metadata:
          * reasoning and inputs come from [AIModelFeatures][link.socket.ampere.domain.ai.model.AIModelFeatures],
          * the context window from [ModelLimits][link.socket.ampere.domain.limits.ModelLimits],
-         * cost from the owning provider, and the rung from [MODEL_RUNGS].
+         * cost from the owning provider, and the rung from [MODEL_RUNGS] — `null`
+         * (unrated) if [name] has no entry, never a silent default.
          */
         private fun AIModel.toModelDescriptor(
             providerId: ProviderId,
@@ -157,7 +170,7 @@ class InMemoryModelDescriptorRegistry(
             cost = CostPolicy.Metered,
             costPerWatt = costPerWatt,
             availabilityGated = false,
-            rung = MODEL_RUNGS[name] ?: CapabilityRung.ONE,
+            rung = MODEL_RUNGS[name],
         )
 
         /**

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/routing/capability/ModelDescriptorRegistryDriftGuardTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/routing/capability/ModelDescriptorRegistryDriftGuardTest.kt
@@ -1,0 +1,34 @@
+package link.socket.ampere.agents.domain.routing.capability
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import link.socket.ampere.domain.ai.model.AIModel_Claude
+import link.socket.ampere.domain.ai.model.AIModel_Gemini
+import link.socket.ampere.domain.ai.model.AIModel_OpenAI
+
+/**
+ * Guards [InMemoryModelDescriptorRegistry.MODEL_RUNGS] against drifting out of
+ * sync with the bundled model catalogs (AMPR-233). The map is keyed by exact
+ * model-name string with no cross-check against `ALL_MODELS`, so a new model,
+ * or a renamed `*_NAME` constant, would otherwise land silently: a new model
+ * projects as unrated, and a stale key just sits there unused.
+ */
+class ModelDescriptorRegistryDriftGuardTest {
+
+    private val allModelNames: Set<String> =
+        (AIModel_Claude.ALL_MODELS + AIModel_Gemini.ALL_MODELS + AIModel_OpenAI.ALL_MODELS)
+            .map { it.name }
+            .toSet()
+
+    @Test
+    fun everyBundledModelHasARungEntry() {
+        val missing = allModelNames - InMemoryModelDescriptorRegistry.MODEL_RUNGS.keys
+        assertTrue(missing.isEmpty(), "models with no MODEL_RUNGS entry (would silently project as unrated): $missing")
+    }
+
+    @Test
+    fun everyRungEntryMatchesAKnownModel() {
+        val stale = InMemoryModelDescriptorRegistry.MODEL_RUNGS.keys - allModelNames
+        assertTrue(stale.isEmpty(), "MODEL_RUNGS key(s) matching no known model (stale rename?): $stale")
+    }
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/routing/capability/ModelDescriptorRegistryRungTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/routing/capability/ModelDescriptorRegistryRungTest.kt
@@ -95,7 +95,7 @@ class ModelDescriptorRegistryRungTest {
     fun noLowReasoningModelExceedsRungTwo() {
         val violations = descriptors.values.filter { d ->
             d.reasoning == link.socket.ampere.domain.ai.model.AIModelFeatures.RelativeReasoning.LOW &&
-                d.rung > CapabilityRung.TWO
+                (d.rung ?: CapabilityRung.ONE) > CapabilityRung.TWO
         }
         assertTrue(violations.isEmpty(), "LOW-reasoning models above rung TWO: ${violations.map { it.modelName }}")
     }

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/routing/capability/ModelDescriptorTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/routing/capability/ModelDescriptorTest.kt
@@ -2,6 +2,7 @@ package link.socket.ampere.agents.domain.routing.capability
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -136,6 +137,30 @@ class ModelDescriptorTest {
         assertEquals(CapabilityRung.THREE, decoded.rung)
     }
 
+    // ── Unrated (rung == null) gate policy (AMPR-233) ─────────────────────────
+
+    @Test
+    fun unratedModelDoesNotSatisfyADeclaredFloor() {
+        val unrated = opus.copy(rung = null)
+        assertFalse(unrated.satisfies(CapabilityRequirement(minRung = CapabilityRung.ONE)))
+    }
+
+    @Test
+    fun unratedModelSatisfiesWhenNoFloorIsDeclared() {
+        val unrated = opus.copy(rung = null)
+        assertTrue(unrated.satisfies(CapabilityRequirement()))
+    }
+
+    @Test
+    fun unratedRungRoundTrips() {
+        val unrated = opus.copy(rung = null)
+        val decoded = json.decodeFromString<ModelDescriptor>(
+            json.encodeToString(ModelDescriptor.serializer(), unrated),
+        )
+        assertEquals(unrated, decoded)
+        assertNull(decoded.rung)
+    }
+
     @Test
     fun defaultRegistrySeedsOneDescriptorPerModel() = runTest {
         val registry = InMemoryModelDescriptorRegistry()
@@ -171,5 +196,13 @@ class ModelDescriptorTest {
         registry.register(updated)
         assertEquals(updated, registry.descriptorFor(opus.modelName))
         assertEquals(1, registry.all().size)
+    }
+
+    @Test
+    fun duplicateModelNameInSeedIsRejectedRatherThanSilentlyDropped() {
+        val fromAnotherProvider = opus.copy(providerId = link.socket.ampere.domain.ai.provider.AIProvider_OpenAI.id)
+        assertFailsWith<IllegalArgumentException> {
+            InMemoryModelDescriptorRegistry(seed = listOf(opus, fromAnotherProvider))
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Adds a test guarding `MODEL_RUNGS` against drifting out of sync with `AIModel_*.ALL_MODELS` in either direction (missing entries or stale renamed keys).
- Makes `ModelDescriptor.rung` nullable so an unrated model is distinguishable from a deliberate rung `ONE`; `satisfies()` now fails closed for unrated models against a declared floor.
- Rejects duplicate `modelName` entries in the registry seed instead of silently dropping one.

I (Claude) wrote this commit and PR based on AMPR-233.

Closes #598

## Test plan
- [x] `./gradlew :ampere-core:jvmTest`
- [x] `./gradlew :ampere-core:compileCommonMainKotlinMetadata`
- [x] `./gradlew ktlintFormat`