### PR TITLE
AMPR-225 #589: Rung 0 — 0W on-device inference contract (Foundation Models)

### DIFF
--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/AgentFactory.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/AgentFactory.kt
@@ -132,18 +132,24 @@ class AgentFactory(
      * The live [CognitiveRelay] wired into the activated CODE path (AMPR-219).
      *
      * This is the production seam the relay was built for: a real
-     * [CognitiveRelayImpl] over the bundled cloud catalog
-     * ([CapabilityRoutingDefaults.cloudCapabilityRules] +
+     * [CognitiveRelayImpl] over the on-device Rung 0 floor plus the bundled
+     * cloud catalog ([CapabilityRoutingDefaults.defaultCapabilityRules] +
      * [InMemoryModelDescriptorRegistry]'s default seed), publishing routing
      * events on the shared [eventSerialBus]. Selection stays cost-aware; the
-     * agent's declared [codeAgentMinimumRung] is the floor it must clear.
+     * agent's declared [codeAgentMinimumRung] is the floor it must clear. No
+     * [link.socket.ampere.agents.domain.routing.local.LocalInferenceEngine] is
+     * bound here (AMPR-203/225: `:ampere-core` binds none), so the on-device
+     * rule can never actually be selected from this factory yet — it stays
+     * inert (its `availabilityGated` descriptor has no
+     * [link.socket.ampere.agents.domain.routing.local.LocalCapacity] reporting
+     * it available) until a platform module binds a real engine.
      *
      * Built lazily and cached so a single relay (and registry) is shared across
      * every CODE agent this factory makes. Tests override it via [cognitiveRelay].
      */
     private val effectiveCognitiveRelay: CognitiveRelay by lazy {
         cognitiveRelay ?: CognitiveRelayImpl(
-            initialConfig = RelayConfig(rules = CapabilityRoutingDefaults.cloudCapabilityRules()),
+            initialConfig = RelayConfig(rules = CapabilityRoutingDefaults.defaultCapabilityRules()),
             eventBus = eventSerialBus,
             registry = InMemoryModelDescriptorRegistry(),
         )

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/reasoning/AgentLLMService.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/reasoning/AgentLLMService.kt
@@ -23,6 +23,7 @@ import link.socket.ampere.domain.ai.pricing.ProviderPricingCalculator
 import link.socket.ampere.domain.llm.LlmProvider
 import link.socket.ampere.domain.util.toClientModelId
 import link.socket.ampere.llm.BundledUpstreamLlmClient
+import link.socket.ampere.llm.DispatchingUpstreamLlmClient
 import link.socket.ampere.llm.UpstreamLlmClient
 import link.socket.ampere.util.ioDispatcher
 import link.socket.ampere.util.logWith
@@ -171,6 +172,17 @@ class AgentLLMService(
             }
         }
 
+        // Probe the bound local engine (if any) so the relay's on-device
+        // availability gate (AMPR-207/225) can see whether Rung 0 is usable
+        // right now. Never overwrites a caller-supplied localCapacity.
+        val probedLocalCapacity = (upstreamLlmClient as? DispatchingUpstreamLlmClient)?.probeLocalCapacity()
+        fun RoutingContext.withProbedLocalCapacity(): RoutingContext =
+            if (probedLocalCapacity != null && localCapacity == null) {
+                copy(localCapacity = probedLocalCapacity)
+            } else {
+                this
+            }
+
         // Thread per-agent rung floor into requirements before relay resolves.
         // Floors compose as the stricter of the two (AMPR-229): a call site asking
         // for FOUR through an agent declaring THREE stays at FOUR. Replacing the
@@ -181,9 +193,9 @@ class AgentLLMService(
                 val mergedRequirements = existing.copy(
                     minRung = existing.minRung?.let { maxOf(it, rung) } ?: rung,
                 )
-                ctx.copy(requirements = mergedRequirements)
-            } ?: RoutingContext(requirements = CapabilityRequirement(minRung = rung))
-        } ?: routingContext
+                ctx.copy(requirements = mergedRequirements).withProbedLocalCapacity()
+            } ?: RoutingContext(requirements = CapabilityRequirement(minRung = rung)).withProbedLocalCapacity()
+        } ?: routingContext?.withProbedLocalCapacity()
 
         // Resolve configuration through CognitiveRelay if available
         val routingResolution = if (effectiveRoutingContext != null) {

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/CapabilityRoutingDefaults.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/CapabilityRoutingDefaults.kt
@@ -4,9 +4,11 @@ import link.socket.ampere.agents.domain.routing.capability.InMemoryModelDescript
 import link.socket.ampere.domain.ai.configuration.AIConfiguration_Default
 import link.socket.ampere.domain.ai.model.AIModel_Claude
 import link.socket.ampere.domain.ai.model.AIModel_Gemini
+import link.socket.ampere.domain.ai.model.AIModel_OnDevice
 import link.socket.ampere.domain.ai.model.AIModel_OpenAI
 import link.socket.ampere.domain.ai.provider.AIProvider_Anthropic
 import link.socket.ampere.domain.ai.provider.AIProvider_Google
+import link.socket.ampere.domain.ai.provider.AIProvider_OnDevice
 import link.socket.ampere.domain.ai.provider.AIProvider_OpenAI
 
 /**
@@ -43,4 +45,28 @@ object CapabilityRoutingDefaults {
                 RoutingRule.ByCapability(AIConfiguration_Default(provider, model))
             }
         }
+
+    /**
+     * One [RoutingRule.ByCapability] per on-device (Rung 0) model (AMPR-225).
+     * Its descriptor is [link.socket.ampere.agents.domain.routing.capability.CostPolicy.Free]
+     * and `availabilityGated`, so [RoutingRule.ByCapability.evaluate] only
+     * matches when [RoutingContext.localCapacity] reports the on-device engine
+     * available — otherwise it reports [CapabilityEvaluation.Skipped] and the
+     * relay falls through to [cloudCapabilityRules] (AMPR-207's honor-and-eat
+     * fallback), exactly as an unavailable gated cloud provider would.
+     */
+    fun onDeviceCapabilityRules(): List<RoutingRule.ByCapability> =
+        AIModel_OnDevice.ALL_MODELS.map { model ->
+            RoutingRule.ByCapability(AIConfiguration_Default(AIProvider_OnDevice, model))
+        }
+
+    /**
+     * The full default rule set: on-device (Rung 0) rules first, then the
+     * bundled cloud catalog. List position doesn't decide the winner once
+     * cost-aware selection engages (see [cloudCapabilityRules] doc), but
+     * ordering on-device first keeps the declared intent — prefer the free
+     * floor — legible in the config itself.
+     */
+    fun defaultCapabilityRules(): List<RoutingRule.ByCapability> =
+        onDeviceCapabilityRules() + cloudCapabilityRules()
 }

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/capability/CapabilityRung.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/capability/CapabilityRung.kt
@@ -7,8 +7,12 @@ import kotlinx.serialization.Serializable
  * Ordinal capability tier for a model, independent of billing/quota tiers
  * ([link.socket.ampere.domain.billing.Tier] et al.). Higher ordinal = higher rung.
  *
- * Four rungs are defined as companion constants. Names carry no quality adjectives
+ * Five rungs are defined as companion constants. Names carry no quality adjectives
  * so they remain stable as the landscape evolves.
+ *
+ * [ZERO] is the ordinal floor: 0W, on-device generation (e.g. Apple Foundation
+ * Models), always the cheapest candidate via [ModelDescriptor.routingCostPerWatt]
+ * when its [ModelDescriptor.cost] is [CostPolicy.Free].
  */
 @Serializable
 @JvmInline
@@ -18,6 +22,7 @@ value class CapabilityRung(val ordinal: Int) : Comparable<CapabilityRung> {
         ordinal.compareTo(other.ordinal)
 
     companion object {
+        val ZERO = CapabilityRung(0)
         val ONE = CapabilityRung(1)
         val TWO = CapabilityRung(2)
         val THREE = CapabilityRung(3)

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/capability/CheapestCapable.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/capability/CheapestCapable.kt
@@ -39,11 +39,20 @@ data class CostRanking(
  * Ranks the models in this collection that [satisfies] the given [req] by cost
  * (cheapest-capable), or returns `null` when none qualify.
  *
+ * Excludes [ModelDescriptor.availabilityGated] models: unlike the live relay
+ * (which reads a [link.socket.ampere.agents.domain.routing.local.LocalCapacity]
+ * snapshot to confirm a gated model is actually usable before counting it as a
+ * candidate — see [link.socket.ampere.agents.domain.routing.RoutingRule.ByCapability]),
+ * this dry-run has no live capacity signal, so a gated model (e.g. Rung 0's
+ * on-device floor) would otherwise always "win" on price without any
+ * confirmation it's really available — reporting a route that live routing
+ * might never actually pick.
+ *
  * Deterministic: equal cost-per-Watt is broken by `modelName`, so the same
  * inputs always yield the same winner.
  */
 fun Iterable<ModelDescriptor>.cheapestCapable(req: CapabilityRequirement): CostRanking? {
-    val ranked = filter { it.satisfies(req) }.sortedWith(CheapestCapableFirst)
+    val ranked = filter { it.satisfies(req) && !it.availabilityGated }.sortedWith(CheapestCapableFirst)
     val chosen = ranked.firstOrNull() ?: return null
     return CostRanking(
         chosen = chosen,

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/capability/ModelDescriptorRegistry.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/capability/ModelDescriptorRegistry.kt
@@ -5,9 +5,11 @@ import kotlinx.coroutines.sync.withLock
 import link.socket.ampere.domain.ai.model.AIModel
 import link.socket.ampere.domain.ai.model.AIModel_Claude
 import link.socket.ampere.domain.ai.model.AIModel_Gemini
+import link.socket.ampere.domain.ai.model.AIModel_OnDevice
 import link.socket.ampere.domain.ai.model.AIModel_OpenAI
 import link.socket.ampere.domain.ai.provider.AIProvider_Anthropic
 import link.socket.ampere.domain.ai.provider.AIProvider_Google
+import link.socket.ampere.domain.ai.provider.AIProvider_OnDevice
 import link.socket.ampere.domain.ai.provider.AIProvider_OpenAI
 import link.socket.ampere.domain.ai.provider.ProviderId
 import link.socket.ampere.domain.limits.numericValue
@@ -79,6 +81,16 @@ class InMemoryModelDescriptorRegistry(
             ProviderCapability.WORLD_KNOWLEDGE,
             ProviderCapability.TOOL_CALLING,
             ProviderCapability.LONG_CONTEXT,
+        )
+
+        /**
+         * What the Rung 0 on-device backend actually offers today: guided/
+         * constrained structured generation (AMPR-225), and nothing else — no
+         * tool calling, no long context (its window is much smaller than any
+         * cloud model's), no broad world knowledge, no streaming yet.
+         */
+        private val ON_DEVICE_MODEL_CAPABILITIES = setOf(
+            ProviderCapability.STRUCTURED_OUTPUT,
         )
 
         /**
@@ -174,8 +186,34 @@ class InMemoryModelDescriptorRegistry(
         )
 
         /**
+         * Rung 0 (AMPR-225): the on-device model is always the ordinal floor,
+         * always [CostPolicy.Free], and always [availabilityGated] — the relay
+         * must probe [link.socket.ampere.agents.domain.routing.local.LocalCapacity]
+         * before routing to it, honoring the same fallback path an unavailable
+         * gated cloud provider would (AMPR-207).
+         */
+        private fun onDeviceModelDescriptors(): List<ModelDescriptor> =
+            AIModel_OnDevice.ALL_MODELS.map { model ->
+                ModelDescriptor(
+                    modelName = model.name,
+                    providerId = AIProvider_OnDevice.id,
+                    capabilities = ON_DEVICE_MODEL_CAPABILITIES,
+                    reasoning = model.features.reasoningLevel,
+                    maxContextTokens = model.limits.token.contextWindow.numericValue
+                        .coerceAtMost(Int.MAX_VALUE.toLong())
+                        .toInt(),
+                    supportedInputs = model.features.supportedInputs,
+                    cost = CostPolicy.Free,
+                    costPerWatt = 0.0,
+                    availabilityGated = true,
+                    rung = CapabilityRung.ZERO,
+                )
+            }
+
+        /**
          * One descriptor per model across the three bundled cloud providers,
-         * each projected from the model's own metadata.
+         * each projected from the model's own metadata, plus one per on-device
+         * (Rung 0) model.
          *
          * Computed on demand (not as a class-load constant). The model lists in
          * each `AIModel.*` companion are declared `by lazy` to break the JVM
@@ -191,9 +229,10 @@ class InMemoryModelDescriptorRegistry(
                 Triple(AIProvider_Google.id, AIModel_Gemini.ALL_MODELS, GOOGLE_USD_PER_WATT),
                 Triple(AIProvider_OpenAI.id, AIModel_OpenAI.ALL_MODELS, OPENAI_USD_PER_WATT),
             )
-            return modelsByProvider.flatMap { (providerId, models, costPerWatt) ->
+            val cloudDescriptors = modelsByProvider.flatMap { (providerId, models, costPerWatt) ->
                 models.map { model -> model.toModelDescriptor(providerId, costPerWatt) }
             }
+            return cloudDescriptors + onDeviceModelDescriptors()
         }
     }
 }

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/local/LocalInferenceEngine.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/routing/local/LocalInferenceEngine.kt
@@ -1,5 +1,9 @@
 package link.socket.ampere.agents.domain.routing.local
 
+import link.socket.ampere.agents.domain.emission.EmissionKind
+import link.socket.ampere.agents.domain.emission.EmissionPayload
+import link.socket.ampere.agents.domain.emission.ProseFormat
+
 /**
  * On-device inference contract for local, 0-Watt generation.
  *
@@ -49,4 +53,31 @@ interface LocalInferenceEngine {
      * decision kept out of this seam.
      */
     suspend fun generate(prompt: String): Result<String>
+
+    /**
+     * Generate a structured [EmissionPayload] shaped like [kind] directly —
+     * the point of guided/constrained on-device generation (AMPR-225; e.g.
+     * Apple's `@Generable`): the returned payload is produced under a
+     * generation-time shape constraint, not parsed out of free text after the
+     * fact — no parse-and-pray.
+     *
+     * Additive to [generate]: an engine that only implements the text-shaped
+     * path (e.g. a first-cut Gemini Nano binding) need not override this at
+     * all. The default here can only honor [EmissionKind.Prose] — the one
+     * payload a raw string already represents without guessing structure —
+     * and fails for every other [kind], so callers never silently receive an
+     * ill-shaped payload from an engine that hasn't implemented real guided
+     * generation.
+     */
+    suspend fun generateStructured(kind: EmissionKind, prompt: String): Result<EmissionPayload> =
+        when (kind) {
+            EmissionKind.Prose ->
+                generate(prompt).map { text -> EmissionPayload.Prose(text = text, format = ProseFormat.PLAIN) }
+            else ->
+                Result.failure(
+                    UnsupportedOperationException(
+                        "This engine does not support structured generation for $kind",
+                    ),
+                )
+        }
 }

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/ai/model/AIModel_OnDevice.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/ai/model/AIModel_OnDevice.kt
@@ -1,0 +1,75 @@
+@file:Suppress("ClassName", "ObjectPropertyName", "ObjectPrivatePropertyName")
+
+package link.socket.ampere.domain.ai.model
+
+import io.ktor.util.date.GMTDate
+import io.ktor.util.date.Month
+import link.socket.ampere.domain.ai.model.AIModelFeatures.RelativeReasoning
+import link.socket.ampere.domain.ai.model.AIModelFeatures.RelativeSpeed
+import link.socket.ampere.domain.ai.model.AIModelFeatures.SupportedInputs
+import link.socket.ampere.domain.limits.ModelLimits
+import link.socket.ampere.domain.limits.RateLimits
+import link.socket.ampere.domain.limits.TokenCount
+import link.socket.ampere.domain.limits.TokenLimits
+
+/**
+ * On-device models backing Rung 0 (AMPR-225): 0-Watt, local generation, no
+ * network round-trip. Parallel to [AIModel_Claude]/[AIModel_Gemini]/
+ * [AIModel_OpenAI] but never dials out — [AIProvider_OnDevice.client] exists
+ * only to satisfy [link.socket.ampere.domain.ai.provider.AIProvider]'s shape
+ * and is never invoked; execution is dispatched to a
+ * [link.socket.ampere.agents.domain.routing.local.LocalInferenceEngine]
+ * instead (see [link.socket.ampere.llm.DispatchingUpstreamLlmClient]).
+ */
+sealed class AIModel_OnDevice(
+    override val name: String,
+    override val displayName: String,
+    override val description: String,
+    override val features: AIModelFeatures,
+    override val limits: ModelLimits,
+) : AIModel(name, displayName, description, features, limits) {
+
+    /**
+     * Apple Foundation Models' on-device model (iOS 26+ / Apple Intelligence).
+     * Context window and reasoning level are provisional pending on-device
+     * verification (AMPR-225 recon, §1.1) — update once confirmed against the
+     * live `SystemLanguageModel`.
+     */
+    data object AppleFoundationModels : AIModel_OnDevice(
+        name = APPLE_FOUNDATION_MODELS_NAME,
+        displayName = APPLE_FOUNDATION_MODELS_DISPLAY_NAME,
+        description = APPLE_FOUNDATION_MODELS_DESCRIPTION,
+        features = APPLE_FOUNDATION_MODELS_FEATURES,
+        limits = APPLE_FOUNDATION_MODELS_LIMITS,
+    )
+
+    companion object {
+        /** Lazy per AMPR-218's class-init-cycle note on the cloud `ALL_MODELS` lists. */
+        val ALL_MODELS: List<AIModel_OnDevice> by lazy { listOf(AppleFoundationModels) }
+    }
+}
+
+private const val APPLE_FOUNDATION_MODELS_NAME = "apple-foundation-models-on-device"
+private const val APPLE_FOUNDATION_MODELS_DISPLAY_NAME = "Apple Foundation Models (on-device)"
+private const val APPLE_FOUNDATION_MODELS_DESCRIPTION =
+    "Apple's on-device foundation model (Apple Intelligence). Runs entirely " +
+        "locally with guided/structured generation; no network round-trip, 0W."
+
+private val APPLE_FOUNDATION_MODELS_CUTOFF =
+    GMTDate(year = 2025, month = Month.JUNE, dayOfMonth = 1, hours = 0, minutes = 0, seconds = 0)
+
+private val APPLE_FOUNDATION_MODELS_FEATURES = AIModelFeatures(
+    availableTools = emptyList(),
+    reasoningLevel = RelativeReasoning.LOW,
+    speed = RelativeSpeed.FAST,
+    supportedInputs = SupportedInputs.TEXT,
+    trainingCutoffDate = APPLE_FOUNDATION_MODELS_CUTOFF,
+)
+
+private val APPLE_FOUNDATION_MODELS_LIMITS = ModelLimits(
+    rate = RateLimits(),
+    token = TokenLimits(
+        contextWindow = TokenCount._4096,
+        maxOutput = TokenCount._4096,
+    ),
+)

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/ai/provider/AIProvider_OnDevice.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/ai/provider/AIProvider_OnDevice.kt
@@ -1,0 +1,32 @@
+@file:Suppress("ktlint:standard:class-naming")
+
+package link.socket.ampere.domain.ai.provider
+
+import com.aallam.openai.client.OpenAI as Client
+import link.socket.ampere.domain.ai.model.AIModel_OnDevice
+import link.socket.ampere.domain.tool.AITool
+
+private const val ID = "apple-on-device"
+private const val NAME = "Apple Foundation Models (on-device)"
+
+/**
+ * Stand-in [AIProvider] for Rung 0 (AMPR-225): identifies the on-device
+ * execution path in routing/cost/provenance, but [client] is never actually
+ * called. Execution for this provider's models is dispatched to a bound
+ * [link.socket.ampere.agents.domain.routing.local.LocalInferenceEngine] by
+ * [link.socket.ampere.llm.DispatchingUpstreamLlmClient] before the OpenAI-shaped
+ * seam is ever reached, exactly like the [AIProvider_Anthropic]/local stand-in
+ * used in `LocalInferenceRelayIntegrationTest`. [client] and [apiToken] exist
+ * only to satisfy the [AIProvider] shape.
+ */
+data object AIProvider_OnDevice : AIProvider<AITool, AIModel_OnDevice> {
+
+    override val id: ProviderId = ID
+    override val name: String = NAME
+    override val apiToken: String = ""
+    override val availableModels: List<AIModel_OnDevice> = AIModel_OnDevice.ALL_MODELS
+
+    override val client: Client by lazy {
+        AIProvider.createClient(token = apiToken)
+    }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/util/AIModelUtil.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/util/AIModelUtil.kt
@@ -8,6 +8,7 @@ import com.aallam.openai.api.model.ModelId as ClientModelId
 import link.socket.ampere.domain.ai.model.AIModel
 import link.socket.ampere.domain.ai.model.AIModel_Claude
 import link.socket.ampere.domain.ai.model.AIModel_Gemini
+import link.socket.ampere.domain.ai.model.AIModel_OnDevice
 import link.socket.ampere.domain.ai.model.AIModel_OpenAI
 
 fun AIModel.toClientModelId(): ClientModelId =
@@ -50,4 +51,5 @@ fun AIModel.toKoogLLMModel(): LLModel? = when (this) {
         is AIModel_Claude.Haiku_4_5 -> null // TODO: Add to koog-agents
         else -> null
     }
+    is AIModel_OnDevice -> null // On-device models run via LocalInferenceEngine, not koog-agents.
 }

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/llm/DispatchingUpstreamLlmClient.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/llm/DispatchingUpstreamLlmClient.kt
@@ -5,6 +5,7 @@ import com.aallam.openai.api.chat.ChatCompletionRequest
 import link.socket.ampere.agents.domain.routing.capability.CostPolicy
 import link.socket.ampere.agents.domain.routing.capability.ModelDescriptor
 import link.socket.ampere.agents.domain.routing.capability.ModelDescriptorRegistry
+import link.socket.ampere.agents.domain.routing.local.LocalCapacity
 import link.socket.ampere.agents.domain.routing.local.LocalInferenceEngine
 import link.socket.ampere.api.AmpereStableApi
 import link.socket.ampere.domain.ai.configuration.AIConfiguration
@@ -42,11 +43,22 @@ import link.socket.ampere.domain.ai.configuration.AIConfiguration
 @AmpereStableApi
 class DispatchingUpstreamLlmClient(
     private val registry: ModelDescriptorRegistry,
-    localEngine: LocalInferenceEngine?,
+    private val localEngine: LocalInferenceEngine?,
     private val bundled: UpstreamLlmClient = BundledUpstreamLlmClient,
 ) : UpstreamLlmClient {
 
     private val local: LocalUpstreamLlmClient? = localEngine?.let(::LocalUpstreamLlmClient)
+
+    /**
+     * Probes the bound [localEngine], if any, so a caller (e.g.
+     * [link.socket.ampere.agents.domain.reasoning.AgentLLMService]) can populate
+     * [link.socket.ampere.agents.domain.routing.RoutingContext.localCapacity]
+     * before asking the relay to resolve — the relay's availability gate
+     * (AMPR-207/225) only opens for a gated on-device rule when this snapshot
+     * reports it available. Returns `null` when no engine is bound, exactly
+     * like the existing `:ampere-core` (no platform module) default.
+     */
+    suspend fun probeLocalCapacity(): LocalCapacity? = localEngine?.probe()
 
     override suspend fun call(
         request: ChatCompletionRequest,

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/routing/capability/ModelDescriptorRegistryRungTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/routing/capability/ModelDescriptorRegistryRungTest.kt
@@ -26,6 +26,19 @@ class ModelDescriptorRegistryRungTest {
     // ── Spot-checks by rung ───────────────────────────────────────────────────
 
     @Test
+    fun rungZeroModels() {
+        // AMPR-225: the on-device floor is always 0W, always availability-gated.
+        val descriptor = descriptors["apple-foundation-models-on-device"]
+        assertEquals(CapabilityRung.ZERO, descriptor?.rung, "on-device model should be rung ZERO")
+        assertEquals(CostPolicy.Free, descriptor?.cost, "on-device model should be 0W")
+        assertEquals(true, descriptor?.availabilityGated, "on-device model must be availability-gated")
+        assertTrue(
+            descriptor?.capabilities?.contains(ProviderCapability.STRUCTURED_OUTPUT) == true,
+            "on-device model should advertise STRUCTURED_OUTPUT",
+        )
+    }
+
+    @Test
     fun rungOneModels() {
         val expected = listOf(
             "claude-3-haiku-20240307",

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/routing/capability/ModelDescriptorTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/routing/capability/ModelDescriptorTest.kt
@@ -13,6 +13,7 @@ import link.socket.ampere.domain.ai.model.AIModelFeatures.RelativeReasoning
 import link.socket.ampere.domain.ai.model.AIModelFeatures.SupportedInputs
 import link.socket.ampere.domain.ai.model.AIModel_Claude
 import link.socket.ampere.domain.ai.model.AIModel_Gemini
+import link.socket.ampere.domain.ai.model.AIModel_OnDevice
 import link.socket.ampere.domain.ai.provider.AIProvider
 import link.socket.ampere.domain.ai.provider.AIProvider_Anthropic
 
@@ -165,8 +166,12 @@ class ModelDescriptorTest {
     fun defaultRegistrySeedsOneDescriptorPerModel() = runTest {
         val registry = InMemoryModelDescriptorRegistry()
 
-        // One descriptor per model across every bundled provider.
-        val expectedCount = AIProvider.ALL_PROVIDERS.sumOf { it.availableModels.size }
+        // One descriptor per model across every bundled cloud provider, plus
+        // one per on-device (Rung 0) model — AIProvider.ALL_PROVIDERS only
+        // lists the bundled cloud providers (AIProvider_OnDevice isn't a real
+        // dial-out provider), so it's counted separately.
+        val expectedCount = AIProvider.ALL_PROVIDERS.sumOf { it.availableModels.size } +
+            AIModel_OnDevice.ALL_MODELS.size
         assertEquals(expectedCount, registry.all().size)
 
         // Each is keyed by model name and projects that model's own tier.

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/routing/local/FakeLocalInferenceEngine.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/routing/local/FakeLocalInferenceEngine.kt
@@ -1,13 +1,22 @@
 package link.socket.ampere.agents.domain.routing.local
 
+import link.socket.ampere.agents.domain.emission.EmissionKind
+import link.socket.ampere.agents.domain.emission.EmissionPayload
+
 /**
  * Test [LocalInferenceEngine] that records the prompts it is asked to generate
  * and returns a scripted [Result]. Stands in for the per-platform engine bound
  * in `:ampere-relay-local-*` modules (Phase 2).
+ *
+ * [respondStructured] is `null` by default, so [generateStructured] exercises
+ * the interface's own default (Prose-only) unless a test opts into scripting a
+ * genuine structured response — e.g. to stand in for Foundation Models' guided
+ * generation (AMPR-225).
  */
 class FakeLocalInferenceEngine(
     private val capacity: LocalCapacity = LocalCapacity(available = true, modelId = "fake-local"),
     private val respond: (prompt: String) -> Result<String> = { Result.success("LOCAL::$it") },
+    private val respondStructured: ((kind: EmissionKind, prompt: String) -> Result<EmissionPayload>)? = null,
 ) : LocalInferenceEngine {
 
     var probeCount: Int = 0
@@ -15,6 +24,10 @@ class FakeLocalInferenceEngine(
     var generateCount: Int = 0
         private set
     var lastPrompt: String? = null
+        private set
+    var structuredGenerateCount: Int = 0
+        private set
+    var lastRequestedKind: EmissionKind? = null
         private set
 
     override suspend fun probe(): LocalCapacity {
@@ -26,5 +39,12 @@ class FakeLocalInferenceEngine(
         generateCount++
         lastPrompt = prompt
         return respond(prompt)
+    }
+
+    override suspend fun generateStructured(kind: EmissionKind, prompt: String): Result<EmissionPayload> {
+        val scripted = respondStructured ?: return super.generateStructured(kind, prompt)
+        structuredGenerateCount++
+        lastRequestedKind = kind
+        return scripted(kind, prompt)
     }
 }

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/routing/local/LocalInferenceEngineStructuredTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/routing/local/LocalInferenceEngineStructuredTest.kt
@@ -1,0 +1,74 @@
+package link.socket.ampere.agents.domain.routing.local
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import link.socket.ampere.agents.domain.emission.DangerLevel
+import link.socket.ampere.agents.domain.emission.EmissionKind
+import link.socket.ampere.agents.domain.emission.EmissionPayload
+import link.socket.ampere.agents.domain.emission.ProseFormat
+
+/**
+ * Structured-output round-trip (AMPR-225): a genuine guided-generation engine
+ * hands back an [EmissionPayload] directly — no string parsing between model
+ * output and typed Emission — while an engine that only implements the
+ * text-shaped [LocalInferenceEngine.generate] falls back to the interface's
+ * safe default.
+ */
+class LocalInferenceEngineStructuredTest {
+
+    @Test
+    fun `default generateStructured wraps plain text as Prose without invoking any parser`() = runTest {
+        val engine = FakeLocalInferenceEngine(respond = { Result.success("Hello from on-device.") })
+
+        val result = engine.generateStructured(EmissionKind.Prose, "Say hello")
+
+        val payload = assertIs<EmissionPayload.Prose>(result.getOrThrow())
+        assertEquals("Hello from on-device.", payload.text)
+        assertEquals(ProseFormat.PLAIN, payload.format)
+        assertEquals(1, engine.generateCount, "default path must go through generate(), not a separate parser")
+        assertEquals(0, engine.structuredGenerateCount, "no scripted structured responder was supplied")
+    }
+
+    @Test
+    fun `default generateStructured fails for non-Prose kinds rather than guessing structure`() = runTest {
+        val engine = FakeLocalInferenceEngine(respond = { Result.success("action: delete file") })
+
+        val result = engine.generateStructured(EmissionKind.Confirmation, "Confirm the delete")
+
+        assertTrue(result.isFailure, "a text-only engine must not fabricate a Confirmation payload")
+        assertEquals(0, engine.generateCount, "must fail before ever calling generate()")
+    }
+
+    @Test
+    fun `an engine with real guided generation returns the typed payload directly`() = runTest {
+        val engine = FakeLocalInferenceEngine(
+            respondStructured = { kind, _ ->
+                when (kind) {
+                    EmissionKind.Confirmation ->
+                        Result.success(
+                            EmissionPayload.Confirmation(
+                                action = "delete build/",
+                                preview = "Removes 1 directory",
+                                dangerLevel = DangerLevel.LOW,
+                            ),
+                        )
+                    else -> Result.failure(UnsupportedOperationException("unscripted"))
+                }
+            },
+        )
+
+        val result = engine.generateStructured(EmissionKind.Confirmation, "Confirm the delete")
+
+        val payload = assertIs<EmissionPayload.Confirmation>(result.getOrThrow())
+        assertEquals("delete build/", payload.action)
+        assertEquals(DangerLevel.LOW, payload.dangerLevel)
+        assertEquals(EmissionKind.Confirmation, engine.lastRequestedKind)
+        assertEquals(1, engine.structuredGenerateCount)
+        // The typed payload came from guided generation directly, never from
+        // parsing a plain-text generate() response.
+        assertEquals(0, engine.generateCount)
+    }
+}

--- a/ampere-core/src/iosMain/kotlin/link/socket/ampere/agents/domain/routing/local/SwiftLocalInferenceEngine.kt
+++ b/ampere-core/src/iosMain/kotlin/link/socket/ampere/agents/domain/routing/local/SwiftLocalInferenceEngine.kt
@@ -1,0 +1,53 @@
+package link.socket.ampere.agents.domain.routing.local
+
+import link.socket.ampere.agents.domain.emission.EmissionKind
+import link.socket.ampere.agents.domain.emission.EmissionPayload
+import link.socket.ampere.agents.domain.emission.ProseFormat
+
+/**
+ * Swift-facing counterpart to [LocalInferenceEngine] (AMPR-225): plain
+ * throwing suspend functions instead of [Result]-returning ones.
+ *
+ * Kotlin's `Result<T>` is not constructible from Swift — Kotlin/Native's
+ * Objective-C export erases it to an opaque `id` with no Swift-visible
+ * factory (confirmed against the generated header: no `Result` wrapper type
+ * is exported). A Swift class implementing [LocalInferenceEngine] directly
+ * would therefore have no way to produce a `Result.success`/`Result.failure`
+ * to return. Subclassing this instead — throwing on failure, as ordinary
+ * Swift `async throws` code already does — lets Kotlin/Native's `@Throws`
+ * export bridge the failure into a catchable `NSError` on the Swift side.
+ * [toLocalInferenceEngine] adapts the throwing contract back to the
+ * [Result]-typed [LocalInferenceEngine] the rest of Ampere depends on.
+ */
+abstract class SwiftLocalInferenceEngine {
+
+    @Throws(Exception::class)
+    abstract suspend fun probe(): LocalCapacity
+
+    @Throws(Exception::class)
+    abstract suspend fun generate(prompt: String): String
+
+    /** Mirrors [LocalInferenceEngine.generateStructured]'s own Prose-only default. */
+    @Throws(Exception::class)
+    open suspend fun generateStructured(kind: EmissionKind, prompt: String): EmissionPayload =
+        if (kind == EmissionKind.Prose) {
+            EmissionPayload.Prose(text = generate(prompt), format = ProseFormat.PLAIN)
+        } else {
+            throw UnsupportedOperationException(
+                "This engine does not support structured generation for $kind",
+            )
+        }
+}
+
+/** Adapts a Swift-implemented [SwiftLocalInferenceEngine] to [LocalInferenceEngine]. */
+fun SwiftLocalInferenceEngine.toLocalInferenceEngine(): LocalInferenceEngine =
+    object : LocalInferenceEngine {
+        override suspend fun probe(): LocalCapacity =
+            this@toLocalInferenceEngine.probe()
+
+        override suspend fun generate(prompt: String): Result<String> =
+            runCatching { this@toLocalInferenceEngine.generate(prompt) }
+
+        override suspend fun generateStructured(kind: EmissionKind, prompt: String): Result<EmissionPayload> =
+            runCatching { this@toLocalInferenceEngine.generateStructured(kind, prompt) }
+    }

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/llm/Rung0RoutingTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/llm/Rung0RoutingTest.kt
@@ -1,0 +1,207 @@
+package link.socket.ampere.llm
+
+import com.aallam.openai.api.chat.ChatChoice
+import com.aallam.openai.api.chat.ChatCompletion
+import com.aallam.openai.api.chat.ChatCompletionRequest
+import com.aallam.openai.api.chat.ChatMessage
+import com.aallam.openai.api.chat.ChatRole
+import com.aallam.openai.api.model.ModelId
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import link.socket.ampere.agents.config.AgentConfiguration
+import link.socket.ampere.agents.config.CognitiveConfig
+import link.socket.ampere.agents.domain.event.Event
+import link.socket.ampere.agents.domain.event.RoutingEvent
+import link.socket.ampere.agents.domain.reasoning.AgentLLMService
+import link.socket.ampere.agents.domain.routing.CapabilityRoutingDefaults
+import link.socket.ampere.agents.domain.routing.CognitiveRelayImpl
+import link.socket.ampere.agents.domain.routing.RelayConfig
+import link.socket.ampere.agents.domain.routing.RoutingContext
+import link.socket.ampere.agents.domain.routing.capability.CapabilityRequirement
+import link.socket.ampere.agents.domain.routing.capability.CapabilityRung
+import link.socket.ampere.agents.domain.routing.capability.InMemoryModelDescriptorRegistry
+import link.socket.ampere.agents.domain.routing.local.FakeLocalInferenceEngine
+import link.socket.ampere.agents.domain.routing.local.LocalCapacity
+import link.socket.ampere.agents.events.api.EventHandler
+import link.socket.ampere.agents.events.bus.EventSerialBus
+import link.socket.ampere.domain.agent.bundled.WriteCodeAgent
+import link.socket.ampere.domain.ai.configuration.AIConfiguration
+import link.socket.ampere.domain.ai.configuration.AIConfiguration_Default
+import link.socket.ampere.domain.ai.model.AIModelFeatures.SupportedInputs
+import link.socket.ampere.domain.ai.model.AIModel_OnDevice
+import link.socket.ampere.domain.ai.provider.AIProvider_OnDevice
+
+/**
+ * End-to-end routing tests for Rung 0 (AMPR-225): the 0-Watt, on-device floor
+ * seeded into the default [InMemoryModelDescriptorRegistry] catalog and
+ * [CapabilityRoutingDefaults.defaultCapabilityRules]. Mirrors
+ * [LocalInferenceRelayIntegrationTest]'s pattern but exercises the real
+ * on-device provider/model/descriptor instead of a cloud provider standing in
+ * for one.
+ */
+class Rung0RoutingTest {
+
+    private val agentFallback = AIConfiguration_Default(AIProvider_OnDevice, AIModel_OnDevice.AppleFoundationModels)
+
+    private fun relayAndRegistry(
+        eventBus: EventSerialBus? = null,
+    ): Pair<CognitiveRelayImpl, InMemoryModelDescriptorRegistry> {
+        val registry = InMemoryModelDescriptorRegistry()
+        val relay = CognitiveRelayImpl(
+            initialConfig = RelayConfig(rules = CapabilityRoutingDefaults.defaultCapabilityRules()),
+            eventBus = eventBus,
+            registry = registry,
+        )
+        return relay to registry
+    }
+
+    @Test
+    fun `Rung 0 is selected and executed on-device when available`() = runBlocking {
+        val eventBus = EventSerialBus(CoroutineScope(Dispatchers.Default))
+        val routeSelections = subscribeTo(eventBus, RoutingEvent.RouteSelected.EVENT_TYPE)
+        val (relay, registry) = relayAndRegistry(eventBus)
+
+        val engine = FakeLocalInferenceEngine(respond = { Result.success(LOCAL_RESPONSE) })
+        val cloud = RecordingUpstreamClient("cloud-response")
+
+        val service = AgentLLMService(
+            agentConfiguration = AgentConfiguration(
+                agentDefinition = WriteCodeAgent,
+                aiConfiguration = agentFallback,
+                cognitiveConfig = CognitiveConfig(),
+                cognitiveRelay = relay,
+                upstreamLlmClient = DispatchingUpstreamLlmClient(registry, engine, cloud),
+            ),
+        )
+
+        val response = service.call(
+            prompt = "Rewrite this sentence.",
+            systemMessage = "You are a text transformer.",
+            routingContext = RoutingContext(
+                requirements = CapabilityRequirement(inputs = SupportedInputs.TEXT),
+                localCapacity = LocalCapacity(available = true, providerId = AIProvider_OnDevice.id),
+            ),
+        )
+
+        assertEquals(LOCAL_RESPONSE, response)
+        assertEquals(1, engine.generateCount, "on-device engine must have executed exactly once")
+        assertEquals(0, cloud.callCount, "cloud path must not be touched for the free on-device route")
+
+        delay(EVENT_DELIVERY_MS)
+        assertEquals(1, routeSelections.size, "expected exactly one RouteSelected event")
+        val decision = (routeSelections.first() as RoutingEvent.RouteSelected).decision
+        assertEquals(AIProvider_OnDevice.name, decision.providerName)
+        assertEquals(AIModel_OnDevice.AppleFoundationModels.name, decision.modelName)
+        assertEquals("capability:${AIProvider_OnDevice.id}", decision.matchedRule)
+    }
+
+    @Test
+    fun `Rung 0 falls back to a metered cloud rung when on-device is unavailable`() = runBlocking {
+        val eventBus = EventSerialBus(CoroutineScope(Dispatchers.Default))
+        val routeFallbacks = subscribeTo(eventBus, RoutingEvent.RouteFallback.EVENT_TYPE)
+        val (relay, registry) = relayAndRegistry(eventBus)
+
+        val engine = FakeLocalInferenceEngine(respond = { Result.success(LOCAL_RESPONSE) })
+        val cloud = RecordingUpstreamClient("cloud-response")
+
+        val service = AgentLLMService(
+            agentConfiguration = AgentConfiguration(
+                agentDefinition = WriteCodeAgent,
+                aiConfiguration = agentFallback,
+                cognitiveConfig = CognitiveConfig(),
+                cognitiveRelay = relay,
+                upstreamLlmClient = DispatchingUpstreamLlmClient(registry, engine, cloud),
+            ),
+        )
+
+        val response = service.call(
+            prompt = "Who won the 1998 World Cup?",
+            systemMessage = "You answer factual questions.",
+            routingContext = RoutingContext(
+                // No required capability beyond TEXT input, so the on-device
+                // model would satisfy the requirement too — this isolates the
+                // fallback to the availability gate, not a capability gap.
+                requirements = CapabilityRequirement(inputs = SupportedInputs.TEXT),
+                // No LocalCapacity supplied: the gate stays closed (unavailable).
+            ),
+        )
+
+        assertEquals("cloud-response", response)
+        assertEquals(0, engine.generateCount, "on-device engine must not run once the gate is closed")
+        assertEquals(1, cloud.callCount, "the metered grid provider must execute the call")
+
+        delay(EVENT_DELIVERY_MS)
+        assertTrue(routeFallbacks.isNotEmpty(), "expected a RouteFallback event for the closed on-device gate")
+        val fallback = routeFallbacks.first() as RoutingEvent.RouteFallback
+        assertEquals(AIProvider_OnDevice.id, fallback.failedProvider)
+    }
+
+    @Test
+    fun `Rung 0 selection reports 0W with on-device provenance`() = runBlocking {
+        val eventBus = EventSerialBus(CoroutineScope(Dispatchers.Default))
+        val routeResolutions = subscribeTo(eventBus, RoutingEvent.RouteResolved.EVENT_TYPE)
+        val (relay, _) = relayAndRegistry(eventBus)
+
+        relay.resolveWithMetadata(
+            context = RoutingContext(
+                requirements = CapabilityRequirement(
+                    minRung = CapabilityRung.ZERO,
+                    inputs = SupportedInputs.TEXT,
+                ),
+                localCapacity = LocalCapacity(available = true, providerId = AIProvider_OnDevice.id),
+            ),
+            fallbackConfiguration = agentFallback,
+        )
+        delay(EVENT_DELIVERY_MS)
+
+        assertTrue(routeResolutions.isNotEmpty(), "expected a RouteResolved event")
+        val resolved = routeResolutions.first() as RoutingEvent.RouteResolved
+        assertEquals(AIProvider_OnDevice.name, resolved.decision.providerName)
+        assertEquals(0.0, resolved.estimatedWattCost, "on-device route must cost 0 Watts")
+    }
+
+    private fun subscribeTo(eventBus: EventSerialBus, eventType: String): MutableList<Event> {
+        val received = mutableListOf<Event>()
+        eventBus.subscribe(
+            agentId = "route-subscriber",
+            eventType = eventType,
+            handler = EventHandler { event, _ -> received.add(event) },
+        )
+        return received
+    }
+
+    private class RecordingUpstreamClient(
+        private val cannedResponse: String,
+    ) : UpstreamLlmClient {
+        var callCount: Int = 0
+            private set
+
+        override suspend fun call(
+            request: ChatCompletionRequest,
+            configuration: AIConfiguration,
+        ): ChatCompletion {
+            callCount++
+            return ChatCompletion(
+                id = "cloud",
+                created = 0L,
+                model = ModelId(configuration.model.name),
+                choices = listOf(
+                    ChatChoice(
+                        index = 0,
+                        message = ChatMessage(role = ChatRole.Assistant, content = cannedResponse),
+                    ),
+                ),
+            )
+        }
+    }
+
+    companion object {
+        private const val LOCAL_RESPONSE = "Generated on-device."
+        private const val EVENT_DELIVERY_MS = 100L
+    }
+}

--- a/ampere-ios/iosApp/FoundationModelsLocalInferenceEngine.swift
+++ b/ampere-ios/iosApp/FoundationModelsLocalInferenceEngine.swift
@@ -1,0 +1,181 @@
+import Foundation
+import FoundationModels
+import shared
+
+/// Rung 0 (AMPR-225): binds Apple's on-device Foundation Models to Ampere's
+/// `LocalInferenceEngine` contract.
+///
+/// Subclasses `SwiftLocalInferenceEngine` rather than conforming to
+/// `LocalInferenceEngine` directly: Kotlin's `Result<T>` (the Kotlin-side
+/// contract's return type) has no Swift-constructible representation across
+/// the Kotlin/Native Objective-C export — verified against the generated
+/// framework header, which exposes `Result`-returning suspend functions as an
+/// opaque `id` with no bridging initializer. `SwiftLocalInferenceEngine`
+/// exists precisely to give Swift a plain `async throws` contract instead;
+/// `toLocalInferenceEngine()` adapts it back on the Kotlin side.
+///
+/// Structured generation uses `DynamicGenerationSchema` — built at runtime
+/// from the requested `EmissionKind` — rather than a macro-generated
+/// `@Generable` Swift type, so there is no compile-time dependency between
+/// this file and Ampere's `EmissionPayload` shapes beyond the field names
+/// below. Fields are read directly off the resulting `GeneratedContent`
+/// (`value(_:forProperty:)`) and used to construct the matching Kotlin
+/// `EmissionPayload` case directly — the shape was already constrained at
+/// generation time, so this is a typed read, not a parse of free text.
+@available(iOS 26.0, *)
+final class FoundationModelsLocalInferenceEngine: SwiftLocalInferenceEngine {
+
+    private let session: LanguageModelSession
+
+    override init() {
+        self.session = LanguageModelSession()
+        super.init()
+    }
+
+    override func probe() async throws -> LocalCapacity {
+        switch SystemLanguageModel.default.availability {
+        case .available:
+            return LocalCapacity(
+                available: true,
+                modelId: Self.modelId,
+                maxContextTokens: KotlinInt(int: Self.maxContextTokens),
+                providerId: AIProvider_OnDevice.shared.id,
+                reason: nil
+            )
+        case .unavailable(let reason):
+            return LocalCapacity(
+                available: false,
+                modelId: nil,
+                maxContextTokens: nil,
+                providerId: AIProvider_OnDevice.shared.id,
+                reason: Self.describe(reason)
+            )
+        @unknown default:
+            return LocalCapacity(
+                available: false,
+                modelId: nil,
+                maxContextTokens: nil,
+                providerId: AIProvider_OnDevice.shared.id,
+                reason: "apple_foundation_models_unavailable"
+            )
+        }
+    }
+
+    override func generate(prompt: String) async throws -> String {
+        let response = try await session.respond(to: prompt)
+        return response.content
+    }
+
+    override func generateStructured(kind: EmissionKind, prompt: String) async throws -> EmissionPayload {
+        // Prose is a single free-text field — the guided-generation schema
+        // path adds nothing over the plain response, so reuse it directly.
+        if kind is EmissionKindProse {
+            return EmissionPayloadProse(text: try await generate(prompt: prompt), format: .plain)
+        }
+
+        let schema = try Self.schema(for: kind)
+        let response = try await session.respond(to: prompt, schema: schema)
+        return try Self.payload(for: kind, content: response.content)
+    }
+
+    // MARK: - Schema construction (AMPR-225: DynamicGenerationSchema, no @Generable macro needed)
+
+    private static func schema(for kind: EmissionKind) throws -> GenerationSchema {
+        let root: DynamicGenerationSchema
+        switch kind {
+        case is EmissionKindDecision:
+            root = DynamicGenerationSchema(
+                name: "Decision",
+                properties: [
+                    stringProperty(name: "prompt"),
+                    stringProperty(name: "context", isOptional: true),
+                ]
+            )
+        case is EmissionKindConfirmation:
+            root = DynamicGenerationSchema(
+                name: "Confirmation",
+                properties: [
+                    stringProperty(name: "action"),
+                    stringProperty(name: "preview", isOptional: true),
+                    .init(
+                        name: "dangerLevel",
+                        schema: DynamicGenerationSchema(
+                            name: "DangerLevel",
+                            anyOf: ["LOW", "MEDIUM", "HIGH"]
+                        )
+                    ),
+                ]
+            )
+        case is EmissionKindSensor:
+            root = DynamicGenerationSchema(
+                name: "Sensor",
+                properties: [
+                    stringProperty(name: "label"),
+                    stringProperty(name: "value"),
+                    stringProperty(name: "unit", isOptional: true),
+                    stringProperty(name: "refreshUri", isOptional: true),
+                ]
+            )
+        default:
+            throw AmpereFoundationModelsError.unsupportedKind
+        }
+        return try GenerationSchema(root: root, dependencies: [])
+    }
+
+    private static func stringProperty(name: String, isOptional: Bool = false) -> DynamicGenerationSchema.Property {
+        .init(name: name, schema: DynamicGenerationSchema(type: String.self), isOptional: isOptional)
+    }
+
+    // MARK: - Reading the constrained result back into a typed EmissionPayload
+
+    private static func payload(for kind: EmissionKind, content: GeneratedContent) throws -> EmissionPayload {
+        switch kind {
+        case is EmissionKindDecision:
+            return EmissionPayloadDecision(
+                prompt: try content.value(String.self, forProperty: "prompt"),
+                context: try content.value(String?.self, forProperty: "context")
+            )
+        case is EmissionKindConfirmation:
+            let dangerLevelName = try content.value(String.self, forProperty: "dangerLevel")
+            return EmissionPayloadConfirmation(
+                action: try content.value(String.self, forProperty: "action"),
+                preview: try content.value(String?.self, forProperty: "preview"),
+                dangerLevel: dangerLevel(named: dangerLevelName)
+            )
+        case is EmissionKindSensor:
+            return EmissionPayloadSensor(
+                label: try content.value(String.self, forProperty: "label"),
+                value: try content.value(String.self, forProperty: "value"),
+                unit: try content.value(String?.self, forProperty: "unit"),
+                refreshUri: try content.value(String?.self, forProperty: "refreshUri")
+            )
+        default:
+            throw AmpereFoundationModelsError.unsupportedKind
+        }
+    }
+
+    private static func dangerLevel(named name: String) -> DangerLevel {
+        switch name.uppercased() {
+        case "HIGH": return .high
+        case "MEDIUM": return .medium
+        default: return .low
+        }
+    }
+
+    private static func describe(_ reason: SystemLanguageModel.Availability.UnavailableReason) -> String {
+        switch reason {
+        case .deviceNotEligible: return "apple_intelligence_device_not_eligible"
+        case .appleIntelligenceNotEnabled: return "apple_intelligence_not_enabled"
+        case .modelNotReady: return "apple_intelligence_model_not_ready"
+        @unknown default: return "apple_intelligence_unavailable"
+        }
+    }
+
+    /// Provisional pending on-device verification (AMPR-225 recon, §1.1).
+    private static let maxContextTokens: Int32 = 4_096
+    private static let modelId = "apple-foundation-models-on-device"
+}
+
+enum AmpereFoundationModelsError: Swift.Error {
+    case unsupportedKind
+}


### PR DESCRIPTION
## Summary
- Adds Rung 0 (`CapabilityRung.ZERO`) as the ordinal floor of the capability registry: a 0W, availability-gated on-device model (Apple Foundation Models) seeded into the default catalog and wired into the CODE agent's relay ahead of the bundled cloud rules, falling back to metered rungs via the existing honor-and-eat/availability-gate machinery (AMPR-207/216) with no relay logic changes.
- Adds an additive `LocalInferenceEngine.generateStructured()` method so structured on-device output produces typed `Emission` payloads directly, with a verified iOS Swift binding to Apple's `FoundationModels` framework — confirmed by actually compiling against the real framework header and the generated Kotlin/Native Obj-C export, not guesswork.
- Fixes a latent bug in `RouteCostReporter`'s dry-run cost ranking, which ignored `availabilityGated` and would have reported an unconfirmed-available model as the guaranteed cheapest route.
- Closes #589

## Test plan
- [x] `./gradlew :ampere-core:jvmTest`
- [x] `./gradlew :ampere-core:compileCommonMainKotlinMetadata`
- [x] `./gradlew :ampere-core:ktlintFormat`
- [x] Swift binding compiled to object code against the generated `shared.framework` and `FoundationModels` via `swiftc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)