### PR TITLE
AMPR-236 #604: Wire the injected UpstreamLlmClient into the agent path

### DIFF
--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/Main.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/Main.kt
@@ -17,6 +17,7 @@ import link.socket.ampere.data.createJvmDriver
 import link.socket.ampere.domain.koog.KoogAgentFactory
 import link.socket.ampere.integrations.git.RepositoryDetector
 import link.socket.ampere.integrations.issues.github.GitHubCliProvider
+import link.socket.ampere.llm.BundledUpstreamLlmClient
 import link.socket.ampere.util.LoggingConfiguration
 import link.socket.ampere.util.configureLogging
 
@@ -91,6 +92,9 @@ fun main(args: Array<String>) {
         repository = repository,
         aiConfiguration = aiConfiguration,
         llmProvider = context.llmProvider,
+        // The CLI is a first-party tool talking to providers with the
+        // operator's own keys, so it opts into the direct-provider call.
+        upstreamLlmClient = BundledUpstreamLlmClient,
     )
 
     // Create agents based on team configuration (or defaults if no config)

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/goal/GoalHandler.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/goal/GoalHandler.kt
@@ -30,6 +30,7 @@ import link.socket.ampere.domain.ai.configuration.AIConfiguration_Default
 import link.socket.ampere.domain.ai.model.AIModel_Claude
 import link.socket.ampere.domain.ai.provider.AIProvider_Anthropic
 import link.socket.ampere.agents.domain.Urgency
+import link.socket.ampere.llm.BundledUpstreamLlmClient
 
 /**
  * Orchestrates goal activation, agent creation, and task execution.
@@ -103,6 +104,7 @@ class GoalHandler(
             eventApiFactory = { agentId -> context.environmentService.createEventApi(agentId) },
             aiConfiguration = effectiveAiConfig,
             toolWriteCodeFileOverride = writeCodeTool,
+            upstreamLlmClient = BundledUpstreamLlmClient,
         )
 
         // Create spark-based code agent

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/demo/AgentTestRunner.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/demo/AgentTestRunner.kt
@@ -40,6 +40,7 @@ import link.socket.ampere.agents.execution.tools.Tool
 import link.socket.ampere.domain.ai.configuration.AIConfiguration_Default
 import link.socket.ampere.domain.ai.model.AIModel_Claude
 import link.socket.ampere.domain.ai.provider.AIProvider_Anthropic
+import link.socket.ampere.llm.BundledUpstreamLlmClient
 
 /** Default timeout for escalation prompts */
 private const val ESCALATION_TIMEOUT_SECONDS = 30L
@@ -106,6 +107,7 @@ fun main(escalation: Boolean = false) {
                     model = AIModel_Claude.Sonnet_4
                 ),
                 toolWriteCodeFileOverride = writeCodeTool,
+                upstreamLlmClient = BundledUpstreamLlmClient,
             )
 
             // Create CodeWriterAgent

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/demo/MultiAgentDemoRunner.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/demo/MultiAgentDemoRunner.kt
@@ -33,6 +33,7 @@ import link.socket.ampere.cli.layout.CognitiveProgressPane
 import link.socket.ampere.domain.ai.configuration.AIConfiguration_Default
 import link.socket.ampere.domain.ai.model.AIModel_Claude
 import link.socket.ampere.domain.ai.provider.AIProvider_Anthropic
+import link.socket.ampere.llm.BundledUpstreamLlmClient
 
 /**
  * Multi-agent demo runner that coordinates two agents for the handoff demonstration.
@@ -81,6 +82,7 @@ class MultiAgentDemoRunner(
                 provider = AIProvider_Anthropic,
                 model = AIModel_Claude.Sonnet_4
             ),
+            upstreamLlmClient = BundledUpstreamLlmClient,
         )
         val coordinator = coordinatorFactory.create<SparkBasedAgent<ProjectState>>(AgentType.PROJECT)
         val coordinatorEventApi = context.environmentService.createEventApi(coordinator.id)
@@ -97,6 +99,7 @@ class MultiAgentDemoRunner(
                 model = AIModel_Claude.Sonnet_4
             ),
             toolWriteCodeFileOverride = writeCodeTool,
+            upstreamLlmClient = BundledUpstreamLlmClient,
         )
         val worker = workerFactory.create<SparkBasedAgent<CodeState>>(AgentType.CODE)
         val workerEventApi = context.environmentService.createEventApi(worker.id)

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/config/AgentConfiguration.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/config/AgentConfiguration.kt
@@ -19,13 +19,19 @@ data class AgentConfiguration(
     @Transient
     val cognitiveRelay: CognitiveRelay? = null,
     /**
-     * Outbound LLM-call seam. Defaults to [BundledUpstreamLlmClient] (the
-     * pre-seam direct-call behavior). Embedded consumers (e.g. Socket)
-     * override this to route LLM calls through their backend proxy.
+     * Outbound LLM-call seam. Embedded consumers (e.g. Socket) set this to
+     * route LLM calls through their backend proxy; callers that want the
+     * direct per-provider call set [BundledUpstreamLlmClient] explicitly.
+     *
+     * `null` means no transport has been chosen. Reaching
+     * [AgentLLMService.call][link.socket.ampere.agents.domain.reasoning.AgentLLMService.call]
+     * in that state throws
+     * [MissingUpstreamLlmClientException][link.socket.ampere.llm.MissingUpstreamLlmClientException]
+     * rather than silently egressing to the provider (AMPR-236).
      *
      * Note: a non-null [llmProvider] still short-circuits before the
-     * upstream client runs.
+     * upstream client runs, so it needs no transport.
      */
     @Transient
-    val upstreamLlmClient: UpstreamLlmClient = BundledUpstreamLlmClient,
+    val upstreamLlmClient: UpstreamLlmClient? = null,
 )

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/AgentFactory.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/AgentFactory.kt
@@ -40,6 +40,7 @@ import link.socket.ampere.domain.ai.configuration.AIConfiguration
 import link.socket.ampere.domain.ai.configuration.AIConfigurationFactory
 import link.socket.ampere.domain.llm.LlmProvider
 import link.socket.ampere.integrations.issues.IssueTrackerProvider
+import link.socket.ampere.llm.UpstreamLlmClient
 import link.socket.ampere.util.runBlockingCompat
 
 enum class AgentType {
@@ -100,6 +101,18 @@ class AgentFactory(
      * downgrading.
      */
     private val codeAgentMinimumRung: CapabilityRung? = DEFAULT_CODE_AGENT_RUNG,
+    /**
+     * Outbound LLM transport handed to every agent this factory builds
+     * (AMPR-236). `Ampere.fromEnvironment(upstreamLlmClient = ...)` supplies
+     * it via [link.socket.ampere.api.AmpereInstance.agentFactory] so an
+     * injected client governs factory-built agents too. Null leaves the
+     * agents without a transport, which turns their first LLM call into a
+     * [MissingUpstreamLlmClientException][link.socket.ampere.llm.MissingUpstreamLlmClientException]
+     * instead of a silent direct-provider call; pass
+     * [BundledUpstreamLlmClient][link.socket.ampere.llm.BundledUpstreamLlmClient]
+     * to opt into that call.
+     */
+    private val upstreamLlmClient: UpstreamLlmClient? = null,
 ) {
     private val toolWriteCodeFile: Tool<ExecutionContext.Code.WriteCode> =
         toolWriteCodeFileOverride ?: ToolWriteCodeFile(AgentActionAutonomy.ASK_BEFORE_ACTION)
@@ -161,6 +174,7 @@ class AgentFactory(
             aiConfiguration = effectiveAiConfiguration,
             cognitiveConfig = cognitiveConfig,
             llmProvider = llmProvider,
+            upstreamLlmClient = upstreamLlmClient,
         )
 
     /**
@@ -263,6 +277,7 @@ class AgentFactory(
                 memoryService = memoryService,
                 llmProvider = llmProvider,
                 observabilityScope = scope,
+                upstreamLlmClient = upstreamLlmClient,
                 // AMPR-219: the CODE path is the one activated production agent.
                 // Only this branch wires the relay + rung floor; PRODUCT,
                 // PROJECT, and QUALITY keep the dormant (null relay) behavior.
@@ -292,6 +307,7 @@ class AgentFactory(
                 memoryService = memoryService,
                 llmProvider = llmProvider,
                 observabilityScope = scope,
+                upstreamLlmClient = upstreamLlmClient,
             )
         }
         AgentType.PROJECT -> {
@@ -306,6 +322,7 @@ class AgentFactory(
                 memoryService = memoryService,
                 llmProvider = llmProvider,
                 observabilityScope = scope,
+                upstreamLlmClient = upstreamLlmClient,
                 tools = setOfNotNull(toolCreateIssues, toolAskHuman),
             )
         }
@@ -321,6 +338,7 @@ class AgentFactory(
                 memoryService = memoryService,
                 llmProvider = llmProvider,
                 observabilityScope = scope,
+                upstreamLlmClient = upstreamLlmClient,
             )
         }
     }

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/SparkAgentFactory.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/SparkAgentFactory.kt
@@ -16,6 +16,7 @@ import link.socket.ampere.agents.events.api.AgentEventApi
 import link.socket.ampere.agents.events.utils.generateUUID
 import link.socket.ampere.agents.execution.executor.Executor
 import link.socket.ampere.domain.ai.configuration.AIConfiguration
+import link.socket.ampere.llm.UpstreamLlmClient
 
 /**
  * Factory for creating agents with Spark-based cognitive differentiation.
@@ -36,6 +37,9 @@ import link.socket.ampere.domain.ai.configuration.AIConfiguration
  * @param sparkRegistry Optional declarative spark registry; defaults to bundled fixtures
  * @param cognitiveRelay Optional relay injected into created agents (e.g. a `PlaybackRelay` for eval Bench runs)
  * @param executor Optional tool executor injected into created agents (e.g. a `NoOpExecutor` for effect-free Bench runs)
+ * @param upstreamLlmClient Outbound LLM transport handed to created agents (AMPR-236). Null leaves them without a
+ *   transport, so their first LLM call throws rather than calling a provider directly; pass
+ *   [link.socket.ampere.llm.BundledUpstreamLlmClient] to opt into the direct call.
  */
 class SparkAgentFactory(
     private val scope: CoroutineScope = CoroutineScope(Dispatchers.Default),
@@ -45,6 +49,7 @@ class SparkAgentFactory(
     private val sparkRegistry: SparkRegistry? = null,
     private val cognitiveRelay: CognitiveRelay? = null,
     private val executor: Executor? = null,
+    private val upstreamLlmClient: UpstreamLlmClient? = null,
 ) {
     private val effectiveSparkRegistry: SparkRegistry
         get() = sparkRegistry ?: DefaultSparkCatalog.registry
@@ -185,6 +190,7 @@ class SparkAgentFactory(
             _observabilityScope = scope,
             _cognitiveRelay = cognitiveRelay,
             _executor = executor,
+            _upstreamLlmClient = upstreamLlmClient,
         )
     }
 

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/SparkBasedAgent.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/SparkBasedAgent.kt
@@ -38,7 +38,6 @@ import link.socket.ampere.domain.agent.bundled.AgentDefinition
 import link.socket.ampere.domain.ai.configuration.AIConfiguration
 import link.socket.ampere.domain.ai.configuration.AIConfigurationFactory
 import link.socket.ampere.domain.llm.LlmProvider
-import link.socket.ampere.llm.BundledUpstreamLlmClient
 import link.socket.ampere.llm.UpstreamLlmClient
 import link.socket.ampere.util.ioDispatcher
 import link.socket.ampere.util.runBlockingCompat
@@ -80,8 +79,16 @@ open class SparkBasedAgent<S : AgentState>(
     private val _aiConfiguration: AIConfiguration? = null,
     @Transient
     private val _llmProvider: LlmProvider? = null,
+    /**
+     * Outbound LLM transport (AMPR-236). Null declares no transport: the
+     * agent's first LLM call throws
+     * [MissingUpstreamLlmClientException][link.socket.ampere.llm.MissingUpstreamLlmClientException]
+     * rather than falling back to the direct-provider call. Pass
+     * [BundledUpstreamLlmClient][link.socket.ampere.llm.BundledUpstreamLlmClient]
+     * to opt into that fallback.
+     */
     @Transient
-    private val _upstreamLlmClient: UpstreamLlmClient = BundledUpstreamLlmClient,
+    private val _upstreamLlmClient: UpstreamLlmClient? = null,
     @Transient
     private val _observabilityScope: CoroutineScope = CoroutineScope(Dispatchers.Default),
     @Transient
@@ -402,7 +409,7 @@ open class SparkBasedAgent<S : AgentState>(
             eventApi: AgentEventApi? = null,
             memoryService: AgentMemoryService? = null,
             llmProvider: LlmProvider? = null,
-            upstreamLlmClient: UpstreamLlmClient = BundledUpstreamLlmClient,
+            upstreamLlmClient: UpstreamLlmClient? = null,
             observabilityScope: CoroutineScope = CoroutineScope(Dispatchers.Default),
             tools: Set<Tool<*>> = emptySet(),
             reasoningOverride: AgentReasoning? = null,
@@ -469,7 +476,7 @@ open class SparkBasedAgent<S : AgentState>(
             eventApi: AgentEventApi? = null,
             memoryService: AgentMemoryService? = null,
             llmProvider: LlmProvider? = null,
-            upstreamLlmClient: UpstreamLlmClient = BundledUpstreamLlmClient,
+            upstreamLlmClient: UpstreamLlmClient? = null,
             observabilityScope: CoroutineScope = CoroutineScope(Dispatchers.Default),
             tools: Set<Tool<*>> = emptySet(),
             reasoningOverride: AgentReasoning? = null,
@@ -519,7 +526,7 @@ open class SparkBasedAgent<S : AgentState>(
             eventApi: AgentEventApi? = null,
             memoryService: AgentMemoryService? = null,
             llmProvider: LlmProvider? = null,
-            upstreamLlmClient: UpstreamLlmClient = BundledUpstreamLlmClient,
+            upstreamLlmClient: UpstreamLlmClient? = null,
             observabilityScope: CoroutineScope = CoroutineScope(Dispatchers.Default),
             tools: Set<Tool<*>> = emptySet(),
             reasoningOverride: AgentReasoning? = null,
@@ -569,7 +576,7 @@ open class SparkBasedAgent<S : AgentState>(
             eventApi: AgentEventApi? = null,
             memoryService: AgentMemoryService? = null,
             llmProvider: LlmProvider? = null,
-            upstreamLlmClient: UpstreamLlmClient = BundledUpstreamLlmClient,
+            upstreamLlmClient: UpstreamLlmClient? = null,
             observabilityScope: CoroutineScope = CoroutineScope(Dispatchers.Default),
             tools: Set<Tool<*>> = emptySet(),
             reasoningOverride: AgentReasoning? = null,

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/reasoning/AgentLLMService.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/reasoning/AgentLLMService.kt
@@ -24,6 +24,7 @@ import link.socket.ampere.domain.llm.LlmProvider
 import link.socket.ampere.domain.util.toClientModelId
 import link.socket.ampere.llm.BundledUpstreamLlmClient
 import link.socket.ampere.llm.DispatchingUpstreamLlmClient
+import link.socket.ampere.llm.MissingUpstreamLlmClientException
 import link.socket.ampere.llm.UpstreamLlmClient
 import link.socket.ampere.util.ioDispatcher
 import link.socket.ampere.util.logWith
@@ -78,14 +79,18 @@ class AgentLLMService(
     private val activePromptProvider: (() -> String?)? = null,
     /**
      * Injection seam for outbound LLM calls. Defaults to whatever the
-     * [agentConfiguration] carries (which itself defaults to
-     * [BundledUpstreamLlmClient] — the pre-seam direct-call path).
-     * Embedded consumers (e.g. Socket) typically set the client on
-     * [AgentConfiguration.upstreamLlmClient] so it flows through
+     * [agentConfiguration] carries. Embedded consumers (e.g. Socket)
+     * typically set the client on [AgentConfiguration.upstreamLlmClient] so
+     * it flows through
      * [link.socket.ampere.agents.domain.reasoning.AgentReasoning];
      * passing this argument explicitly overrides whatever the config says,
      * for direct-construction tests that don't want to round-trip through
      * the config.
+     *
+     * When neither is supplied, [call] throws
+     * [MissingUpstreamLlmClientException] instead of falling back to
+     * [BundledUpstreamLlmClient] — a direct provider call is opt-in
+     * (AMPR-236).
      *
      * Local, on-device execution flows through this same seam: a
      * [link.socket.ampere.llm.DispatchingUpstreamLlmClient] supplied here (or on
@@ -97,7 +102,7 @@ class AgentLLMService(
      * Note: a custom [link.socket.ampere.domain.llm.LlmProvider] configured
      * on [AgentConfiguration] short-circuits before this client runs.
      */
-    private val upstreamLlmClient: UpstreamLlmClient = agentConfiguration.upstreamLlmClient,
+    private val upstreamLlmClient: UpstreamLlmClient? = agentConfiguration.upstreamLlmClient,
 ) {
 
     private val logger: Logger = logWith("AgentLLMService")
@@ -172,10 +177,16 @@ class AgentLLMService(
             }
         }
 
+        // No custom provider: an outbound transport is required. Resolve it
+        // before any relay work or telemetry so an unconfigured agent fails
+        // loudly instead of falling through to the direct-provider call.
+        val client = upstreamLlmClient
+            ?: throw MissingUpstreamLlmClientException(agentConfiguration.agentDefinition.name)
+
         // Probe the bound local engine (if any) so the relay's on-device
         // availability gate (AMPR-207/225) can see whether Rung 0 is usable
         // right now. Never overwrites a caller-supplied localCapacity.
-        val probedLocalCapacity = (upstreamLlmClient as? DispatchingUpstreamLlmClient)?.probeLocalCapacity()
+        val probedLocalCapacity = (client as? DispatchingUpstreamLlmClient)?.probeLocalCapacity()
         fun RoutingContext.withProbedLocalCapacity(): RoutingContext =
             if (probedLocalCapacity != null && localCapacity == null) {
                 copy(localCapacity = probedLocalCapacity)
@@ -250,7 +261,7 @@ class AgentLLMService(
         val startedAt = Clock.System.now()
         val completion = try {
             withContext(ioDispatcher) {
-                upstreamLlmClient.call(request, effectiveConfig)
+                client.call(request, effectiveConfig)
             }
         } catch (t: Throwable) {
             emitCompletedTelemetry(

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/api/AmpereFromEnvironment.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/api/AmpereFromEnvironment.kt
@@ -1,5 +1,8 @@
 package link.socket.ampere.api
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import link.socket.ampere.agents.definition.AgentFactory
 import link.socket.ampere.agents.domain.knowledge.KnowledgeRepository
 import link.socket.ampere.agents.environment.EnvironmentService
 import link.socket.ampere.agents.events.messages.DefaultThreadViewService
@@ -41,12 +44,19 @@ import link.socket.ampere.memory.MemoryStore
  *   [EnvironmentService.outcomeMemoryRepository]. Embedded consumers (e.g.
  *   Socket) pass this to route durable agent memory through their own
  *   on-device store while reusing Ampere's other infrastructure.
- * @param upstreamLlmClient Runtime default for outbound LLM calls. Exposed
- *   on the returned [AmpereInstance.upstreamLlmClient] property so callers
- *   constructing agents off this instance can pass it into agent factories
- *   (e.g. [link.socket.ampere.agents.definition.SparkBasedAgent.Code]) and
- *   have every agent share the same upstream routing. Defaults to
- *   [BundledUpstreamLlmClient] (direct per-provider OpenAI call).
+ * @param upstreamLlmClient Transport for outbound LLM calls. Wired into the
+ *   returned [AmpereInstance.agentFactory], so every agent built off this
+ *   instance routes its LLM calls through it without per-construction-site
+ *   plumbing, and exposed on [AmpereInstance.upstreamLlmClient] for callers
+ *   that construct agents by hand (e.g.
+ *   [link.socket.ampere.agents.definition.SparkBasedAgent.Code]). Omitting it
+ *   leaves agents without a transport: their first LLM call throws
+ *   [MissingUpstreamLlmClientException][link.socket.ampere.llm.MissingUpstreamLlmClientException]
+ *   rather than calling a provider directly (AMPR-236). Pass
+ *   [BundledUpstreamLlmClient] to opt into the direct per-provider call.
+ * @param agentScope Coroutine scope the instance's [AmpereInstance.agentFactory]
+ *   hands to the agents it builds. Defaults to a fresh `Dispatchers.Default`
+ *   scope; pass the environment's own scope to share cancellation.
  */
 @AmpereStableApi
 fun Ampere.fromEnvironment(
@@ -54,7 +64,8 @@ fun Ampere.fromEnvironment(
     knowledgeRepository: KnowledgeRepository,
     workspace: String? = null,
     memoryStore: MemoryStore? = null,
-    upstreamLlmClient: UpstreamLlmClient = BundledUpstreamLlmClient,
+    upstreamLlmClient: UpstreamLlmClient? = null,
+    agentScope: CoroutineScope = CoroutineScope(Dispatchers.Default),
 ): AmpereInstance {
     val sdkEventApi = environmentService.createEventApi("sdk-cli")
 
@@ -115,6 +126,17 @@ fun Ampere.fromEnvironment(
         workspace = workspace,
     )
 
+    // The seam that makes the injected transport actually govern agent LLM
+    // calls (AMPR-236): agents built off this instance inherit the client
+    // instead of falling through to the direct-provider default.
+    val boundAgentFactory = AgentFactory(
+        scope = agentScope,
+        ticketOrchestrator = environmentService.ticketOrchestrator,
+        eventApiFactory = { agentId -> environmentService.createEventApi(agentId) },
+        eventSerialBus = environmentService.eventBus,
+        upstreamLlmClient = upstreamLlmClient,
+    )
+
     return object : AmpereInstance {
         override val agents = agentService
         override val tickets = ticketService
@@ -124,7 +146,8 @@ fun Ampere.fromEnvironment(
         override val pricing = pricingService
         override val knowledge = knowledgeService
         override val status = statusService
-        override val upstreamLlmClient: UpstreamLlmClient = upstreamLlmClient
+        override val upstreamLlmClient: UpstreamLlmClient? = upstreamLlmClient
+        override val agentFactory: AgentFactory = boundAgentFactory
         override fun close() {
             // No-op: caller owns the lifecycle of shared resources
         }

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/api/AmpereInstance.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/api/AmpereInstance.kt
@@ -1,5 +1,6 @@
 package link.socket.ampere.api
 
+import link.socket.ampere.agents.definition.AgentFactory
 import link.socket.ampere.api.service.AgentService
 import link.socket.ampere.api.service.EventService
 import link.socket.ampere.api.service.KnowledgeService
@@ -55,16 +56,31 @@ interface AmpereInstance : AutoCloseable {
     val status: StatusService
 
     /**
-     * Runtime default for outbound LLM calls.
+     * Runtime transport for outbound LLM calls.
      *
      * Set at construction time via [Ampere.fromEnvironment] (or its
-     * platform-specific siblings). Code that constructs agents off this
-     * instance should pass this client into agent factories so every
-     * agent inherits the same upstream routing — Socket's typical pattern.
+     * platform-specific siblings) and already wired into [agentFactory], so
+     * every agent built off this instance shares it — no per-construction-site
+     * re-plumbing required.
      *
-     * Defaults to [BundledUpstreamLlmClient] (direct per-provider OpenAI
-     * call) when not overridden.
+     * `null` means no transport was supplied. Agents built in that state throw
+     * [MissingUpstreamLlmClientException][link.socket.ampere.llm.MissingUpstreamLlmClientException]
+     * on their first LLM call rather than silently egressing to a provider
+     * (AMPR-236). Pass [BundledUpstreamLlmClient] to opt into the direct
+     * per-provider call.
      */
-    val upstreamLlmClient: UpstreamLlmClient
-        get() = BundledUpstreamLlmClient
+    val upstreamLlmClient: UpstreamLlmClient?
+        get() = null
+
+    /**
+     * Agent factory bound to this instance's environment and
+     * [upstreamLlmClient].
+     *
+     * Constructing agents through this factory is what makes the injected
+     * transport govern their LLM calls. `null` on instances that carry no
+     * agent-capable environment (e.g. the stub instance); the
+     * [Ampere.fromEnvironment] path always supplies one.
+     */
+    val agentFactory: AgentFactory?
+        get() = null
 }

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/arc/AmpereRuntime.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/arc/AmpereRuntime.kt
@@ -2,6 +2,7 @@ package link.socket.ampere.domain.arc
 
 import link.socket.ampere.agents.domain.routing.CognitiveRelay
 import link.socket.ampere.agents.execution.executor.Executor
+import link.socket.ampere.llm.UpstreamLlmClient
 import link.socket.ampere.util.systemFileSystem
 import okio.FileSystem
 import okio.Path
@@ -42,6 +43,7 @@ class AmpereRuntime(
     private val maxFlowTicks: Int = 100,
     private val cognitiveRelay: CognitiveRelay? = null,
     private val executor: Executor? = null,
+    private val upstreamLlmClient: UpstreamLlmClient? = null,
 ) {
     private var chargeResult: ChargeResult? = null
     private var flowResult: FlowResult? = null
@@ -96,6 +98,7 @@ class AmpereRuntime(
             fileSystem = fileSystem,
             cognitiveRelay = cognitiveRelay,
             executor = executor,
+            upstreamLlmClient = upstreamLlmClient,
         )
         return chargePhase.execute(userGoal)
     }
@@ -107,6 +110,7 @@ class AmpereRuntime(
             fileSystem = fileSystem,
             cognitiveRelay = cognitiveRelay,
             executor = executor,
+            upstreamLlmClient = upstreamLlmClient,
         )
         return chargePhase.execute(userGoal)
     }

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/arc/ChargePhase.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/arc/ChargePhase.kt
@@ -14,6 +14,7 @@ import link.socket.ampere.agents.domain.cognition.sparks.SparkRegistry
 import link.socket.ampere.agents.domain.routing.CognitiveRelay
 import link.socket.ampere.agents.events.utils.generateUUID
 import link.socket.ampere.agents.execution.executor.Executor
+import link.socket.ampere.llm.UpstreamLlmClient
 import link.socket.ampere.util.systemFileSystem
 import okio.FileSystem
 import okio.Path
@@ -72,6 +73,7 @@ class ChargePhase(
     private val fileSystem: FileSystem = systemFileSystem,
     private val cognitiveRelay: CognitiveRelay? = null,
     private val executor: Executor? = null,
+    private val upstreamLlmClient: UpstreamLlmClient? = null,
 ) {
     suspend fun execute(userGoal: String): ChargeResult {
         require(userGoal.isNotBlank()) { "ChargePhase requires a non-empty user goal." }
@@ -87,7 +89,11 @@ class ChargePhase(
         }
 
         val agents = ArcAgentSpawner(
-            agentFactory = SparkAgentFactory(cognitiveRelay = cognitiveRelay, executor = executor),
+            agentFactory = SparkAgentFactory(
+                cognitiveRelay = cognitiveRelay,
+                executor = executor,
+                upstreamLlmClient = upstreamLlmClient,
+            ),
         ).spawn(arcConfig, projectContext)
 
         return ChargeResult(

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/llm/UpstreamLlmClient.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/llm/UpstreamLlmClient.kt
@@ -34,11 +34,15 @@ import link.socket.ampere.domain.ai.configuration.AIConfiguration
  * the natural seam for Socket's backend proxy: same request shape, same
  * response shape, just a different network endpoint.
  *
- * ## Default behavior
+ * ## No implicit default
  *
- * The bundled default ([BundledUpstreamLlmClient]) calls
- * `configuration.provider.client.chatCompletion(request)` — exactly what
- * Ampere did before this seam existed. Existing callers see no change.
+ * There is deliberately no default implementation. A configuration that
+ * reaches [link.socket.ampere.agents.domain.reasoning.AgentLLMService] without
+ * a client fails with [MissingUpstreamLlmClientException] rather than falling
+ * back to the direct-provider path — a transport is something a caller opts
+ * into, never something it inherits by omission (AMPR-236). Callers that do
+ * want the direct per-provider call name [BundledUpstreamLlmClient]
+ * explicitly.
  *
  * ## Streaming
  *
@@ -81,8 +85,10 @@ interface UpstreamLlmClient {
  * `OpenAI` client constructed by
  * [link.socket.ampere.domain.ai.provider.AIProvider].
  *
- * This is Ampere's default; using it is byte-equivalent to the pre-seam
- * direct `provider.client.chatCompletion(request)` call.
+ * Using it is byte-equivalent to the pre-seam direct
+ * `provider.client.chatCompletion(request)` call — prompt content leaves the
+ * device straight to the provider's endpoint. It is **not** wired in by
+ * default: callers that want it must name it (AMPR-236).
  */
 @AmpereStableApi
 object BundledUpstreamLlmClient : UpstreamLlmClient {
@@ -91,3 +97,28 @@ object BundledUpstreamLlmClient : UpstreamLlmClient {
         configuration: AIConfiguration,
     ): ChatCompletion = configuration.provider.client.chatCompletion(request)
 }
+
+/**
+ * Raised when an agent reaches the outbound LLM call with no
+ * [UpstreamLlmClient] configured.
+ *
+ * Ampere used to fall back to [BundledUpstreamLlmClient] here, which meant an
+ * embedded consumer that forgot to inject a transport — or injected one at a
+ * seam that was never read — silently egressed prompt content to the
+ * provider. The transport is now mandatory: supply one on
+ * [link.socket.ampere.agents.config.AgentConfiguration.upstreamLlmClient]
+ * (typically via the agent factory or
+ * [Ampere.fromEnvironment][link.socket.ampere.api.fromEnvironment]), or name
+ * [BundledUpstreamLlmClient] to opt into the direct-provider call.
+ */
+@AmpereStableApi
+class MissingUpstreamLlmClientException(
+    agentName: String?,
+) : IllegalStateException(
+    "No UpstreamLlmClient configured for " +
+        (agentName?.let { "agent '$it'" } ?: "this agent") +
+        ". Ampere no longer falls back to the direct-provider call. Pass an " +
+        "UpstreamLlmClient into the agent factory (or " +
+        "Ampere.fromEnvironment(upstreamLlmClient = ...)), or explicitly pass " +
+        "BundledUpstreamLlmClient to opt into calling the provider directly.",
+)

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/llm/UpstreamLlmClientRuntimePlumbingTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/llm/UpstreamLlmClientRuntimePlumbingTest.kt
@@ -8,8 +8,9 @@ import com.aallam.openai.api.chat.ChatRole
 import com.aallam.openai.api.model.ModelId
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
-import kotlin.test.assertSame
+import kotlin.test.assertNull
 import kotlinx.coroutines.test.runTest
 import link.socket.ampere.agents.config.AgentConfiguration
 import link.socket.ampere.agents.domain.reasoning.AgentLLMService
@@ -74,10 +75,13 @@ class UpstreamLlmClientRuntimePlumbingTest {
     }
 
     @Test
-    fun `default config carries BundledUpstreamLlmClient`() {
-        // The Wave 0 contract: callers who don't touch the new field get
-        // the pre-seam direct-call behavior preserved.
-        assertSame(BundledUpstreamLlmClient, baseConfig.upstreamLlmClient)
+    fun `default config carries no upstream client`() = runTest {
+        // AMPR-236: omitting the field no longer means "call the provider
+        // directly" — it means no transport was chosen, and the call fails.
+        assertNull(baseConfig.upstreamLlmClient)
+        assertFailsWith<MissingUpstreamLlmClientException> {
+            AgentLLMService(agentConfiguration = baseConfig).call(prompt = "no transport")
+        }
     }
 }
 

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/api/AmpereFromEnvironmentTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/api/AmpereFromEnvironmentTest.kt
@@ -11,7 +11,9 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -19,18 +21,22 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import link.socket.ampere.agents.definition.AgentType
+import link.socket.ampere.agents.definition.SparkBasedAgent
+import link.socket.ampere.agents.definition.code.CodeState
 import link.socket.ampere.agents.domain.cognition.sparks.DefaultPhaseSparkLibrary
 import link.socket.ampere.agents.domain.event.Event
 import link.socket.ampere.agents.domain.knowledge.KnowledgeRepository
 import link.socket.ampere.agents.domain.knowledge.KnowledgeRepositoryImpl
 import link.socket.ampere.agents.domain.outcome.OutcomeMemoryRepositoryImpl
+import link.socket.ampere.agents.domain.reasoning.AgentLLMService
 import link.socket.ampere.agents.environment.EnvironmentService
 import link.socket.ampere.db.Database
 import link.socket.ampere.domain.ai.configuration.AIConfiguration
 import link.socket.ampere.domain.ai.configuration.AIConfiguration_Default
 import link.socket.ampere.domain.ai.model.AIModel_Claude
 import link.socket.ampere.domain.ai.provider.AIProvider_Anthropic
-import link.socket.ampere.llm.BundledUpstreamLlmClient
+import link.socket.ampere.llm.MissingUpstreamLlmClientException
 import link.socket.ampere.llm.UpstreamLlmClient
 import link.socket.ampere.memory.MemoryStore
 import link.socket.ampere.memory.memoryStoreOf
@@ -130,7 +136,7 @@ class AmpereFromEnvironmentTest {
     }
 
     @Test
-    fun `fromEnvironment exposes the supplied upstreamLlmClient as the runtime default`() {
+    fun `fromEnvironment exposes the supplied upstreamLlmClient`() {
         val recorder = RecordingUpstream()
         val instance = Ampere.fromEnvironment(
             environmentService = environmentService,
@@ -138,24 +144,47 @@ class AmpereFromEnvironmentTest {
             upstreamLlmClient = recorder,
         )
 
-        // The runtime default on the instance is the one the caller passed.
-        // Callers constructing agents off this instance read this property
-        // and pass it into the agent factory so every agent shares the
-        // same upstream routing.
         assertSame(recorder, instance.upstreamLlmClient)
     }
 
     @Test
-    fun `fromEnvironment defaults upstreamLlmClient to BundledUpstreamLlmClient when omitted`() {
+    fun `fromEnvironment leaves upstreamLlmClient unset when omitted`() {
         val instance = Ampere.fromEnvironment(
             environmentService = environmentService,
             knowledgeRepository = knowledgeRepository,
         )
-        assertSame(BundledUpstreamLlmClient, instance.upstreamLlmClient)
+        // AMPR-236: omission no longer means "call the provider directly".
+        assertNull(instance.upstreamLlmClient)
     }
 
     @Test
-    fun `runtime default flows through SparkBasedAgent factory to AgentLLMService`() {
+    fun `injected client governs agents built off the instance factory`() {
+        val recorder = RecordingUpstream()
+        val instance = Ampere.fromEnvironment(
+            environmentService = environmentService,
+            knowledgeRepository = knowledgeRepository,
+            upstreamLlmClient = recorder,
+            agentScope = scope,
+        )
+
+        // No re-plumbing: the agent is built through the instance's own
+        // factory, which already carries the injected transport.
+        val factory = assertNotNull(instance.agentFactory)
+        val agent = factory.create<SparkBasedAgent<CodeState>>(AgentType.CODE)
+
+        assertSame(recorder, agent.agentConfiguration.upstreamLlmClient)
+
+        // Drive an LLM call via a fresh AgentLLMService built from the
+        // agent's config to verify the seam end-to-end (does not start the
+        // full PROPEL loop; that's exercised in the smoke tests).
+        val llmService = AgentLLMService(agentConfiguration = agent.agentConfiguration)
+        val response = runBlocking { llmService.call(prompt = "ping") }
+        assertEquals("from-runtime-client", response)
+        assertNotNull(recorder.lastRequest)
+    }
+
+    @Test
+    fun `injected client reaches hand-constructed agents via the instance property`() {
         val recorder = RecordingUpstream()
         val instance = Ampere.fromEnvironment(
             environmentService = environmentService,
@@ -163,11 +192,10 @@ class AmpereFromEnvironmentTest {
             upstreamLlmClient = recorder,
         )
 
-        // Stamp the instance's runtime default onto the agent — the call
-        // site Socket replicates for each agent it constructs off the
-        // shared AmpereInstance.
+        // Consumers that build agents by hand still read the instance
+        // property; this keeps that path covered alongside the factory one.
         val agent = runBlocking {
-            link.socket.ampere.agents.definition.SparkBasedAgent.Code(
+            SparkBasedAgent.Code(
                 sparkRegistry = DefaultPhaseSparkLibrary.load(),
                 aiConfiguration = AIConfiguration_Default(
                     provider = AIProvider_Anthropic,
@@ -177,19 +205,25 @@ class AmpereFromEnvironmentTest {
             )
         }
 
-        // The agent's computed AgentConfiguration must carry the runtime
-        // default forward, so AgentReasoning + AgentLLMService both see it.
         assertSame(recorder, agent.agentConfiguration.upstreamLlmClient)
+    }
 
-        // Drive an LLM call via a fresh AgentLLMService built from the
-        // agent's config to verify the seam end-to-end (does not start the
-        // full PROPEL loop; that's exercised in the smoke tests).
-        val llmService = link.socket.ampere.agents.domain.reasoning.AgentLLMService(
-            agentConfiguration = agent.agentConfiguration,
+    @Test
+    fun `agents built with no injected client fail loudly instead of calling the provider`() {
+        val instance = Ampere.fromEnvironment(
+            environmentService = environmentService,
+            knowledgeRepository = knowledgeRepository,
+            agentScope = scope,
         )
-        val response = runBlocking { llmService.call(prompt = "ping") }
-        assertEquals("from-runtime-client", response)
-        assertNotNull(recorder.lastRequest)
+
+        val factory = assertNotNull(instance.agentFactory)
+        val agent = factory.create<SparkBasedAgent<CodeState>>(AgentType.CODE)
+        assertNull(agent.agentConfiguration.upstreamLlmClient)
+
+        val llmService = AgentLLMService(agentConfiguration = agent.agentConfiguration)
+        assertFailsWith<MissingUpstreamLlmClientException> {
+            runBlocking { llmService.call(prompt = "ping") }
+        }
     }
 
     @Test

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/llm/AgentDefinitionRungThreadingTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/llm/AgentDefinitionRungThreadingTest.kt
@@ -20,6 +20,13 @@ import link.socket.ampere.domain.ai.provider.AIProvider
 
 class AgentDefinitionRungThreadingTest {
 
+    private object UnreachableUpstream : UpstreamLlmClient {
+        override suspend fun call(
+            request: com.aallam.openai.api.chat.ChatCompletionRequest,
+            configuration: AIConfiguration,
+        ) = throw NotImplementedError("These tests never get as far as the transport")
+    }
+
     private class FakeAIConfiguration : AIConfiguration {
         override val provider: AIProvider<*, *>
             get() = throw NotImplementedError()
@@ -83,6 +90,9 @@ class AgentDefinitionRungThreadingTest {
             agentDefinition = definition,
             aiConfiguration = FakeAIConfiguration(),
             cognitiveRelay = relay,
+            // A transport must be present for `call` to reach the relay at
+            // all (AMPR-236); the FakeAIConfiguration is what blows up after.
+            upstreamLlmClient = UnreachableUpstream,
         )
         val service = AgentLLMService(agentConfiguration = config)
 
@@ -104,6 +114,9 @@ class AgentDefinitionRungThreadingTest {
             agentDefinition = definition,
             aiConfiguration = FakeAIConfiguration(),
             cognitiveRelay = relay,
+            // A transport must be present for `call` to reach the relay at
+            // all (AMPR-236); the FakeAIConfiguration is what blows up after.
+            upstreamLlmClient = UnreachableUpstream,
         )
         val service = AgentLLMService(agentConfiguration = config)
 
@@ -125,6 +138,9 @@ class AgentDefinitionRungThreadingTest {
             agentDefinition = definition,
             aiConfiguration = FakeAIConfiguration(),
             cognitiveRelay = relay,
+            // A transport must be present for `call` to reach the relay at
+            // all (AMPR-236); the FakeAIConfiguration is what blows up after.
+            upstreamLlmClient = UnreachableUpstream,
         )
         val service = AgentLLMService(agentConfiguration = config)
 
@@ -146,6 +162,9 @@ class AgentDefinitionRungThreadingTest {
             agentDefinition = definition,
             aiConfiguration = FakeAIConfiguration(),
             cognitiveRelay = relay,
+            // A transport must be present for `call` to reach the relay at
+            // all (AMPR-236); the FakeAIConfiguration is what blows up after.
+            upstreamLlmClient = UnreachableUpstream,
         )
         val service = AgentLLMService(agentConfiguration = config)
 
@@ -170,6 +189,9 @@ class AgentDefinitionRungThreadingTest {
             agentDefinition = definition,
             aiConfiguration = FakeAIConfiguration(),
             cognitiveRelay = relay,
+            // A transport must be present for `call` to reach the relay at
+            // all (AMPR-236); the FakeAIConfiguration is what blows up after.
+            upstreamLlmClient = UnreachableUpstream,
         )
         val service = AgentLLMService(agentConfiguration = config)
 
@@ -194,6 +216,9 @@ class AgentDefinitionRungThreadingTest {
             agentDefinition = definition,
             aiConfiguration = FakeAIConfiguration(),
             cognitiveRelay = relay,
+            // A transport must be present for `call` to reach the relay at
+            // all (AMPR-236); the FakeAIConfiguration is what blows up after.
+            upstreamLlmClient = UnreachableUpstream,
         )
         val service = AgentLLMService(agentConfiguration = config)
 
@@ -219,6 +244,9 @@ class AgentDefinitionRungThreadingTest {
             agentDefinition = definition,
             aiConfiguration = FakeAIConfiguration(),
             cognitiveRelay = relay,
+            // A transport must be present for `call` to reach the relay at
+            // all (AMPR-236); the FakeAIConfiguration is what blows up after.
+            upstreamLlmClient = UnreachableUpstream,
         )
         val service = AgentLLMService(agentConfiguration = config)
 

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/llm/CustomLlmProviderIntegrationTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/llm/CustomLlmProviderIntegrationTest.kt
@@ -3,6 +3,7 @@ package link.socket.ampere.llm
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
@@ -187,11 +188,12 @@ class CustomLlmProviderIntegrationTest {
     }
 
     /**
-     * Test that null provider falls back to built-in (would fail without real API).
-     * This test verifies the code path, not the actual API call.
+     * With no custom provider *and* no upstream client, there is no transport
+     * to call. AMPR-236 turned that state into a hard failure instead of a
+     * silent direct-provider call.
      */
     @Test
-    fun `null provider attempts to use built-in provider`() = runTest {
+    fun `no provider and no upstream client fails instead of calling the provider`() = runTest {
         val config = AgentConfiguration(
             agentDefinition = WriteCodeAgent,
             aiConfiguration = FakeAIConfiguration(),
@@ -201,14 +203,31 @@ class CustomLlmProviderIntegrationTest {
 
         val llmService = AgentLLMService(config)
 
-        // This will throw because FakeAIConfiguration throws on provider access
-        // This verifies the fallback path is taken
-        try {
+        assertFailsWith<MissingUpstreamLlmClientException> {
             llmService.call("Test prompt")
-            assertTrue(false, "Should have thrown when accessing fake provider")
-        } catch (e: NotImplementedError) {
-            // Expected - the fake provider throws this
-            assertContains(e.message ?: "", "Provider should not be called")
         }
+    }
+
+    /**
+     * Naming [BundledUpstreamLlmClient] explicitly opts back into the direct
+     * per-provider call — verified here by the fake provider blowing up on
+     * access, which only happens if that path is taken.
+     */
+    @Test
+    fun `explicit BundledUpstreamLlmClient opts into the direct provider path`() = runTest {
+        val config = AgentConfiguration(
+            agentDefinition = WriteCodeAgent,
+            aiConfiguration = FakeAIConfiguration(),
+            cognitiveConfig = CognitiveConfig(),
+            llmProvider = null,
+            upstreamLlmClient = BundledUpstreamLlmClient,
+        )
+
+        val llmService = AgentLLMService(config)
+
+        val error = assertFailsWith<NotImplementedError> {
+            llmService.call("Test prompt")
+        }
+        assertContains(error.message ?: "", "Provider should not be called")
     }
 }


### PR DESCRIPTION
Closes #604.

`Ampere.fromEnvironment(upstreamLlmClient = X)` stored X and nothing read it — agent LLM calls resolved their transport from a separate chain that defaulted to `BundledUpstreamLlmClient`, so an embedded consumer's injected client was ignored and prompt content egressed straight to a provider. `fromEnvironment` now builds an `AgentFactory` bound to the environment and the injected client (exposed as `AmpereInstance.agentFactory`), with `AgentFactory`, `SparkAgentFactory`, `ChargePhase`, and `AmpereRuntime` all forwarding it so the arc path isn't a second dormant hole. `BundledUpstreamLlmClient` is no longer a default anywhere in the library: `upstreamLlmClient` is nullable throughout, and `AgentLLMService.call` resolves it before any relay work or telemetry and throws the new `MissingUpstreamLlmClientException` when absent, so silent egress becomes a loud failure and the direct-provider call is opt-in by naming it (which the four `ampere-cli` factory sites now do). Tests drop the `AmpereFromEnvironmentTest` re-plumbing workaround and assert the injected recorder actually receives the request, plus new coverage for the no-transport failure; `./gradlew jvmTest` (1402 tests), `:ampere-core:compileCommonMainKotlinMetadata`, and `ktlintFormat` are green.

Two things worth reviewer judgment: this is **source-breaking** — reading `AmpereInstance.upstreamLlmClient` now yields a nullable, which is what distinguishes "unspecified" from "chose the bundled path" and surfaces at build time rather than runtime, so it collapses the ticket's Option B and Option A into one minor bump; and change 3 on the ticket (narrowing the shipped provider surface) is deliberately left out as an independent follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)