### PR TITLE
AMPR-238 #608: Make EmissionScope delegable (Q1 Option A)

### DIFF
--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/emission/Emission.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/emission/Emission.kt
@@ -28,6 +28,13 @@ data class Emission(
     val provenance: EmissionProvenance,
     val dedupKey: String? = null,
     val producedAt: Instant,
+    /**
+     * Ordered surface-delivery intent, highest priority first. Empty means
+     * "no opinion" — the host's `SurfacePolicy` falls back to its own
+     * default (typically [Surface.Console]). AMPERE never interprets this
+     * list itself; it only carries it for the host to consult.
+     */
+    val surfaces: List<Surface> = emptyList(),
 )
 
 /**

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/emission/EmissionScope.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/emission/EmissionScope.kt
@@ -6,28 +6,40 @@ import kotlinx.datetime.Clock
 import link.socket.ampere.agents.definition.AgentId
 import link.socket.ampere.agents.domain.Urgency
 import link.socket.ampere.agents.domain.event.EmissionEvent
+import link.socket.ampere.agents.domain.event.Event
 import link.socket.ampere.agents.domain.event.EventSource
 import link.socket.ampere.agents.domain.event.HumanInteractionEvent
+import link.socket.ampere.agents.domain.reasoning.Confidence
 import link.socket.ampere.agents.events.bus.EventSerialBus
 import link.socket.ampere.agents.events.bus.subscribe
 import link.socket.ampere.agents.events.subscription.EventSubscription
 import link.socket.ampere.util.randomUUID
 
 /**
- * DSL scope for emitting [Emission]s and awaiting replies.
+ * DSL scope for authoring, publishing, and (where applicable) awaiting
+ * replies to [Emission]s.
  *
- * Obtain via [emission]. Two builders are available:
- * - [ask] — generic Emissions, produces [EmissionEvent.BaseProduced]
+ * Obtain via [emission]. Builders available:
+ * - [ask] — a prompt-and-affordances [EmissionKind.Decision], or a pre-built [Emission]
  * - [askHuman] — human-interaction Emissions, produces [HumanInteractionEvent.InputRequested]
+ * - [confirm] — an [EmissionKind.Confirmation] gating an effect
+ * - [emit] — fire-and-forget [EmissionKind.Prose] narration
+ * - [sense] — fire-and-forget [EmissionKind.Sensor] readings
  *
- * Both builders publish, register a reply waiter in [replyRegistry], and
- * suspend until the matching [EmissionEvent.Resolved] arrives or
- * [EmissionTimeout] fires.
+ * [ask], [askHuman], and [confirm] publish, register a reply waiter in
+ * [replyRegistry], and suspend until the matching [EmissionEvent.Resolved]
+ * arrives or [EmissionTimeout] fires. [emit] and [sense] publish and return
+ * immediately — narration and ambient readings have no reply to await.
+ *
+ * [publish] is the seam a host uses to intercept or wrap outgoing events —
+ * for example to carry [Emission.surfaces] to its own renderers — before
+ * they reach [eventSerialBus]. It defaults to publishing directly.
  */
 class EmissionScope(
     private val eventSource: EventSource,
     private val eventSerialBus: EventSerialBus,
     private val replyRegistry: EmissionReplyRegistry,
+    private val publish: suspend (Event) -> Unit = eventSerialBus::publish,
 ) {
 
     /**
@@ -39,7 +51,7 @@ class EmissionScope(
         emission: Emission,
         timeout: Duration = 30.minutes,
     ): EmissionEvent.Resolved {
-        eventSerialBus.publish(
+        publish(
             EmissionEvent.BaseProduced(
                 eventId = randomUUID(),
                 timestamp = Clock.System.now(),
@@ -50,6 +62,141 @@ class EmissionScope(
         return replyRegistry.awaitReply(emission.id, timeout)
             ?: throw EmissionTimeout(emission.id, timeout)
     }
+
+    /**
+     * Author and publish an [EmissionKind.Decision] Emission from [prompt] and
+     * [affordances], suspending until the matching reply arrives.
+     *
+     * This is the authoring-level counterpart to `ask(emission)` — callers
+     * describe intent rather than assembling an [Emission] by hand.
+     *
+     * @throws EmissionTimeout if no reply arrives within [timeout]
+     */
+    suspend fun ask(
+        prompt: String,
+        context: String? = null,
+        affordances: AffordanceBuilder.() -> Unit = { freeTextAffordance("Provide response") },
+        surfaces: List<Surface> = emptyList(),
+        confidence: Confidence? = null,
+        provenance: EmissionProvenance? = null,
+        dedupKey: String? = null,
+        timeout: Duration = 30.minutes,
+    ): EmissionEvent.Resolved {
+        val payload = EmissionPayload.Decision(prompt = prompt, context = context)
+        val emission = Emission(
+            id = randomUUID(),
+            kind = EmissionKind.Decision,
+            payload = payload,
+            affordances = AffordanceBuilder().apply(affordances).build(),
+            confidence = confidence,
+            provenance = provenance ?: defaultProvenance(payload),
+            dedupKey = dedupKey,
+            producedAt = Clock.System.now(),
+            surfaces = surfaces,
+        )
+        return ask(emission, timeout)
+    }
+
+    /**
+     * Author and publish an [EmissionKind.Confirmation] Emission gating [action],
+     * suspending until the human confirms or declines.
+     *
+     * Defaults to a `Confirm` / `Cancel` affordance pair. [dedupKey] defaults
+     * to [Emission.computeDedupKey] — a content digest of the payload, since
+     * Confirmation is an effect-bearing kind.
+     *
+     * @throws EmissionTimeout if no reply arrives within [timeout]
+     */
+    suspend fun confirm(
+        action: String,
+        dangerLevel: DangerLevel,
+        preview: String? = null,
+        affordances: AffordanceBuilder.() -> Unit = {
+            affordance("Confirm")
+            affordance("Cancel")
+        },
+        surfaces: List<Surface> = emptyList(),
+        provenance: EmissionProvenance? = null,
+        dedupKey: String? = null,
+        timeout: Duration = 30.minutes,
+    ): EmissionEvent.Resolved {
+        val payload = EmissionPayload.Confirmation(action = action, preview = preview, dangerLevel = dangerLevel)
+        val emission = Emission(
+            id = randomUUID(),
+            kind = EmissionKind.Confirmation,
+            payload = payload,
+            affordances = AffordanceBuilder().apply(affordances).build(),
+            provenance = provenance ?: defaultProvenance(payload),
+            dedupKey = null,
+            producedAt = Clock.System.now(),
+            surfaces = surfaces,
+        )
+        return ask(emission.copy(dedupKey = dedupKey ?: emission.computeDedupKey()), timeout)
+    }
+
+    /**
+     * Author and publish an [EmissionKind.Prose] Emission. Fire-and-forget —
+     * narration has no affordances and no reply is awaited.
+     */
+    suspend fun emit(
+        text: String,
+        format: ProseFormat = ProseFormat.PLAIN,
+        surfaces: List<Surface> = emptyList(),
+        provenance: EmissionProvenance? = null,
+    ): Emission {
+        val payload = EmissionPayload.Prose(text = text, format = format)
+        return publishOnly(
+            Emission(
+                id = randomUUID(),
+                kind = EmissionKind.Prose,
+                payload = payload,
+                provenance = provenance ?: defaultProvenance(payload),
+                producedAt = Clock.System.now(),
+                surfaces = surfaces,
+            ),
+        )
+    }
+
+    /**
+     * Author and publish an [EmissionKind.Sensor] Emission. Fire-and-forget —
+     * ambient readings have no affordances and no reply is awaited.
+     */
+    suspend fun sense(
+        label: String,
+        value: String,
+        unit: String? = null,
+        refreshUri: String? = null,
+        surfaces: List<Surface> = emptyList(),
+        provenance: EmissionProvenance? = null,
+    ): Emission {
+        val payload = EmissionPayload.Sensor(label = label, value = value, unit = unit, refreshUri = refreshUri)
+        return publishOnly(
+            Emission(
+                id = randomUUID(),
+                kind = EmissionKind.Sensor,
+                payload = payload,
+                provenance = provenance ?: defaultProvenance(payload),
+                producedAt = Clock.System.now(),
+                surfaces = surfaces,
+            ),
+        )
+    }
+
+    private suspend fun publishOnly(emission: Emission): Emission {
+        publish(
+            EmissionEvent.BaseProduced(
+                eventId = randomUUID(),
+                timestamp = Clock.System.now(),
+                eventSource = eventSource,
+                emission = emission,
+            ),
+        )
+        return emission
+    }
+
+    /** Provenance for callers that don't supply their own — digest only, no attribution. */
+    private fun defaultProvenance(payload: EmissionPayload): EmissionProvenance =
+        EmissionProvenance(inputDigest = inputDigest(payload))
 
     /**
      * Publish a human-interaction [Emission] and suspend until the reply arrives.
@@ -64,6 +211,9 @@ class EmissionScope(
      * @param ticketId Optional ticket attribution (preserved in the event)
      * @param taskId Optional task attribution (preserved in the event)
      * @param affordances Builder for response options; defaults to a single free-text affordance
+     * @param surfaces Ordered surface-delivery intent; see [Emission.surfaces]
+     * @param provenance Attribution for this Emission; defaults to digest-only (no run/workflow/tool
+     *   attribution) when the caller doesn't have richer context to supply
      * @param urgency Urgency of this request (drives surface-priority defaults)
      * @param timeout How long to wait before timing out
      * @param onProduced Called synchronously after the event is published but before suspension;
@@ -77,30 +227,24 @@ class EmissionScope(
         ticketId: String? = null,
         taskId: String? = null,
         affordances: AffordanceBuilder.() -> Unit = { freeTextAffordance("Provide response") },
+        surfaces: List<Surface> = emptyList(),
+        provenance: EmissionProvenance? = null,
         urgency: Urgency = Urgency.HIGH,
         timeout: Duration = 30.minutes,
         onProduced: suspend (HumanInteractionEvent.InputRequested) -> Unit = {},
     ): EmissionEvent.Resolved {
         val affordanceList = AffordanceBuilder().apply(affordances).build()
         val payload = EmissionPayload.Decision(prompt = prompt, context = context)
-        val provenance = EmissionProvenance(
-            runId = null,
-            workflowId = null,
-            sourceEventId = null,
-            toolInvocationId = null,
-            plugId = null,
-            modelId = null,
-            inputDigest = inputDigest(payload),
-        )
         val emission = Emission(
             id = randomUUID(),
             kind = EmissionKind.Decision,
             payload = payload,
             affordances = affordanceList,
             confidence = null,
-            provenance = provenance,
+            provenance = provenance ?: defaultProvenance(payload),
             dedupKey = null,
             producedAt = Clock.System.now(),
+            surfaces = surfaces,
         )
 
         val requestId = randomUUID()
@@ -116,12 +260,12 @@ class EmissionScope(
             taskId = taskId,
         )
 
-        eventSerialBus.publish(inputRequested)
+        publish(inputRequested)
         onProduced(inputRequested)
 
         val reply = replyRegistry.awaitReply(emission.id, timeout)
         if (reply == null) {
-            eventSerialBus.publish(
+            publish(
                 HumanInteractionEvent.RequestTimedOut(
                     eventId = randomUUID(),
                     timestamp = Clock.System.now(),
@@ -144,12 +288,16 @@ class EmissionScope(
  *
  * Also wires reply-delivery subscribers so that incoming [EmissionEvent.BaseResolved] and
  * [HumanInteractionEvent.InputProvided] events are forwarded to [replyRegistry], resuming
- * any suspended [EmissionScope.ask] / [EmissionScope.askHuman] calls.
+ * any suspended [EmissionScope.ask] / [EmissionScope.askHuman] / [EmissionScope.confirm] calls.
+ *
+ * @param publish Seam for a host to intercept or wrap outgoing events before they reach
+ *   [eventSerialBus] — see [EmissionScope]. Defaults to publishing directly.
  */
 suspend fun <T> emission(
     eventSource: EventSource,
     eventSerialBus: EventSerialBus,
     replyRegistry: EmissionReplyRegistry = GlobalEmissionReplyRegistry.instance,
+    publish: suspend (Event) -> Unit = eventSerialBus::publish,
     block: suspend EmissionScope.() -> T,
 ): T {
     eventSerialBus.subscribe<EmissionEvent.BaseResolved, EventSubscription.ByEventClassType>(
@@ -166,5 +314,5 @@ suspend fun <T> emission(
         replyRegistry.deliver(event)
     }
 
-    return EmissionScope(eventSource, eventSerialBus, replyRegistry).block()
+    return EmissionScope(eventSource, eventSerialBus, replyRegistry, publish).block()
 }

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/emission/EmissionScopeTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/emission/EmissionScopeTest.kt
@@ -1,0 +1,234 @@
+package link.socket.ampere.agents.domain.emission
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import kotlinx.datetime.Clock
+import link.socket.ampere.agents.domain.Urgency
+import link.socket.ampere.agents.domain.event.EmissionEvent
+import link.socket.ampere.agents.domain.event.Event
+import link.socket.ampere.agents.domain.event.EventSource
+import link.socket.ampere.agents.domain.event.HumanInteractionEvent
+import link.socket.ampere.agents.events.bus.EventSerialBus
+import link.socket.ampere.agents.events.bus.subscribe
+import link.socket.ampere.agents.events.subscription.EventSubscription
+import link.socket.ampere.util.randomUUID
+
+/**
+ * Validates the authoring-level builders added for AMPR-238 Option A —
+ * [EmissionScope.ask] (prompt overload), [EmissionScope.confirm], [EmissionScope.emit],
+ * [EmissionScope.sense] — plus caller-supplied provenance/surfaces and the `publish` seam
+ * that lets a host wrap outgoing events instead of publishing directly to [EventSerialBus].
+ */
+class EmissionScopeTest {
+
+    private fun resolvedFor(emissionId: EmissionId) = EmissionEvent.BaseResolved(
+        eventId = randomUUID(),
+        timestamp = Clock.System.now(),
+        eventSource = EventSource.Human,
+        urgency = Urgency.HIGH,
+        emissionId = emissionId,
+        affordanceId = "confirm",
+    )
+
+    @Test
+    fun `ask prompt overload publishes Decision emission and awaits reply`() = runTest {
+        coroutineScope {
+            val bus = EventSerialBus(scope = this)
+            val registry = EmissionReplyRegistry()
+            val published = CompletableDeferred<EmissionEvent.BaseProduced>()
+
+            bus.subscribe<EmissionEvent.BaseProduced, EventSubscription.ByEventClassType>(
+                agentId = "test-sub",
+                eventType = EmissionEvent.Produced.EVENT_TYPE,
+            ) { event, _ -> published.complete(event) }
+
+            val askDeferred = async {
+                emission(EventSource.Agent("test-agent"), bus, registry) {
+                    ask(
+                        prompt = "Proceed?",
+                        affordances = {
+                            affordance("Yes")
+                            affordance("No")
+                        },
+                        timeout = 5.seconds,
+                    )
+                }
+            }
+
+            val event = withTimeout(5.seconds) { published.await() }
+            assertEquals(EmissionKind.Decision, event.emission.kind)
+            assertIs<EmissionPayload.Decision>(event.emission.payload)
+            assertEquals(2, event.emission.affordances.size)
+
+            registry.deliver(resolvedFor(event.emission.id))
+            askDeferred.await()
+        }
+    }
+
+    @Test
+    fun `confirm defaults to Confirm Cancel affordances and computes dedupKey`() = runTest {
+        coroutineScope {
+            val bus = EventSerialBus(scope = this)
+            val registry = EmissionReplyRegistry()
+            val published = CompletableDeferred<EmissionEvent.BaseProduced>()
+
+            bus.subscribe<EmissionEvent.BaseProduced, EventSubscription.ByEventClassType>(
+                agentId = "test-sub",
+                eventType = EmissionEvent.Produced.EVENT_TYPE,
+            ) { event, _ -> published.complete(event) }
+
+            val confirmDeferred = async {
+                emission(EventSource.Agent("test-agent"), bus, registry) {
+                    confirm(
+                        action = "Delete branch",
+                        dangerLevel = DangerLevel.HIGH,
+                        timeout = 5.seconds,
+                    )
+                }
+            }
+
+            val event = withTimeout(5.seconds) { published.await() }
+            assertEquals(EmissionKind.Confirmation, event.emission.kind)
+            assertEquals(listOf("Confirm", "Cancel"), event.emission.affordances.map { it.label })
+            assertEquals(event.emission.computeDedupKey(), event.emission.dedupKey)
+            assertTrue(event.emission.dedupKey != null)
+
+            registry.deliver(resolvedFor(event.emission.id))
+            confirmDeferred.await()
+        }
+    }
+
+    @Test
+    fun `emit publishes Prose emission without awaiting a reply`() = runTest {
+        coroutineScope {
+            val bus = EventSerialBus(scope = this)
+            val registry = EmissionReplyRegistry()
+            val published = CompletableDeferred<EmissionEvent.BaseProduced>()
+
+            bus.subscribe<EmissionEvent.BaseProduced, EventSubscription.ByEventClassType>(
+                agentId = "test-sub",
+                eventType = EmissionEvent.Produced.EVENT_TYPE,
+            ) { event, _ -> published.complete(event) }
+
+            val result = emission(EventSource.Agent("test-agent"), bus, registry) {
+                emit(text = "Build finished", format = ProseFormat.PLAIN)
+            }
+
+            assertEquals(EmissionKind.Prose, result.kind)
+            val event = withTimeout(5.seconds) { published.await() }
+            assertEquals(result.id, event.emission.id)
+        }
+    }
+
+    @Test
+    fun `sense publishes Sensor emission without awaiting a reply`() = runTest {
+        coroutineScope {
+            val bus = EventSerialBus(scope = this)
+            val registry = EmissionReplyRegistry()
+
+            val result = emission(EventSource.Agent("test-agent"), bus, registry) {
+                sense(label = "cpu", value = "42", unit = "%")
+            }
+
+            assertEquals(EmissionKind.Sensor, result.kind)
+            assertIs<EmissionPayload.Sensor>(result.payload)
+        }
+    }
+
+    @Test
+    fun `caller-supplied provenance overrides the digest-only default`() = runTest {
+        coroutineScope {
+            val bus = EventSerialBus(scope = this)
+            val registry = EmissionReplyRegistry()
+
+            val result = emission(EventSource.Agent("test-agent"), bus, registry) {
+                sense(
+                    label = "cpu",
+                    value = "42",
+                    provenance = EmissionProvenance(runId = "run-1", inputDigest = "ignored"),
+                )
+            }
+
+            assertEquals("run-1", result.provenance.runId)
+        }
+    }
+
+    @Test
+    fun `askHuman defaults provenance to digest-only when none supplied`() = runTest {
+        coroutineScope {
+            val bus = EventSerialBus(scope = this)
+            val registry = EmissionReplyRegistry()
+            val published = CompletableDeferred<HumanInteractionEvent.InputRequested>()
+
+            bus.subscribe<HumanInteractionEvent.InputRequested, EventSubscription.ByEventClassType>(
+                agentId = "test-sub",
+                eventType = HumanInteractionEvent.InputRequested.EVENT_TYPE,
+            ) { event, _ -> published.complete(event) }
+
+            val askDeferred = async {
+                emission(EventSource.Agent("test-agent"), bus, registry) {
+                    askHuman(prompt = "Proceed?", agentId = "test-agent", timeout = 5.seconds)
+                }
+            }
+
+            val event = withTimeout(5.seconds) { published.await() }
+            assertNull(event.emission.provenance.runId)
+            assertTrue(event.emission.provenance.inputDigest.isNotEmpty())
+
+            registry.deliver(resolvedFor(event.emission.id))
+            askDeferred.await()
+        }
+    }
+
+    @Test
+    fun `surfaces declared on a builder are carried onto the published Emission`() = runTest {
+        coroutineScope {
+            val bus = EventSerialBus(scope = this)
+            val registry = EmissionReplyRegistry()
+
+            val result = emission(EventSource.Agent("test-agent"), bus, registry) {
+                sense(label = "cpu", value = "42", surfaces = listOf(Surface.Push, Surface.Console))
+            }
+
+            assertEquals(listOf(Surface.Push, Surface.Console), result.surfaces)
+        }
+    }
+
+    @Test
+    fun `publish seam lets a host intercept outgoing events instead of the raw bus`() = runTest {
+        coroutineScope {
+            val bus = EventSerialBus(scope = this)
+            val registry = EmissionReplyRegistry()
+            val intercepted = mutableListOf<Event>()
+            val busReceived = CompletableDeferred<Boolean>()
+
+            bus.subscribe<EmissionEvent.BaseProduced, EventSubscription.ByEventClassType>(
+                agentId = "bus-sub",
+                eventType = EmissionEvent.Produced.EVENT_TYPE,
+            ) { _, _ -> busReceived.complete(true) }
+
+            emission(
+                eventSource = EventSource.Agent("test-agent"),
+                eventSerialBus = bus,
+                replyRegistry = registry,
+                publish = { event -> intercepted.add(event) },
+            ) {
+                sense(label = "cpu", value = "42")
+            }
+
+            assertEquals(1, intercepted.size)
+            assertIs<EmissionEvent.BaseProduced>(intercepted.single())
+            assertFalse(busReceived.isCompleted)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Implements AMPR-238 Option A: closes the AMPR-181 Q1 gap where Socket's `ArcEmissionScope` couldn't actually delegate to AMPERE's `EmissionScope`.
- Adds an ordered `Emission.surfaces` field, authoring-level `ask`/`confirm`/`emit`/`sense` builders with caller-supplied `EmissionProvenance` (replacing the hardcoded-null default), and a `publish` seam so a host can wrap outgoing events before they hit the raw `EventSerialBus`.
- All changes are additive/backward-compatible — existing `askHuman` call sites and tests are untouched.

Written by Claude (Anthropic), on behalf of @mileychandonnet.

Closes #608

## Test plan
- [x] `./gradlew :ampere-core:compileCommonMainKotlinMetadata`
- [x] `./gradlew ktlintFormat`
- [x] `./gradlew :ampere-core:jvmTest` (1415/1416 passing; one pre-existing perf-budget flake unrelated to this change, confirmed passing on retry)
- [x] Added `EmissionScopeTest.kt` covering the new builders, provenance override, `surfaces` propagation, and the publish seam