### PR TITLE
AMPR-229 #594: Close three silent-downgrade paths in rung floor enforcement

### DIFF
--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/reasoning/AgentLLMService.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/reasoning/AgentLLMService.kt
@@ -171,10 +171,16 @@ class AgentLLMService(
             }
         }
 
-        // Thread per-agent rung floor into requirements before relay resolves
+        // Thread per-agent rung floor into requirements before relay resolves.
+        // Floors compose as the stricter of the two (AMPR-229): a call site asking
+        // for FOUR through an agent declaring THREE stays at FOUR. Replacing the
+        // call-site floor with the agent's would be a silent downgrade.
         val effectiveRoutingContext = agentConfiguration.agentDefinition.minimumRung?.let { rung ->
             routingContext?.let { ctx ->
-                val mergedRequirements = (ctx.requirements ?: CapabilityRequirement()).copy(minRung = rung)
+                val existing = ctx.requirements ?: CapabilityRequirement()
+                val mergedRequirements = existing.copy(
+                    minRung = existing.minRung?.let { maxOf(it, rung) } ?: rung,
+                )
                 ctx.copy(requirements = mergedRequirements)
             } ?: RoutingContext(requirements = CapabilityRequirement(minRung = rung))
         } ?: routingContext

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/CognitiveRelayImpl.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/CognitiveRelayImpl.kt
@@ -6,11 +6,13 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.datetime.Clock
 import link.socket.ampere.agents.domain.event.EventSource
 import link.socket.ampere.agents.domain.event.RoutingEvent
+import link.socket.ampere.agents.domain.routing.capability.CapabilityRequirement
 import link.socket.ampere.agents.domain.routing.capability.CapabilityRung
 import link.socket.ampere.agents.domain.routing.capability.CheapestCapableFirst
 import link.socket.ampere.agents.domain.routing.capability.ModelDescriptor
 import link.socket.ampere.agents.domain.routing.capability.ModelDescriptorRegistry
 import link.socket.ampere.agents.domain.routing.capability.routingCostPerWatt
+import link.socket.ampere.agents.domain.routing.capability.satisfies
 import link.socket.ampere.agents.events.bus.EventSerialBus
 import link.socket.ampere.agents.events.utils.generateUUID
 import link.socket.ampere.domain.ai.configuration.AIConfiguration
@@ -25,7 +27,7 @@ import link.socket.ampere.util.logWith
  *
  * When the first match is capability-based, selection is cost-aware (AMPR-210):
  * among all capable [RoutingRule.ByCapability] candidates the relay resolves to
- * the cheapest by cost-per-Watt (stable tie-break by `providerId`) and emits a
+ * the cheapest by cost-per-Watt (stable tie-break by `modelName`) and emits a
  * [RoutingEvent.RouteResolved]. A capability rule whose provider is capable but
  * gated out by local availability (AMPR-207) is skipped — it does not match and
  * is not a cost candidate — and the relay emits [RoutingEvent.RouteFallback] for
@@ -92,23 +94,29 @@ class CognitiveRelayImpl(
         // unavailability — the local-preferred route the relay routed around.
         val skip = firstAvailabilitySkip(currentConfig.rules, context)
 
-        // Floor-unmet check: when a rung floor is requested but no ByCapability
-        // rule's model meets it, resolution is terminal — never silently downgrade.
-        val minRung = context.requirements?.minRung
-        if (matchedRule == null && minRung != null) {
-            val bestAvailableRung = bestRungAmongCapabilityRules(currentConfig.rules)
-            if (bestAvailableRung == null || bestAvailableRung < minRung) {
-                emitRouteFloorUnmet(context, minRung, bestAvailableRung)
-                return RoutingResolution.FloorUnmet(
-                    requestedFloor = minRung,
-                    bestAvailableRung = bestAvailableRung,
-                )
-            }
-        }
-
         val selectedConfig = matchedRule?.configuration
             ?: currentConfig.defaultConfiguration
             ?: fallbackConfiguration
+
+        // Floor-unmet check (AMPR-229): a requested rung floor is terminal for
+        // *every* route, not just the no-rule-matched one — never silently
+        // downgrade. The route actually about to be returned is validated against
+        // the whole requirement, which closes three downgrade paths: a
+        // ByPhase/ByAgent/ByRole/ByFeatures/ByTag rule matching on its own axis
+        // and bypassing the floor, and the fall-through to defaultConfiguration
+        // or fallbackConfiguration, neither of which was ever checked. A
+        // ByCapability match already passed `satisfies`, so it re-validates
+        // trivially.
+        val requirement = context.requirements
+        val minRung = requirement?.minRung
+        if (requirement != null && minRung != null && !satisfiesRequirement(selectedConfig, requirement)) {
+            val bestAvailableRung = bestRungAmongCapabilityRules(currentConfig.rules)
+            emitRouteFloorUnmet(context, minRung, bestAvailableRung)
+            return RoutingResolution.FloorUnmet(
+                requestedFloor = minRung,
+                bestAvailableRung = bestAvailableRung,
+            )
+        }
 
         val ruleDescription = matchedRule?.describeRule() ?: "default"
 
@@ -133,6 +141,20 @@ class CognitiveRelayImpl(
             configuration = selectedConfig,
             reason = ruleDescription,
         )
+    }
+
+    /**
+     * Whether the model behind [configuration] can serve [requirement], per the
+     * registry. A model the registry cannot describe is not provably capable, so
+     * it does not satisfy: an unverifiable route is treated as sub-floor rather
+     * than waved through (AMPR-229).
+     */
+    private suspend fun satisfiesRequirement(
+        configuration: AIConfiguration,
+        requirement: CapabilityRequirement,
+    ): Boolean {
+        val descriptor = registry?.descriptorFor(configuration.model.name) ?: return false
+        return descriptor.satisfies(requirement)
     }
 
     /**

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/routing/CognitiveRelayFloorTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/routing/CognitiveRelayFloorTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
+import link.socket.ampere.agents.domain.cognition.sparks.CognitivePhase
 import link.socket.ampere.agents.domain.event.RoutingEvent
 import link.socket.ampere.agents.domain.routing.capability.CapabilityRequirement
 import link.socket.ampere.agents.domain.routing.capability.CapabilityRung
@@ -221,6 +222,133 @@ class CognitiveRelayFloorTest {
         delay(100)
 
         assertEquals(0, selected.size, "RouteSelected must not be emitted when floor is unmet")
+    }
+
+    // --- AMPR-229 Gap A: a non-capability rule must not bypass the floor ---
+
+    @Test
+    fun `a matching ByPhase rule below the floor resolves to FloorUnmet, not to its model`() = runTest {
+        val relay = CognitiveRelayImpl(
+            initialConfig = RelayConfig(
+                rules = listOf(
+                    // Matches on phase alone and points at a rung ONE model.
+                    RoutingRule.ByPhase(CognitivePhase.EXECUTE, lowRungConfig),
+                    RoutingRule.ByCapability(highRungConfig),
+                ),
+            ),
+            registry = lowRungRegistry,
+        )
+
+        val result = relay.resolveWithMetadata(
+            context = RoutingContext(
+                phase = CognitivePhase.EXECUTE,
+                requirements = CapabilityRequirement(minRung = CapabilityRung.THREE),
+            ),
+            fallbackConfiguration = agentFallback,
+        )
+
+        assertIs<RoutingResolution.FloorUnmet>(result)
+        assertEquals(CapabilityRung.THREE, result.requestedFloor)
+        assertEquals(CapabilityRung.TWO, result.bestAvailableRung)
+    }
+
+    @Test
+    fun `the floor stays terminal for a ByPhase match even when a capable model exists`() = runTest {
+        val relay = CognitiveRelayImpl(
+            initialConfig = RelayConfig(
+                rules = listOf(
+                    RoutingRule.ByPhase(CognitivePhase.EXECUTE, lowRungConfig),
+                    RoutingRule.ByCapability(highRungConfig),
+                ),
+            ),
+            registry = highRungRegistry,
+        )
+
+        val result = relay.resolveWithMetadata(
+            context = RoutingContext(
+                phase = CognitivePhase.EXECUTE,
+                requirements = CapabilityRequirement(minRung = CapabilityRung.THREE),
+            ),
+            fallbackConfiguration = agentFallback,
+        )
+
+        assertIs<RoutingResolution.FloorUnmet>(result)
+    }
+
+    @Test
+    fun `a matching ByPhase rule at or above the floor still resolves normally`() = runTest {
+        val relay = CognitiveRelayImpl(
+            initialConfig = RelayConfig(
+                rules = listOf(RoutingRule.ByPhase(CognitivePhase.EXECUTE, highRungConfig)),
+            ),
+            registry = highRungRegistry,
+        )
+
+        val result = relay.resolveWithMetadata(
+            context = RoutingContext(
+                phase = CognitivePhase.EXECUTE,
+                requirements = CapabilityRequirement(minRung = CapabilityRung.THREE),
+            ),
+            fallbackConfiguration = agentFallback,
+        )
+
+        assertIs<RoutingResolution.Success>(result)
+        assertEquals(AIModel_Gemini.Flash_2_5, result.configuration.model)
+    }
+
+    // --- AMPR-229 Gap B: fall-through configs must be checked against the requirement ---
+
+    @Test
+    fun `defaultConfiguration is not routed to unchecked when a non-rung axis is unsatisfiable`() = runTest {
+        val relay = CognitiveRelayImpl(
+            initialConfig = RelayConfig(
+                rules = listOf(
+                    RoutingRule.ByCapability(lowRungConfig),
+                    RoutingRule.ByCapability(highRungConfig),
+                ),
+                defaultConfiguration = lowRungConfig,
+            ),
+            registry = highRungRegistry,
+        )
+
+        // minRung THREE is satisfiable (Gemini is rung THREE), so the floor check alone
+        // passes — but no model has a 1M-token context, so no capability rule matches
+        // and control falls through to defaultConfiguration, which is rung ONE.
+        val result = relay.resolveWithMetadata(
+            context = RoutingContext(
+                requirements = CapabilityRequirement(
+                    minRung = CapabilityRung.THREE,
+                    minContextTokens = 1_000_000,
+                ),
+            ),
+            fallbackConfiguration = agentFallback,
+        )
+
+        assertIs<RoutingResolution.FloorUnmet>(result)
+        assertEquals(CapabilityRung.THREE, result.requestedFloor)
+    }
+
+    @Test
+    fun `fallbackConfiguration is not routed to unchecked when a non-rung axis is unsatisfiable`() = runTest {
+        val relay = CognitiveRelayImpl(
+            initialConfig = RelayConfig(
+                rules = listOf(RoutingRule.ByCapability(highRungConfig)),
+            ),
+            registry = highRungRegistry,
+        )
+
+        val result = relay.resolveWithMetadata(
+            context = RoutingContext(
+                requirements = CapabilityRequirement(
+                    minRung = CapabilityRung.THREE,
+                    minContextTokens = 1_000_000,
+                ),
+            ),
+            fallbackConfiguration = agentFallback,
+        )
+
+        assertIs<RoutingResolution.FloorUnmet>(result)
+        assertEquals(CapabilityRung.THREE, result.requestedFloor)
     }
 
     @Test

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/routing/CognitiveRelayFloorTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/routing/CognitiveRelayFloorTest.kt
@@ -227,7 +227,7 @@ class CognitiveRelayFloorTest {
     // --- AMPR-229 Gap A: a non-capability rule must not bypass the floor ---
 
     @Test
-    fun `a matching ByPhase rule below the floor resolves to FloorUnmet, not to its model`() = runTest {
+    fun `a matching ByPhase rule below the floor resolves to FloorUnmet — not to its model`() = runTest {
         val relay = CognitiveRelayImpl(
             initialConfig = RelayConfig(
                 rules = listOf(

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/llm/AgentDefinitionRungThreadingTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/llm/AgentDefinitionRungThreadingTest.kt
@@ -9,6 +9,7 @@ import link.socket.ampere.agents.domain.reasoning.AgentLLMService
 import link.socket.ampere.agents.domain.routing.CognitiveRelay
 import link.socket.ampere.agents.domain.routing.RelayConfig
 import link.socket.ampere.agents.domain.routing.RoutingContext
+import link.socket.ampere.agents.domain.routing.capability.CapabilityRequirement
 import link.socket.ampere.agents.domain.routing.capability.CapabilityRung
 import link.socket.ampere.domain.agent.bundled.AgentDefinition
 import link.socket.ampere.domain.ai.configuration.AIConfiguration
@@ -135,6 +136,79 @@ class AgentDefinitionRungThreadingTest {
         } catch (_: Throwable) {}
 
         assertEquals(CapabilityRung.FOUR, relay.capturedContext?.requirements?.minRung)
+    }
+
+    @Test
+    fun `a stricter call-site floor survives an agent declaring a lower one`() = runTest {
+        val relay = CapturingRelay()
+        val definition = makeDefinition(CapabilityRung.THREE)
+        val config = AgentConfiguration(
+            agentDefinition = definition,
+            aiConfiguration = FakeAIConfiguration(),
+            cognitiveRelay = relay,
+        )
+        val service = AgentLLMService(agentConfiguration = config)
+
+        try {
+            service.call(
+                prompt = "test",
+                routingContext = RoutingContext(
+                    agentId = "agent-1",
+                    requirements = CapabilityRequirement(minRung = CapabilityRung.FOUR),
+                ),
+            )
+        } catch (_: Throwable) {}
+
+        assertEquals(CapabilityRung.FOUR, relay.capturedContext?.requirements?.minRung)
+    }
+
+    @Test
+    fun `the agent floor wins when it is stricter than the call-site floor`() = runTest {
+        val relay = CapturingRelay()
+        val definition = makeDefinition(CapabilityRung.THREE)
+        val config = AgentConfiguration(
+            agentDefinition = definition,
+            aiConfiguration = FakeAIConfiguration(),
+            cognitiveRelay = relay,
+        )
+        val service = AgentLLMService(agentConfiguration = config)
+
+        try {
+            service.call(
+                prompt = "test",
+                routingContext = RoutingContext(
+                    agentId = "agent-1",
+                    requirements = CapabilityRequirement(minRung = CapabilityRung.TWO),
+                ),
+            )
+        } catch (_: Throwable) {}
+
+        assertEquals(CapabilityRung.THREE, relay.capturedContext?.requirements?.minRung)
+    }
+
+    @Test
+    fun `merging the agent floor preserves the call-site's other requirement axes`() = runTest {
+        val relay = CapturingRelay()
+        val definition = makeDefinition(CapabilityRung.THREE)
+        val config = AgentConfiguration(
+            agentDefinition = definition,
+            aiConfiguration = FakeAIConfiguration(),
+            cognitiveRelay = relay,
+        )
+        val service = AgentLLMService(agentConfiguration = config)
+
+        try {
+            service.call(
+                prompt = "test",
+                routingContext = RoutingContext(
+                    agentId = "agent-1",
+                    requirements = CapabilityRequirement(minContextTokens = 128_000),
+                ),
+            )
+        } catch (_: Throwable) {}
+
+        assertEquals(CapabilityRung.THREE, relay.capturedContext?.requirements?.minRung)
+        assertEquals(128_000, relay.capturedContext?.requirements?.minContextTokens)
     }
 
     @Test


### PR DESCRIPTION
## Summary

The rung floor is documented as terminal ("never silently downgrade"), but three paths violated that — all latent today, and all reachable exactly when this epic's per-call requirements and non-capability rules land. **Gap A**: the floor check was gated on `matchedRule == null`, so any `ByPhase`/`ByAgent`/`ByRole`/`ByFeatures`/`ByTag` match bypassed it; **Gap B**: with a satisfiable `minRung` but a rule failing on some *other* axis, control fell through to `defaultConfiguration`/`fallbackConfiguration`, neither ever checked against the requirement; **Gap C**: `AgentLLMService`'s unconditional `copy(minRung = agentRung)` *replaced* a call-site floor instead of composing with it, downgrading a call requiring `FOUR` to an agent's `THREE`.

A and B are closed by one restructure — `selectedConfig` is computed before the check, and the configuration actually about to be returned is validated against the *whole* `CapabilityRequirement` via `satisfies` (gated only on `minRung != null`), with a registry-unknown model treated as sub-floor rather than waved through; C becomes `existing.minRung?.let { maxOf(it, rung) } ?: rung`. Also fixes the stale KDoc at `CognitiveRelayImpl.kt:29` claiming the cost tie-break is by `providerId` when the comparator sorts by `modelName`.

Closes #594

## Test plan

- [x] Five new tests, one per gap plus the fall-through and composition variants — each verified **failing before** the fix via `git stash` of the two source files
- [x] Two added regression tests confirm the stricter check does not over-reject a compliant non-capability rule or drop other requirement axes
- [x] `:ampere-core:jvmTest :ampere-cli:jvmTest :ampere-compose:jvmTest :ampere-phosphor:jvmTest` and `:ampere-core:compileCommonMainKotlinMetadata` green; `ktlintCheck` clean
- [ ] `./gradlew jvmTest` not run whole: `:ampere-eval:compileKotlinJvm` has a **pre-existing** failure on this branch's base (`PlaybackRelay.kt:115,142` still treats `RoutingResolution` as a data class after #580 made it a sealed interface) — confirmed unrelated by stashing all changes and rebuilding at 4ce74ff5

🤖 Generated with [Claude Code](https://claude.com/claude-code)