### PR TITLE
AMPR-230 #595: T1 — ModelDescriptorSource + refresh() on the registry

### DIFF
--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/capability/ModelDescriptor.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/capability/ModelDescriptor.kt
@@ -21,8 +21,8 @@ import link.socket.ampere.domain.ai.provider.ProviderId
  * longer the selection key.
  *
  * Because no live client is held here, a descriptor round-trips cleanly through
- * serialization — the foundation for a future declarative-config story (no
- * loader is built yet).
+ * serialization — which is what lets a [ModelDescriptorSource] carry a catalog
+ * across an I/O boundary into a live [ModelDescriptorRegistry].
  *
  * @property modelName Matches the corresponding `AIModel.name`; the selection key.
  * @property providerId The owning provider's `AIProvider.id`.

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/capability/ModelDescriptorRegistry.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/capability/ModelDescriptorRegistry.kt
@@ -1,5 +1,6 @@
 package link.socket.ampere.agents.domain.routing.capability
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import link.socket.ampere.domain.ai.model.AIModel
@@ -32,6 +33,17 @@ interface ModelDescriptorRegistry {
 
     /** Register (or replace) the descriptor for its `modelName`. */
     suspend fun register(descriptor: ModelDescriptor)
+
+    /**
+     * Reload the catalog from this registry's [ModelDescriptorSource], replacing
+     * it wholesale. This is how a consumer changes model→rung assignments at
+     * runtime — no relay reconstruction, no framework release.
+     *
+     * A load that fails returns that failure with the previous catalog
+     * untouched; it never leaves the registry empty. Defaults to a no-op
+     * success, because a registry with a fixed catalog has nothing to reload.
+     */
+    suspend fun refresh(): Result<Unit> = Result.success(Unit)
 }
 
 /**
@@ -40,20 +52,30 @@ interface ModelDescriptorRegistry {
  *
  * Seeded by default with one descriptor per model across the bundled cloud
  * providers, each projected from the model's own metadata.
+ *
+ * The catalog is not frozen at construction: [source] is where [refresh] reads
+ * a replacement from. Left unset, the source echoes [seed], so a registry built
+ * with no arguments holds the bundled catalog and reloads that same catalog —
+ * identical to [DefaultModelDescriptorSource]. Pass a [source] to hand catalog
+ * ownership to the consumer while [seed] keeps routing working until the first
+ * [refresh] lands; or use [from] to load once before the registry exists.
+ *
+ * @param seed The catalog the registry starts with.
+ * @param source Where [refresh] reads the replacement catalog from.
  */
 class InMemoryModelDescriptorRegistry(
     seed: List<ModelDescriptor> = defaultModelDescriptors(),
+    private val source: ModelDescriptorSource = ModelDescriptorSource { Result.success(seed) },
 ) : ModelDescriptorRegistry {
 
     private val mutex = Mutex()
-    private val descriptors: MutableMap<String, ModelDescriptor> = run {
-        val duplicates = seed.groupingBy { it.modelName }.eachCount().filterValues { it > 1 }.keys
-        require(duplicates.isEmpty()) {
-            "Duplicate modelName(s) in registry seed (two providers exposing the same model " +
-                "name would silently drop one): $duplicates"
-        }
-        seed.associateByTo(mutableMapOf()) { it.modelName }
-    }
+
+    /**
+     * An immutable snapshot, swapped whole rather than mutated in place. Every
+     * read and every write takes [mutex], so a reader observes the catalog
+     * either before a [refresh] or after it — never a half-replaced map.
+     */
+    private var descriptors: Map<String, ModelDescriptor> = indexCatalog(seed)
 
     override suspend fun descriptorFor(modelName: String): ModelDescriptor? =
         mutex.withLock { descriptors[modelName] }
@@ -62,10 +84,55 @@ class InMemoryModelDescriptorRegistry(
         mutex.withLock { descriptors.values.toList() }
 
     override suspend fun register(descriptor: ModelDescriptor) {
-        mutex.withLock { descriptors[descriptor.modelName] = descriptor }
+        mutex.withLock { descriptors = descriptors + (descriptor.modelName to descriptor) }
+    }
+
+    override suspend fun refresh(): Result<Unit> {
+        // Loaded and indexed outside the lock — including the duplicate check,
+        // which arrives here as a failure rather than a throw because a bad
+        // catalog must leave the live one alone, not tear the registry down.
+        val next = try {
+            source.load().map(::indexCatalog)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            Result.failure(e)
+        }
+
+        return next.map { catalog -> mutex.withLock { descriptors = catalog } }
     }
 
     companion object {
+
+        /**
+         * A registry whose catalog comes entirely from [source], loaded before
+         * the registry is handed back. A failed load surfaces as a failure
+         * rather than as a registry with nothing in it.
+         */
+        suspend fun from(source: ModelDescriptorSource): Result<InMemoryModelDescriptorRegistry> {
+            val registry = InMemoryModelDescriptorRegistry(seed = emptyList(), source = source)
+            return registry.refresh().map { registry }
+        }
+
+        /**
+         * Keys a catalog by `modelName`, rejecting duplicates rather than
+         * silently dropping one (AMPR-233) — two providers exposing the same
+         * model name is a catalog bug, and swallowing it would hide a model
+         * that routing was told it had.
+         *
+         * Shared by seeding and [refresh] so a consumer-supplied catalog is held
+         * to the same rule as the bundled one; the two paths differ only in how
+         * the rejection surfaces (a throw at construction, a failed [Result] on
+         * refresh).
+         */
+        private fun indexCatalog(catalog: List<ModelDescriptor>): Map<String, ModelDescriptor> {
+            val duplicates = catalog.groupingBy { it.modelName }.eachCount().filterValues { it > 1 }.keys
+            require(duplicates.isEmpty()) {
+                "Duplicate modelName(s) in model catalog (two providers exposing the same model " +
+                    "name would silently drop one): $duplicates"
+            }
+            return catalog.associateBy { it.modelName }
+        }
 
         /**
          * Default capability set projected onto the bundled cloud models.

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/capability/ModelDescriptorSource.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/capability/ModelDescriptorSource.kt
@@ -1,0 +1,36 @@
+package link.socket.ampere.agents.domain.routing.capability
+
+/**
+ * Where a [ModelDescriptorRegistry] gets its catalog.
+ *
+ * The framework ships this interface and one implementation of it — the bundled
+ * cloud catalog ([DefaultModelDescriptorSource]) — and nothing more. A consumer
+ * supplies its own source (HTTP, a file, remote config, a hand-built list) and
+ * refreshes model→rung assignments while the process runs, without waiting on a
+ * framework release. No backend, transport, or host application is assumed here.
+ *
+ * [load] returns a [Result] because reading a catalog crosses an I/O boundary.
+ * A source that cannot produce a catalog must return [Result.failure] rather
+ * than an empty list: a failed load leaves the registry's previous catalog
+ * intact, whereas an empty *successful* load is taken at its word and empties
+ * the registry.
+ */
+fun interface ModelDescriptorSource {
+
+    /** The full catalog this source describes, or the reason it could not be read. */
+    suspend fun load(): Result<List<ModelDescriptor>>
+}
+
+/**
+ * The catalog Ampere ships with: one [ModelDescriptor] per model across the
+ * bundled cloud providers, projected from each model's own metadata.
+ *
+ * This is what a no-argument [InMemoryModelDescriptorRegistry] holds, and the
+ * source to compose with when a consumer wants its own catalog layered over the
+ * bundled one rather than replacing it.
+ */
+object DefaultModelDescriptorSource : ModelDescriptorSource {
+
+    override suspend fun load(): Result<List<ModelDescriptor>> =
+        Result.success(InMemoryModelDescriptorRegistry.defaultModelDescriptors())
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/routing/capability/ModelDescriptorSourceTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/routing/capability/ModelDescriptorSourceTest.kt
@@ -132,7 +132,7 @@ class ModelDescriptorSourceTest {
     }
 
     @Test
-    fun `a source that throws is caught as a failure, not propagated`() = runTest {
+    fun `a source that throws is caught as a failure rather than propagated`() = runTest {
         val seed = listOf(descriptor("survivor", CapabilityRung.THREE))
         val registry = InMemoryModelDescriptorRegistry(
             seed = seed,
@@ -146,7 +146,7 @@ class ModelDescriptorSourceTest {
     }
 
     @Test
-    fun `a catalog with duplicate model names is rejected, not silently deduplicated`() = runTest {
+    fun `a catalog with duplicate model names is rejected rather than silently deduplicated`() = runTest {
         // AMPR-233 rejects duplicates in the seed; a consumer-supplied catalog is
         // held to the same rule, but surfaces as a failure rather than a throw so
         // the live catalog survives a bad load.

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/routing/capability/ModelDescriptorSourceTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/routing/capability/ModelDescriptorSourceTest.kt
@@ -1,0 +1,278 @@
+package link.socket.ampere.agents.domain.routing.capability
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import link.socket.ampere.domain.ai.model.AIModelFeatures.RelativeReasoning
+import link.socket.ampere.domain.ai.model.AIModelFeatures.SupportedInputs
+import link.socket.ampere.domain.ai.provider.AIProvider_Anthropic
+import link.socket.ampere.domain.ai.provider.AIProvider_Google
+
+/**
+ * The injectable-catalog contract (AMPR-230): a consumer supplies a
+ * [ModelDescriptorSource] and refreshes model→rung assignments at runtime.
+ */
+class ModelDescriptorSourceTest {
+
+    private fun descriptor(
+        name: String,
+        rung: CapabilityRung,
+    ): ModelDescriptor = ModelDescriptor(
+        modelName = name,
+        providerId = AIProvider_Anthropic.id,
+        capabilities = emptySet(),
+        reasoning = RelativeReasoning.NORMAL,
+        maxContextTokens = 200_000,
+        supportedInputs = SupportedInputs.TEXT,
+        rung = rung,
+    )
+
+    // ── Default construction ──────────────────────────────────────────────────
+
+    @Test
+    fun `no-argument construction holds the bundled catalog`() = runTest {
+        val registry = InMemoryModelDescriptorRegistry()
+
+        assertEquals(
+            InMemoryModelDescriptorRegistry.defaultModelDescriptors().toSet(),
+            registry.all().toSet(),
+        )
+    }
+
+    @Test
+    fun `default source echoes the seed rather than swapping in the bundled catalog`() = runTest {
+        val seed = listOf(descriptor("only-model", CapabilityRung.TWO))
+        val registry = InMemoryModelDescriptorRegistry(seed = seed)
+
+        assertTrue(registry.refresh().isSuccess)
+
+        assertEquals(seed, registry.all())
+    }
+
+    @Test
+    fun `refreshing a default registry reloads the same bundled catalog`() = runTest {
+        val registry = InMemoryModelDescriptorRegistry()
+        val before = registry.all().toSet()
+
+        assertTrue(registry.refresh().isSuccess)
+
+        assertEquals(before, registry.all().toSet())
+        assertEquals(DefaultModelDescriptorSource.load().getOrThrow().toSet(), before)
+    }
+
+    // ── Refresh replaces the catalog ──────────────────────────────────────────
+
+    @Test
+    fun `refresh picks up a changed rung for an existing model`() = runTest {
+        var rung = CapabilityRung.TWO
+        val source = ModelDescriptorSource { Result.success(listOf(descriptor("shifting-model", rung))) }
+        val registry = InMemoryModelDescriptorRegistry(seed = emptyList(), source = source)
+
+        assertTrue(registry.refresh().isSuccess)
+        assertEquals(CapabilityRung.TWO, registry.descriptorFor("shifting-model")?.rung)
+
+        rung = CapabilityRung.FOUR
+        assertTrue(registry.refresh().isSuccess)
+
+        assertEquals(CapabilityRung.FOUR, registry.descriptorFor("shifting-model")?.rung)
+    }
+
+    @Test
+    fun `refresh drops models the source no longer lists`() = runTest {
+        var catalog = listOf(descriptor("retired-model", CapabilityRung.THREE))
+        val registry = InMemoryModelDescriptorRegistry(
+            seed = catalog,
+            source = ModelDescriptorSource { Result.success(catalog) },
+        )
+
+        catalog = listOf(descriptor("successor-model", CapabilityRung.THREE))
+        assertTrue(registry.refresh().isSuccess)
+
+        assertNull(registry.descriptorFor("retired-model"), "replacement is wholesale, not a merge")
+        assertNotNull(registry.descriptorFor("successor-model"))
+    }
+
+    @Test
+    fun `register still upserts a single descriptor without touching the rest`() = runTest {
+        val registry = InMemoryModelDescriptorRegistry(
+            seed = listOf(descriptor("kept", CapabilityRung.ONE)),
+        )
+
+        registry.register(descriptor("added", CapabilityRung.FOUR))
+
+        assertEquals(CapabilityRung.ONE, registry.descriptorFor("kept")?.rung)
+        assertEquals(CapabilityRung.FOUR, registry.descriptorFor("added")?.rung)
+    }
+
+    // ── Failure leaves the previous catalog intact ────────────────────────────
+
+    @Test
+    fun `a failed load surfaces the error and never empties the registry`() = runTest {
+        val boom = IllegalStateException("catalog endpoint unreachable")
+        val seed = listOf(descriptor("survivor", CapabilityRung.THREE))
+        val registry = InMemoryModelDescriptorRegistry(
+            seed = seed,
+            source = { Result.failure(boom) },
+        )
+
+        val result = registry.refresh()
+
+        assertEquals(boom, result.exceptionOrNull())
+        assertEquals(seed, registry.all())
+        assertEquals(CapabilityRung.THREE, registry.descriptorFor("survivor")?.rung)
+    }
+
+    @Test
+    fun `a source that throws is caught as a failure, not propagated`() = runTest {
+        val seed = listOf(descriptor("survivor", CapabilityRung.THREE))
+        val registry = InMemoryModelDescriptorRegistry(
+            seed = seed,
+            source = { throw IllegalArgumentException("malformed catalog") },
+        )
+
+        val result = registry.refresh()
+
+        assertTrue(result.exceptionOrNull() is IllegalArgumentException)
+        assertEquals(seed, registry.all())
+    }
+
+    @Test
+    fun `a catalog with duplicate model names is rejected, not silently deduplicated`() = runTest {
+        // AMPR-233 rejects duplicates in the seed; a consumer-supplied catalog is
+        // held to the same rule, but surfaces as a failure rather than a throw so
+        // the live catalog survives a bad load.
+        val seed = listOf(descriptor("survivor", CapabilityRung.THREE))
+        val registry = InMemoryModelDescriptorRegistry(
+            seed = seed,
+            source = {
+                Result.success(
+                    listOf(
+                        descriptor("collides", CapabilityRung.ONE),
+                        descriptor("collides", CapabilityRung.FOUR),
+                    ),
+                )
+            },
+        )
+
+        val result = registry.refresh()
+
+        assertTrue(result.exceptionOrNull() is IllegalArgumentException)
+        assertTrue(
+            result.exceptionOrNull()?.message?.contains("collides") == true,
+            "the failure should name the colliding model",
+        )
+        assertEquals(seed, registry.all(), "a rejected catalog must not disturb the live one")
+    }
+
+    @Test
+    fun `an empty successful load is taken at its word`() = runTest {
+        val registry = InMemoryModelDescriptorRegistry(
+            seed = listOf(descriptor("doomed", CapabilityRung.THREE)),
+            source = { Result.success(emptyList()) },
+        )
+
+        assertTrue(registry.refresh().isSuccess)
+
+        assertEquals(emptyList<ModelDescriptor>(), registry.all())
+    }
+
+    // ── from() ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `from loads the catalog before handing back a registry`() = runTest {
+        val catalog = listOf(descriptor("consumer-model", CapabilityRung.FOUR))
+
+        val registry = InMemoryModelDescriptorRegistry.from { Result.success(catalog) }.getOrThrow()
+
+        assertEquals(catalog, registry.all())
+    }
+
+    @Test
+    fun `from surfaces a load failure instead of an empty registry`() = runTest {
+        val boom = IllegalStateException("no catalog")
+
+        val result = InMemoryModelDescriptorRegistry.from { Result.failure(boom) }
+
+        assertEquals(boom, result.exceptionOrNull())
+    }
+
+    // ── Concurrency ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `concurrent refresh and reads never observe a half-replaced catalog`() = runBlocking {
+        // Two disjoint catalogs of equal size. A read that comes up short, or
+        // that mixes names from both, saw a partial swap.
+        val even = (0 until 24).map { descriptor("even-$it", CapabilityRung.TWO) }
+        val odd = (0 until 24).map { descriptor("odd-$it", CapabilityRung.THREE) }
+        var flip = false
+        val registry = InMemoryModelDescriptorRegistry(
+            seed = even,
+            source = {
+                flip = !flip
+                Result.success(if (flip) odd else even)
+            },
+        )
+
+        val snapshots = withContext(Dispatchers.Default) {
+            val writers = List(8) { launch { repeat(50) { registry.refresh() } } }
+            val readers = List(8) { async { List(50) { registry.all() } } }
+
+            writers.forEach { it.join() }
+            readers.awaitAll().flatten()
+        }
+
+        snapshots.forEach { snapshot ->
+            assertEquals(24, snapshot.size, "snapshot was partially replaced: $snapshot")
+            val catalogs = snapshot.map { it.modelName.substringBefore('-') }.toSet()
+            assertEquals(1, catalogs.size, "snapshot mixed two catalogs: $catalogs")
+        }
+    }
+
+    // ── The point of all this: routing changes without rebuilding the relay ───
+
+    @Test
+    fun `refresh changes which model satisfies a floor`() = runTest {
+        var catalog = listOf(
+            descriptor("cheap-model", CapabilityRung.ONE),
+            ModelDescriptor(
+                modelName = "capable-model",
+                providerId = AIProvider_Google.id,
+                capabilities = emptySet(),
+                reasoning = RelativeReasoning.HIGH,
+                maxContextTokens = 200_000,
+                supportedInputs = SupportedInputs.TEXT,
+                rung = CapabilityRung.TWO,
+            ),
+        )
+        val registry = InMemoryModelDescriptorRegistry(
+            seed = catalog,
+            source = { Result.success(catalog) },
+        )
+        val floor = CapabilityRequirement(minRung = CapabilityRung.FOUR)
+
+        assertTrue(
+            registry.all().none { it.satisfies(floor) },
+            "no model clears a rung FOUR floor yet",
+        )
+
+        // The consumer re-rates capable-model without a framework release.
+        catalog = catalog.map {
+            if (it.modelName == "capable-model") it.copy(rung = CapabilityRung.FOUR) else it
+        }
+        assertTrue(registry.refresh().isSuccess)
+
+        assertEquals(
+            listOf("capable-model"),
+            registry.all().filter { it.satisfies(floor) }.map { it.modelName },
+        )
+    }
+}

--- a/docs/concepts/cognitive-relay.md
+++ b/docs/concepts/cognitive-relay.md
@@ -8,7 +8,7 @@ tracked_sources:
   - ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/ProviderCallStartedEvent.kt
   - ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/ProviderCallCompletedEvent.kt
 related: [PropelLoop, EventSerialBus, CognitionTrace]
-last_verified: 2026-06-08
+last_verified: 2026-07-28
 ---
 
 # CognitiveRelay
@@ -56,7 +56,8 @@ change.
 - `agents/domain/routing/RoutingRule.kt` — predicate + target configuration.
 - `agents/domain/routing/RoutingContext.kt` — what rules match against (`CognitivePhase`, `agentId`, hints, optional `requirements`).
 - `agents/domain/routing/RoutingDecision.kt` — the event payload.
-- `agents/domain/routing/capability/` — provider capability vocabulary (`ProviderCapability`, `CapabilityRequirement`) and the SDK-free `ProviderDescriptor` + `ProviderDescriptorRegistry` the `ByCapability` rule matches against. Parallel to `domain/ai/provider/AIProvider` (left untouched).
+- `agents/domain/routing/capability/` — capability vocabulary (`ProviderCapability`, `CapabilityRequirement`, `CapabilityRung`) and the SDK-free `ModelDescriptor` + `ModelDescriptorRegistry` the `ByCapability` rule matches against, keyed per *model* rather than per provider (AMPR-214). Parallel to `domain/ai/model/AIModel` (left untouched).
+- `agents/domain/routing/capability/ModelDescriptorSource.kt` — where a registry's catalog comes from. The framework ships the interface and `DefaultModelDescriptorSource` (the bundled cloud catalog); a consumer supplies its own.
 - `agents/domain/reasoning/AgentLLMService.kt` — the only legitimate caller.
 - `agents/domain/event/RoutingEvent.kt`, `ProviderCallStartedEvent.kt`, `ProviderCallCompletedEvent.kt` — observability events.
 
@@ -66,7 +67,8 @@ change.
 - **All LLM calls go through the relay.** `AgentLLMService` is the single entry point. Direct construction of an `AIConfiguration` and a model client in domain code bypasses routing, observability, and rule precedence.
 - **Routing rules are evaluated in declared order; first match wins.** Reordering rules changes routing behaviour. The relay is intentionally not "best match" — it is "first match", because predictability beats cleverness. The one principled exception is cost: when the first match is a `ByCapability`, selection is cheapest-capable across the capable candidates (still deterministic — a total order on cost-per-Watt with a `providerId` tie-break, not a scoring engine).
 - **Every resolved call emits `ProviderCallStartedEvent` and `ProviderCallCompletedEvent`.** With `cognitivePhase`, `providerId`, `modelId`, and `routingReason` populated. `ArcTraceProjection` joins these to build `ModelInvocationTrace`; missing events produce gaps in the trace.
-- **Hot-swap goes through `updateConfig`.** Mutating a `RelayConfig` field in place is not supported. `updateConfig` exists so changes can be observed by long-running reasoning sessions.
+- **Hot-swap goes through `updateConfig`.** Mutating a `RelayConfig` field in place is not supported. `updateConfig` exists so changes can be observed by long-running reasoning sessions. `updateConfig` swaps *rules*; `ModelDescriptorRegistry.refresh` swaps the *catalog*. They are separate seams and neither substitutes for the other.
+- **A failed catalog load never empties the registry.** `refresh` replaces the catalog atomically or not at all: a `Result.failure` from the source leaves the previous catalog fully intact and surfaces the error. A registry that silently emptied itself would turn a transient network blip into blanket `FloorUnmet` — the exact silent downgrade the rung floor exists to prevent. A source that cannot produce a catalog must return `failure`, not an empty list.
 - **The fallback is not optional.** A relay that can return null on no-match would make every `AgentLLMService` caller responsible for a fallback decision, defeating the point. Every call must produce some `AIConfiguration`.
 
 ## Common operations
@@ -75,6 +77,7 @@ change.
 - **Route by phase** — `RoutingContext.phase` is a `CognitivePhase`; rules can switch on it directly.
 - **Route by capability** — set `RoutingContext.requirements` (a `CapabilityRequirement`) on the step and add `RoutingRule.ByCapability` rules ordered most-preferred-first. Each matches only when its target provider's `ProviderDescriptor` (looked up in the injected `ProviderDescriptorRegistry`) `satisfies` the requirement. The registry-aware `RoutingRule.matches(context, registry)` overload is `suspend` (the registry is mutex-guarded) and defaults to the pure `matches`, so the five non-capability rules are unaffected.
 - **Route by cost (cheapest-capable)** — when the first matching rule is a `ByCapability`, the relay does not stop at first-match: it ranks *all* capable `ByCapability` candidates by `CostPolicy.usdPerWatt` (cost-per-Watt) and resolves to the cheapest, breaking ties stably by `providerId`. "Prefer on-device" is the limiting case — a local provider priced `CostPolicy.Free` (0W) always wins. The choice is observable via `RoutingEvent.RouteResolved` (chosen / runner-up / `savingsVsRunnerUp`), a sibling to `RouteFallback`. Single-candidate matches and all non-capability rules keep pure first-match. Rates are provider *data* in the registry; selection never hardcodes them. `RouteCostReporter` prints a deterministic dry-run of cheapest route + Watt cost per step across the launch Arcs.
+- **Supply your own model catalog** — implement `ModelDescriptorSource` (a `fun interface`; `suspend fun load(): Result<List<ModelDescriptor>>`) and either build the registry from it up front with `InMemoryModelDescriptorRegistry.from(source)`, or pass it alongside a seed so routing works from the bundled catalog until the first load lands. Calling `refresh()` re-reads the source, so model→rung assignments change while the process runs — no relay reconstruction, no framework release.
 - **Inspect a routing decision in tests** — call `resolveWithMetadata` instead of `resolve`. The returned `RoutingResolution.reason` is a free-form tag describing which rule matched ("phase=PLAN" / "default fallback").
 - **Trace which model handled a phase** — `ArcTraceProjection.project(runId)` returns `ModelInvocationTrace`s keyed by phase, with `routingReason` populated from the routing event.
 
@@ -85,3 +88,4 @@ change.
 - **Importing a provider SDK from cognition code.** Even "temporarily" or "for a quick test" — the import lingers, and now `agents/domain/...` is provider-coupled.
 - **Treating `routingReason` as an internal detail.** It is read by the trace and displayed to humans debugging cognitive runs. A blank or unhelpful reason ("matched") is a regression in observability.
 - **Mutating `RelayConfig` fields directly to "hot-update" rules.** The `updateConfig` path emits the changes; direct mutation is invisible to subscribers and to the trace.
+- **Rebuilding the relay to change a model's rung.** The registry is the mutable surface — `refresh()` (whole catalog) or `register()` (one descriptor). Tearing down a live relay drops the rule set and every in-flight reasoning session along with it.


### PR DESCRIPTION
Makes the model catalog consumer-injectable and runtime-refreshable — the recon's one genuinely unmet constraint — by adding a `ModelDescriptorSource` fun interface (`suspend load(): Result<List<ModelDescriptor>>`, `Result` because a catalog load crosses an I/O boundary) plus `refresh()` on `ModelDescriptorRegistry`, so a consumer can change model→rung assignments at runtime without a framework release and without the framework assuming any backend or transport. `InMemoryModelDescriptorRegistry` now holds an immutable map swapped whole under the existing mutex: `refresh()` loads and indexes outside the lock and swaps inside, so a reader sees the catalog before or after but never a mix, and a load that fails — returned or thrown — leaves the previous catalog fully intact rather than emptying it.

One deliberate deviation from the ticket: the default source echoes the seed instead of being `DefaultModelDescriptorSource`, because taken literally the ~15 existing call sites passing a narrow seed would have had `refresh()` silently swap in the full bundled catalog, which is the silent-downgrade family this epic exists to close; no-arg construction is still byte-for-byte the bundled catalog. Rebased onto AMPR-233 (T4) and resolved by extracting its duplicate-`modelName` check into a shared `indexCatalog()` so a consumer-supplied catalog is held to the same rule as the bundled one — otherwise `refresh()` would have reopened, on the source path, exactly the silent-drop T4 just closed — with rejection surfacing as a throw at construction but a failed `Result` on refresh.

`ModelDescriptorSourceTest` (14 cases) covers all four validation points from the ticket, including an 8-writer/8-reader race on `Dispatchers.Default` asserting every snapshot is one coherent catalog, and `docs/concepts/cognitive-relay.md` moves in this diff since it tracks `routing/**`. Verified green with `./gradlew jvmTest :ampere-core:compileCommonMainKotlinMetadata ktlintCheck` across the whole repo, T4's drift guard included.

Closes #595

🤖 Generated with [Claude Code](https://claude.com/claude-code)