### PR TITLE
AMPR-222 #586, AMPR-223 #587: Canon v1 + Link/PlugManifest primitives

### DIFF
--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/watch/presentation/EventCategorizer.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/watch/presentation/EventCategorizer.kt
@@ -9,6 +9,7 @@ import link.socket.ampere.agents.domain.event.Event
 import link.socket.ampere.agents.domain.event.FileSystemEvent
 import link.socket.ampere.agents.domain.event.GitEvent
 import link.socket.ampere.agents.domain.event.HumanInteractionEvent
+import link.socket.ampere.agents.domain.event.LinkEvent
 import link.socket.ampere.agents.domain.event.MeetingEvent
 import link.socket.ampere.agents.domain.event.MemoryEvent
 import link.socket.ampere.agents.domain.event.MessageEvent
@@ -61,6 +62,8 @@ object EventCategorizer {
         is MessageEvent.EscalationRequested,
         is HumanInteractionEvent.InputRequested,
         is PermissionDeniedEvent,
+        is LinkEvent.LinkRevoked,
+        is LinkEvent.LinkResolutionFailed,
         is TaskEvent.TaskFailed -> EventSignificance.CRITICAL
 
         // Significant events represent state changes worth noting
@@ -100,6 +103,7 @@ object EventCategorizer {
         is AgentSurfaceEvent.Requested,
         is AgentSurfaceEvent.Responded,
         is EmissionEvent.Produced,
+        is LinkEvent.LinkGranted,
         is EmissionEvent.Resolved -> EventSignificance.SIGNIFICANT
 
         // Routine cognitive operations - maintenance work
@@ -124,6 +128,7 @@ object EventCategorizer {
         is CognitivePhaseEvent,
         is SparkEvent,
         is BenchEvent.BenchRunStarted,
+        is LinkEvent.LinkResolved,
         is BenchEvent.ProbeGraded -> EventSignificance.ROUTINE
 
         is RoutingEvent.RouteFallback,

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/renderer/EventRenderer.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/renderer/EventRenderer.kt
@@ -22,6 +22,7 @@ import link.socket.ampere.agents.domain.event.EventSource
 import link.socket.ampere.agents.domain.event.FileSystemEvent
 import link.socket.ampere.agents.domain.event.GitEvent
 import link.socket.ampere.agents.domain.event.HumanInteractionEvent
+import link.socket.ampere.agents.domain.event.LinkEvent
 import link.socket.ampere.agents.domain.event.MeetingEvent
 import link.socket.ampere.agents.domain.event.MemoryEvent
 import link.socket.ampere.agents.domain.event.MessageEvent
@@ -177,6 +178,11 @@ class EventRenderer(
             is EmissionEvent.Resolved -> "📡" to blue
             // Bench (eval) lifecycle events
             is BenchEvent -> "🧪" to cyan
+            // Link lifecycle: the wire a Plug runs over
+            is LinkEvent.LinkResolved -> "🔌" to green
+            is LinkEvent.LinkGranted -> "🔌" to blue
+            is LinkEvent.LinkRevoked -> "🔌" to red
+            is LinkEvent.LinkResolutionFailed -> "🔌" to red
         }
     }
 

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/EventRegistry.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/EventRegistry.kt
@@ -111,6 +111,12 @@ object EventRegistry {
         // PermissionEvent types
         PermissionDeniedEvent.EVENT_TYPE,
 
+        // LinkEvent types
+        LinkEvent.LinkGranted.EVENT_TYPE,
+        LinkEvent.LinkRevoked.EVENT_TYPE,
+        LinkEvent.LinkResolved.EVENT_TYPE,
+        LinkEvent.LinkResolutionFailed.EVENT_TYPE,
+
         // AgentSurfaceEvent types
         AgentSurfaceEvent.Requested.EVENT_TYPE,
         AgentSurfaceEvent.Responded.EVENT_TYPE,

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/LinkEvent.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/LinkEvent.kt
@@ -1,0 +1,163 @@
+package link.socket.ampere.agents.domain.event
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import link.socket.ampere.agents.domain.Urgency
+import link.socket.ampere.link.LinkId
+import link.socket.ampere.link.LinkResolutionFailure
+import link.socket.ampere.link.RevocationScope
+import link.socket.ampere.link.Transport
+
+/**
+ * Lifecycle of a Link: granted, resolved for a Plug, resolution refused,
+ * revoked.
+ *
+ * These exist so the trace can answer "which wire carried this, and who
+ * authorized it" without asking the Plug. Resolution failures in particular
+ * must reach the bus — a Plug that quietly does nothing because its Link was
+ * revoked is the exact opacity the glass brain exists to prevent.
+ *
+ * Lives in `agents.domain.event` because [Event] is sealed: every subtype has
+ * to share its module and package.
+ */
+@Serializable
+sealed interface LinkEvent : Event {
+
+    val linkId: LinkId
+
+    /** A Plug was granted use of a Link. */
+    @Serializable
+    @SerialName("LinkEvent.LinkGranted")
+    data class LinkGranted(
+        override val eventId: EventId,
+        override val timestamp: Instant,
+        override val eventSource: EventSource,
+        override val urgency: Urgency = Urgency.MEDIUM,
+        override val linkId: LinkId,
+        val plugId: String,
+        val transport: Transport,
+    ) : LinkEvent {
+
+        override val eventType: EventType = EVENT_TYPE
+
+        override fun getSummary(
+            formatUrgency: (Urgency) -> String,
+            formatSource: (EventSource) -> String,
+        ): String = buildString {
+            append("Link granted: ${linkId.value} to plug=$plugId")
+            append(" transport=$transport")
+            append(" ${formatUrgency(urgency)}")
+            append(" from ${formatSource(eventSource)}")
+        }
+
+        companion object {
+            const val EVENT_TYPE: EventType = "LinkGranted"
+        }
+    }
+
+    /**
+     * A Link, its credential, or one Plug's grant on it was revoked.
+     *
+     * [affectedPlugIds] is the cascade: a Link-level revocation names every
+     * Plug that loses access, so the consent surface can show the true blast
+     * radius rather than one row.
+     */
+    @Serializable
+    @SerialName("LinkEvent.LinkRevoked")
+    data class LinkRevoked(
+        override val eventId: EventId,
+        override val timestamp: Instant,
+        override val eventSource: EventSource,
+        override val urgency: Urgency = Urgency.HIGH,
+        override val linkId: LinkId,
+        val scope: RevocationScope,
+        val affectedPlugIds: List<String> = emptyList(),
+    ) : LinkEvent {
+
+        override val eventType: EventType = EVENT_TYPE
+
+        override fun getSummary(
+            formatUrgency: (Urgency) -> String,
+            formatSource: (EventSource) -> String,
+        ): String = buildString {
+            append("Link revoked: ${linkId.value} scope=$scope")
+            append(" affects=${affectedPlugIds.size} plug(s)")
+            append(" ${formatUrgency(urgency)}")
+            append(" from ${formatSource(eventSource)}")
+        }
+
+        companion object {
+            const val EVENT_TYPE: EventType = "LinkRevoked"
+        }
+    }
+
+    /** A Plug's Link requirement was satisfied at Arc execution time. */
+    @Serializable
+    @SerialName("LinkEvent.LinkResolved")
+    data class LinkResolved(
+        override val eventId: EventId,
+        override val timestamp: Instant,
+        override val eventSource: EventSource,
+        override val urgency: Urgency = Urgency.LOW,
+        override val linkId: LinkId,
+        val plugId: String,
+        val requirementName: String,
+        val transport: Transport,
+    ) : LinkEvent {
+
+        override val eventType: EventType = EVENT_TYPE
+
+        override fun getSummary(
+            formatUrgency: (Urgency) -> String,
+            formatSource: (EventSource) -> String,
+        ): String = buildString {
+            append("Link resolved: $requirementName -> ${linkId.value}")
+            append(" plug=$plugId transport=$transport")
+            append(" ${formatUrgency(urgency)}")
+            append(" from ${formatSource(eventSource)}")
+        }
+
+        companion object {
+            const val EVENT_TYPE: EventType = "LinkResolved"
+        }
+    }
+
+    /**
+     * A Plug's Link requirement could not be satisfied.
+     *
+     * [linkId] is the Link that came closest — the empty [LinkId] when nothing
+     * of the required transport was available at all.
+     */
+    @Serializable
+    @SerialName("LinkEvent.LinkResolutionFailed")
+    data class LinkResolutionFailed(
+        override val eventId: EventId,
+        override val timestamp: Instant,
+        override val eventSource: EventSource,
+        override val urgency: Urgency = Urgency.HIGH,
+        override val linkId: LinkId,
+        val plugId: String,
+        val failure: LinkResolutionFailure,
+    ) : LinkEvent {
+
+        override val eventType: EventType = EVENT_TYPE
+
+        override fun getSummary(
+            formatUrgency: (Urgency) -> String,
+            formatSource: (EventSource) -> String,
+        ): String = buildString {
+            append("Link resolution failed: ${failure.requirementName}")
+            append(" plug=$plugId reason=${failure::class.simpleName}")
+            append(" ${formatUrgency(urgency)}")
+            append(" from ${formatSource(eventSource)}")
+        }
+
+        companion object {
+            const val EVENT_TYPE: EventType = "LinkResolutionFailed"
+
+            /** Stands in for "no candidate Link existed". */
+            val NO_LINK: LinkId = LinkId("")
+        }
+    }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/utils/SignificanceAwareEventLogger.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/utils/SignificanceAwareEventLogger.kt
@@ -13,6 +13,7 @@ import link.socket.ampere.agents.domain.event.EventType
 import link.socket.ampere.agents.domain.event.FileSystemEvent
 import link.socket.ampere.agents.domain.event.GitEvent
 import link.socket.ampere.agents.domain.event.HumanInteractionEvent
+import link.socket.ampere.agents.domain.event.LinkEvent
 import link.socket.ampere.agents.domain.event.MeetingEvent
 import link.socket.ampere.agents.domain.event.MemoryEvent
 import link.socket.ampere.agents.domain.event.MessageEvent
@@ -184,6 +185,13 @@ class SignificanceAwareEventLogger(
         is BenchEvent.BenchRunStarted -> EventSignificance.ROUTINE
         is BenchEvent.ProbeGraded -> EventSignificance.ROUTINE
         is BenchEvent.BenchRunCompleted -> EventSignificance.SIGNIFICANT
+
+        // Link lifecycle - resolution is routine, but anything that changes or
+        // denies a Plug's access to a wire is a consent-visible fact.
+        is LinkEvent.LinkResolved -> EventSignificance.ROUTINE
+        is LinkEvent.LinkGranted -> EventSignificance.SIGNIFICANT
+        is LinkEvent.LinkRevoked -> EventSignificance.CRITICAL
+        is LinkEvent.LinkResolutionFailed -> EventSignificance.CRITICAL
     }
 
     private fun formatUrgency(urgency: Urgency): String = when (urgency) {

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/CanonBinding.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/CanonBinding.kt
@@ -1,0 +1,106 @@
+package link.socket.ampere.canon
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Declarative platform binding for a [CanonType].
+ *
+ * Bindings are *data*, not annotations. Kotlin annotations cannot be read
+ * reflectively on Kotlin/Native and `kotlin-reflect` is JVM-only, so an
+ * annotation-based binding would be unavailable on exactly the platform that
+ * needs it most. Modelling bindings as values also makes them serializable, so
+ * a trace records which projection produced an entity.
+ *
+ * The canon type is the superset; a binding is a *projection* of it. Everything
+ * the projection drops is named in [lossyFields] and is what the
+ * preserve-and-merge write-back contract
+ * ([link.socket.ampere.canon.adapter.CanonAdapter]) exists to protect.
+ */
+@Serializable
+data class CanonBinding(
+    val apple: AppleSchemaBinding? = null,
+    val android: AndroidSchemaBinding = AndroidSchemaBinding.PendingSdkVerification,
+    val lossyFields: List<String> = emptyList(),
+) {
+    companion object {
+        /** A canon type with no platform binding at all — Ring 3 service types. */
+        val UNBOUND: CanonBinding = CanonBinding(
+            apple = null,
+            android = AndroidSchemaBinding.None,
+        )
+    }
+}
+
+/**
+ * How a canon type reaches Apple's cross-app vocabulary.
+ *
+ * Two shapes exist because Apple ships two mechanisms: named entity schemas
+ * grouped into domains (`mail.message`), and free-floating *system value types*
+ * usable through `IntentValueRepresentation` / `Transferable` with no schema at
+ * all (`IntentPerson`, `CLPlacemark`).
+ */
+@Serializable
+sealed interface AppleSchemaBinding {
+
+    /** The SDK identifier, e.g. `MailMessageEntity` or `IntentPerson`. */
+    val identifier: String
+
+    /**
+     * A system-defined entity schema, addressed as `domain.accessor` — the
+     * `appleSchema = .mail.message` form from the ticket.
+     */
+    @Serializable
+    @SerialName("apple_schema.entity")
+    data class EntitySchema(
+        val domain: String,
+        val accessor: String,
+        override val identifier: String,
+    ) : AppleSchemaBinding {
+        /** The `.mail.message` address, rendered. */
+        val qualifiedName: String get() = "$domain.$accessor"
+    }
+
+    /**
+     * An Apple system value type. These carry no domain because they are not
+     * scoped to one — any intent parameter can be one.
+     */
+    @Serializable
+    @SerialName("apple_schema.system_value")
+    data class SystemValueType(
+        override val identifier: String,
+    ) : AppleSchemaBinding
+}
+
+/**
+ * How a canon type reaches Android's AppFunctions vocabulary.
+ *
+ * [PendingSdkVerification] is the honest default and the current state of every
+ * canon type. `androidx.appfunctions` is not on this repo's classpath, so
+ * `AppFunctionSchemaDefinition` could not be enumerated during recon — see the
+ * "Recon caveats" section of `.context/issue-586-domain-type-canon-v1.md`.
+ * Modelling the gap as a variant rather than a `null` keeps "we have not looked"
+ * distinguishable from "we looked and there is nothing".
+ */
+@Serializable
+sealed interface AndroidSchemaBinding {
+
+    /** Verified: Android defines no predefined schema for this type. */
+    @Serializable
+    @SerialName("android_schema.none")
+    data object None : AndroidSchemaBinding
+
+    /** Not yet checked against the AppFunctions SDK. */
+    @Serializable
+    @SerialName("android_schema.unverified")
+    data object PendingSdkVerification : AndroidSchemaBinding
+
+    /** A predefined `AppFunctionSchemaDefinition` this canon type binds to. */
+    @Serializable
+    @SerialName("android_schema.predefined")
+    data class Predefined(
+        val category: String,
+        val schemaName: String,
+        val schemaVersion: Int,
+    ) : AndroidSchemaBinding
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/CanonEntity.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/CanonEntity.kt
@@ -1,0 +1,35 @@
+package link.socket.ampere.canon
+
+import kotlinx.serialization.Serializable
+
+/**
+ * A provenance-carrying instance of a [CanonType].
+ *
+ * The hierarchy is sealed, so a renderer, adapter registry, or Arc step can
+ * `when` over it exhaustively — the same property that makes `AgentSurface`
+ * safely renderable per platform. There is deliberately no `Custom(payload)`
+ * escape hatch: the escape hatch is [CanonProvenance.nativePayload], which is
+ * *attached to a typed entity* rather than replacing one.
+ *
+ * Ring 1 entities are modelled in full. Ring 2 and Ring 3 entities carry the
+ * minimum needed for `PlugManifest` emits/consumes declarations and for
+ * provenance to flow; their field sets fill in as each platform integration
+ * lands.
+ *
+ * Every implementation is `@Serializable` with a stable `@SerialName`. These
+ * types cross the wire and land in traces — a renamed discriminator breaks
+ * `PlaybackRelay` replay of every trace already recorded.
+ */
+@Serializable
+sealed interface CanonEntity {
+
+    val canonId: CanonId
+
+    /** Always the constant matching this type. Never varies per instance. */
+    val canonType: CanonType
+
+    val provenance: CanonProvenance
+
+    /** The ring this entity's type belongs to. Convenience over [canonType]. */
+    val ring: CanonRing get() = canonType.ring
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/CanonProvenance.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/CanonProvenance.kt
@@ -1,0 +1,73 @@
+package link.socket.ampere.canon
+
+import kotlin.jvm.JvmInline
+import kotlinx.datetime.Instant
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
+import link.socket.ampere.link.LinkId
+
+/** Ampere-scoped identity for a canon entity. Stable across projections. */
+@JvmInline
+@Serializable
+value class CanonId(val value: String)
+
+/**
+ * The opaque handle back to wherever an entity came from.
+ *
+ * This is the canon's escape hatch and its audit trail in one type. It is
+ * *opaque by design*: Ampere never parses [nativeId], because the moment it
+ * does, a provider's identifier format becomes a contract Ampere has to honour.
+ *
+ * [linkId] ties canon provenance to Link provenance so the two cannot disagree.
+ * A trace that says "this CalendarEvent came from Link `google-oauth-1`" and a
+ * consent ledger that says the same are then reading the same fact, not two
+ * facts that happen to line up.
+ *
+ * @property linkId The Link the entity travelled over.
+ * @property sourceSystem Coarse origin label, e.g. `apple.mail`, `mcp:notion`.
+ *   Used for grouping and display; never for dispatch.
+ * @property nativeId The provider's own identifier, verbatim.
+ * @property etag Optimistic-concurrency token when the provider offers one.
+ *   Write-back can use it to detect that the native object moved under it.
+ */
+@Serializable
+data class SourceHandle(
+    val linkId: LinkId,
+    val sourceSystem: String,
+    val nativeId: String,
+    val etag: String? = null,
+)
+
+/**
+ * The lossless native object, carried alongside the lossy canon projection.
+ *
+ * Held as a [JsonObject] rather than a string so preserve-and-merge write-back
+ * can be a structural field overlay rather than a per-adapter re-parse. That
+ * choice is what lets the merge live in the SPI instead of in every adapter.
+ *
+ * @property schema The native shape's identifier, e.g. `MailMessageEntity`.
+ *   Checked against the adapter's declared schema before any write.
+ * @property fields The native object's fields, verbatim.
+ */
+@Serializable
+data class NativePayload(
+    val schema: String,
+    val fields: JsonObject,
+)
+
+/**
+ * Everything a canon entity knows about its own origin.
+ *
+ * Every canon entity carries one. An entity with no provenance is not a canon
+ * entity — it is a guess.
+ *
+ * @property nativePayload Null when the adapter could not or would not carry
+ *   the native object (large binaries, provider policy). A null payload does
+ *   not disable write-back; it forces the adapter to re-fetch before merging.
+ */
+@Serializable
+data class CanonProvenance(
+    val sourceHandle: SourceHandle,
+    val observedAt: Instant,
+    val nativePayload: NativePayload? = null,
+)

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/CanonRing.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/CanonRing.kt
@@ -1,0 +1,49 @@
+package link.socket.ampere.canon
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Where a canon type's provenance comes from.
+ *
+ * A ring is a statement about *binding provenance*, not about support level. A
+ * [PLATFORM] type is every bit as usable by an Arc as an [INTERCHANGE] one; what
+ * the ring records is whether the type can travel through the operating system's
+ * own cross-app registry, or whether Ampere is the only thing that knows it is a
+ * canonical noun.
+ *
+ * Ring membership was settled by the SDK pass documented in
+ * `.context/issue-586-domain-type-canon-v1.md`. Six of the originally proposed
+ * Ring 1 types demoted because the shipped Apple assistant-schema catalog is
+ * documents-and-content shaped: it has no calendar, messages, reminders, notes,
+ * alarm, or music/video noun.
+ */
+@Serializable
+enum class CanonRing {
+
+    /**
+     * Maps to an Apple assistant-schema entity or an Apple system value type
+     * without lossy contortion, so the entity can cross app boundaries through
+     * the platform's own registry.
+     */
+    @SerialName("interchange")
+    INTERCHANGE,
+
+    /**
+     * Reachable only through a native framework (EventKit, HealthKit, AlarmKit,
+     * …). Outside the assistant vocabulary, inside the OS.
+     */
+    @SerialName("platform")
+    PLATFORM,
+
+    /**
+     * Arrives through a non-OS transport — `Mcp`, `OAuthRest`, `FolderMount`,
+     * or `Cli`.
+     *
+     * The original ticket wrote this as "Mcp/OAuthRest only". Recon widened it:
+     * a Note read out of an Obsidian vault arrives over `FolderMount` and was
+     * otherwise unhoused by the taxonomy.
+     */
+    @SerialName("service")
+    SERVICE,
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/CanonRing1Entities.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/CanonRing1Entities.kt
@@ -1,0 +1,264 @@
+package link.socket.ampere.canon
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Ring 1 — Interchange. Modelled in full.
+ *
+ * Each type maps to an Apple assistant-schema entity or system value type
+ * without contortion; see [CanonType] for the binding and for the fields each
+ * projection drops.
+ */
+
+/**
+ * A human, addressable by handle.
+ *
+ * Apple's `IntentPerson` is handle-plus-display-name shaped, so relationships,
+ * organisation, and alternate handles live on the canon type but not in the
+ * projection. A photos-scoped recognized person projects here too, with
+ * [recognizedIn] set — an Arc asking "who is in this photo" and one asking "who
+ * did I email" want the same type.
+ */
+@Serializable
+@SerialName("canon.person")
+data class CanonPerson(
+    override val canonId: CanonId,
+    override val provenance: CanonProvenance,
+    val displayName: String,
+    val handles: List<PersonHandle> = emptyList(),
+    val organization: String? = null,
+    val jobTitle: String? = null,
+    val recognizedIn: RecognitionContext? = null,
+) : CanonEntity {
+    override val canonType: CanonType get() = CanonType.PERSON
+}
+
+@Serializable
+data class PersonHandle(
+    val kind: PersonHandleKind,
+    val value: String,
+    val isPrimary: Boolean = false,
+)
+
+@Serializable
+enum class PersonHandleKind {
+    @SerialName("email")
+    EMAIL,
+
+    @SerialName("phone")
+    PHONE,
+
+    @SerialName("service")
+    SERVICE,
+}
+
+@Serializable
+enum class RecognitionContext {
+    @SerialName("photos")
+    PHOTOS,
+}
+
+/** A delivered email. Its MIME structure and raw headers stay in the payload. */
+@Serializable
+@SerialName("canon.email_message")
+data class CanonEmailMessage(
+    override val canonId: CanonId,
+    override val provenance: CanonProvenance,
+    val subject: String,
+    val from: CanonPerson?,
+    val to: List<CanonPerson> = emptyList(),
+    val cc: List<CanonPerson> = emptyList(),
+    val bodyText: String? = null,
+    val sentAt: Instant? = null,
+    val isRead: Boolean = false,
+    val mailboxId: CanonId? = null,
+) : CanonEntity {
+    override val canonType: CanonType get() = CanonType.EMAIL_MESSAGE
+}
+
+/** An unsent email. Distinct from [CanonEmailMessage] because Apple's registry is. */
+@Serializable
+@SerialName("canon.email_draft")
+data class CanonEmailDraft(
+    override val canonId: CanonId,
+    override val provenance: CanonProvenance,
+    val subject: String,
+    val to: List<CanonPerson> = emptyList(),
+    val cc: List<CanonPerson> = emptyList(),
+    val bodyText: String? = null,
+    val lastEditedAt: Instant? = null,
+) : CanonEntity {
+    override val canonType: CanonType get() = CanonType.EMAIL_DRAFT
+}
+
+/**
+ * A mail container.
+ *
+ * The lossy axis is real and worth naming: a Gmail label and an IMAP folder
+ * both project here, and they are not the same thing. The provider's own
+ * semantics survive only in the native payload.
+ */
+@Serializable
+@SerialName("canon.mailbox")
+data class CanonMailbox(
+    override val canonId: CanonId,
+    override val provenance: CanonProvenance,
+    val name: String,
+    val accountId: String? = null,
+    val unreadCount: Int? = null,
+) : CanonEntity {
+    override val canonType: CanonType get() = CanonType.MAILBOX
+}
+
+/** A photo or video asset. The edit stack never crosses the projection. */
+@Serializable
+@SerialName("canon.photo")
+data class CanonPhoto(
+    override val canonId: CanonId,
+    override val provenance: CanonProvenance,
+    val capturedAt: Instant? = null,
+    val widthPixels: Int? = null,
+    val heightPixels: Int? = null,
+    val isFavorite: Boolean = false,
+    val place: CanonPlace? = null,
+    val recognizedPeople: List<CanonPerson> = emptyList(),
+) : CanonEntity {
+    override val canonType: CanonType get() = CanonType.PHOTO
+}
+
+@Serializable
+@SerialName("canon.photo_album")
+data class CanonPhotoAlbum(
+    override val canonId: CanonId,
+    override val provenance: CanonProvenance,
+    val title: String,
+    val assetCount: Int? = null,
+    val isShared: Boolean = false,
+) : CanonEntity {
+    override val canonType: CanonType get() = CanonType.PHOTO_ALBUM
+}
+
+/**
+ * A document of any kind.
+ *
+ * One canon type covers Apple's five document domains. [kind] is the
+ * discriminator that makes the fan-out survivable: drop it, and a projection
+ * cannot find its way back to the right schema on write-back.
+ */
+@Serializable
+@SerialName("canon.document")
+data class CanonDocument(
+    override val canonId: CanonId,
+    override val provenance: CanonProvenance,
+    val title: String,
+    val kind: DocumentKind,
+    val mimeType: String? = null,
+    val sizeBytes: Long? = null,
+    val modifiedAt: Instant? = null,
+    val plainText: String? = null,
+) : CanonEntity {
+    override val canonType: CanonType get() = CanonType.DOCUMENT
+}
+
+/**
+ * Which Apple document domain a [CanonDocument] projects to.
+ *
+ * [FILE] is the fallback for anything with no richer domain — it binds to
+ * `files.file` alone.
+ */
+@Serializable
+enum class DocumentKind(val appleDomain: String) {
+    @SerialName("file")
+    FILE("files"),
+
+    @SerialName("word_processor")
+    WORD_PROCESSOR("wordProcessor"),
+
+    @SerialName("spreadsheet")
+    SPREADSHEET("spreadsheet"),
+
+    @SerialName("presentation")
+    PRESENTATION("presentation"),
+
+    @SerialName("reader")
+    READER("reader"),
+
+    @SerialName("whiteboard")
+    WHITEBOARD("whiteboard"),
+}
+
+/**
+ * A location.
+ *
+ * `CLPlacemark` is a postal address plus a coordinate, so venue identity,
+ * hours, and category are canon-only. That is exactly the gap a Ring 3 places
+ * service (Google Places, Foursquare) fills over an `OAuthRest` Link.
+ */
+@Serializable
+@SerialName("canon.place")
+data class CanonPlace(
+    override val canonId: CanonId,
+    override val provenance: CanonProvenance,
+    val name: String? = null,
+    val latitude: Double? = null,
+    val longitude: Double? = null,
+    val street: String? = null,
+    val locality: String? = null,
+    val administrativeArea: String? = null,
+    val postalCode: String? = null,
+    val country: String? = null,
+) : CanonEntity {
+    override val canonType: CanonType get() = CanonType.PLACE
+}
+
+@Serializable
+@SerialName("canon.journal_entry")
+data class CanonJournalEntry(
+    override val canonId: CanonId,
+    override val provenance: CanonProvenance,
+    val title: String? = null,
+    val bodyText: String? = null,
+    val createdAt: Instant? = null,
+    val place: CanonPlace? = null,
+) : CanonEntity {
+    override val canonType: CanonType get() = CanonType.JOURNAL_ENTRY
+}
+
+@Serializable
+@SerialName("canon.book")
+data class CanonBook(
+    override val canonId: CanonId,
+    override val provenance: CanonProvenance,
+    val title: String,
+    val authors: List<String> = emptyList(),
+    val isAudiobook: Boolean = false,
+    val progressFraction: Double? = null,
+) : CanonEntity {
+    override val canonType: CanonType get() = CanonType.BOOK
+}
+
+@Serializable
+@SerialName("canon.web_bookmark")
+data class CanonWebBookmark(
+    override val canonId: CanonId,
+    override val provenance: CanonProvenance,
+    val title: String,
+    val url: String,
+    val createdAt: Instant? = null,
+) : CanonEntity {
+    override val canonType: CanonType get() = CanonType.WEB_BOOKMARK
+}
+
+@Serializable
+@SerialName("canon.browser_tab")
+data class CanonBrowserTab(
+    override val canonId: CanonId,
+    override val provenance: CanonProvenance,
+    val title: String,
+    val url: String,
+    val isActive: Boolean = false,
+) : CanonEntity {
+    override val canonType: CanonType get() = CanonType.BROWSER_TAB
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/CanonRing2Entities.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/CanonRing2Entities.kt
@@ -1,0 +1,159 @@
+package link.socket.ampere.canon
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Ring 2 — Platform. Typed declarations with minimal properties.
+ *
+ * These reach Ampere through a native framework, not through the assistant
+ * vocabulary. They carry enough shape for `PlugManifest` emits/consumes
+ * declarations and for provenance to flow end-to-end; richer fields land with
+ * each platform integration.
+ *
+ * `CalendarEvent`, `Reminder`, `Alarm`, and `MediaItem` were Ring 1 candidates.
+ * They are here because the shipped Apple catalog has no calendar, reminders,
+ * clock, or music/video noun — not because they matter less. A Ring 2 type is
+ * fully usable by an Arc; what the ring records is that it does not travel
+ * through Apple's cross-app registry.
+ */
+
+@Serializable
+@SerialName("canon.calendar_event")
+data class CanonCalendarEvent(
+    override val canonId: CanonId,
+    override val provenance: CanonProvenance,
+    val title: String,
+    val startsAt: Instant,
+    val endsAt: Instant? = null,
+    val isAllDay: Boolean = false,
+    val calendarId: String? = null,
+    val place: CanonPlace? = null,
+    val attendees: List<CanonPerson> = emptyList(),
+) : CanonEntity {
+    override val canonType: CanonType get() = CanonType.CALENDAR_EVENT
+}
+
+@Serializable
+@SerialName("canon.reminder")
+data class CanonReminder(
+    override val canonId: CanonId,
+    override val provenance: CanonProvenance,
+    val title: String,
+    val dueAt: Instant? = null,
+    val isCompleted: Boolean = false,
+    val listId: String? = null,
+) : CanonEntity {
+    override val canonType: CanonType get() = CanonType.REMINDER
+}
+
+@Serializable
+@SerialName("canon.alarm")
+data class CanonAlarm(
+    override val canonId: CanonId,
+    override val provenance: CanonProvenance,
+    val label: String? = null,
+    val firesAt: Instant? = null,
+    val isEnabled: Boolean = true,
+) : CanonEntity {
+    override val canonType: CanonType get() = CanonType.ALARM
+}
+
+@Serializable
+@SerialName("canon.media_item")
+data class CanonMediaItem(
+    override val canonId: CanonId,
+    override val provenance: CanonProvenance,
+    val title: String,
+    val artist: String? = null,
+    val durationSeconds: Long? = null,
+) : CanonEntity {
+    override val canonType: CanonType get() = CanonType.MEDIA_ITEM
+}
+
+@Serializable
+@SerialName("canon.health_sample")
+data class CanonHealthSample(
+    override val canonId: CanonId,
+    override val provenance: CanonProvenance,
+    val quantityType: String,
+    val value: Double,
+    val unit: String,
+    val recordedAt: Instant,
+) : CanonEntity {
+    override val canonType: CanonType get() = CanonType.HEALTH_SAMPLE
+}
+
+@Serializable
+@SerialName("canon.home_accessory")
+data class CanonHomeAccessory(
+    override val canonId: CanonId,
+    override val provenance: CanonProvenance,
+    val name: String,
+    val room: String? = null,
+    val isReachable: Boolean = true,
+) : CanonEntity {
+    override val canonType: CanonType get() = CanonType.HOME_ACCESSORY
+}
+
+@Serializable
+@SerialName("canon.transaction")
+data class CanonTransaction(
+    override val canonId: CanonId,
+    override val provenance: CanonProvenance,
+    val amountMinorUnits: Long,
+    val currencyCode: String,
+    val merchantName: String? = null,
+    val postedAt: Instant? = null,
+) : CanonEntity {
+    override val canonType: CanonType get() = CanonType.TRANSACTION
+}
+
+@Serializable
+@SerialName("canon.pass")
+data class CanonPass(
+    override val canonId: CanonId,
+    override val provenance: CanonProvenance,
+    val description: String,
+    val organizationName: String? = null,
+    val expiresAt: Instant? = null,
+) : CanonEntity {
+    override val canonType: CanonType get() = CanonType.PASS
+}
+
+@Serializable
+@SerialName("canon.weather_forecast")
+data class CanonWeatherForecast(
+    override val canonId: CanonId,
+    override val provenance: CanonProvenance,
+    val place: CanonPlace?,
+    val validAt: Instant,
+    val temperatureCelsius: Double? = null,
+    val conditionSummary: String? = null,
+) : CanonEntity {
+    override val canonType: CanonType get() = CanonType.WEATHER_FORECAST
+}
+
+@Serializable
+@SerialName("canon.bluetooth_peripheral")
+data class CanonBluetoothPeripheral(
+    override val canonId: CanonId,
+    override val provenance: CanonProvenance,
+    val name: String? = null,
+    val isConnected: Boolean = false,
+) : CanonEntity {
+    override val canonType: CanonType get() = CanonType.BLUETOOTH_PERIPHERAL
+}
+
+@Serializable
+@SerialName("canon.motion_sample")
+data class CanonMotionSample(
+    override val canonId: CanonId,
+    override val provenance: CanonProvenance,
+    val activity: String,
+    val confidence: Double? = null,
+    val recordedAt: Instant,
+) : CanonEntity {
+    override val canonType: CanonType get() = CanonType.MOTION_SAMPLE
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/CanonRing3Entities.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/CanonRing3Entities.kt
@@ -1,0 +1,96 @@
+package link.socket.ampere.canon
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Ring 3 — Service. Typed declarations with minimal properties.
+ *
+ * These arrive over a non-OS Link: `Mcp`, `OAuthRest`, `FolderMount`, or `Cli`.
+ * They have no platform binding at all, which makes the native payload the only
+ * lossless record — Ring 3 adapters that write should be especially careful to
+ * merge rather than replace.
+ *
+ * `Message` and `Note` were Ring 1 candidates. Neither has an Apple
+ * assistant-schema domain, and on iOS neither has a public read API, so their
+ * realistic sources are service Links (Slack, Twilio, Notion) and folder mounts
+ * (an Obsidian vault). Housing `Note` here is why Ring 3's definition widened
+ * from "Mcp/OAuthRest only" to "any non-OS Link".
+ */
+
+@Serializable
+@SerialName("canon.message")
+data class CanonMessage(
+    override val canonId: CanonId,
+    override val provenance: CanonProvenance,
+    val bodyText: String,
+    val sender: CanonPerson? = null,
+    val conversationId: String? = null,
+    val sentAt: Instant? = null,
+) : CanonEntity {
+    override val canonType: CanonType get() = CanonType.MESSAGE
+}
+
+@Serializable
+@SerialName("canon.note")
+data class CanonNote(
+    override val canonId: CanonId,
+    override val provenance: CanonProvenance,
+    val title: String? = null,
+    val bodyText: String? = null,
+    val tags: List<String> = emptyList(),
+    val modifiedAt: Instant? = null,
+) : CanonEntity {
+    override val canonType: CanonType get() = CanonType.NOTE
+}
+
+@Serializable
+@SerialName("canon.ride")
+data class CanonRide(
+    override val canonId: CanonId,
+    override val provenance: CanonProvenance,
+    val status: String,
+    val pickup: CanonPlace? = null,
+    val dropoff: CanonPlace? = null,
+    val requestedAt: Instant? = null,
+) : CanonEntity {
+    override val canonType: CanonType get() = CanonType.RIDE
+}
+
+@Serializable
+@SerialName("canon.order")
+data class CanonOrder(
+    override val canonId: CanonId,
+    override val provenance: CanonProvenance,
+    val status: String,
+    val merchantName: String? = null,
+    val placedAt: Instant? = null,
+) : CanonEntity {
+    override val canonType: CanonType get() = CanonType.ORDER
+}
+
+@Serializable
+@SerialName("canon.delivery")
+data class CanonDelivery(
+    override val canonId: CanonId,
+    override val provenance: CanonProvenance,
+    val status: String,
+    val carrier: String? = null,
+    val expectedAt: Instant? = null,
+    val destination: CanonPlace? = null,
+) : CanonEntity {
+    override val canonType: CanonType get() = CanonType.DELIVERY
+}
+
+@Serializable
+@SerialName("canon.third_party_playlist")
+data class CanonThirdPartyPlaylist(
+    override val canonId: CanonId,
+    override val provenance: CanonProvenance,
+    val title: String,
+    val trackCount: Int? = null,
+    val ownerDisplayName: String? = null,
+) : CanonEntity {
+    override val canonType: CanonType get() = CanonType.THIRD_PARTY_PLAYLIST
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/CanonType.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/CanonType.kt
@@ -1,0 +1,333 @@
+package link.socket.ampere.canon
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * The closed canon of domain types Ampere understands — v1.
+ *
+ * The canon is an **intermediate representation**, not a convenience DTO set.
+ * Apps are frontends and backends; Arc logic compiles against the IR, and one
+ * Arc runs on iOS and Android because it targets the IR rather than either
+ * platform's vocabulary. Where Apple built a canonical registry the IR partly
+ * duplicates it and integration is a mapping table; where Android built none,
+ * the IR *is* the missing canon. An agent guesses two tasks are the same kind
+ * of thing; Ampere knows it, with provenance.
+ *
+ * **The set is closed for v1.** Extensibility is a post-launch decision. The
+ * escape hatch is not a new canon member — it is
+ * [CanonProvenance.nativePayload], which carries the lossless native object
+ * alongside the projection.
+ *
+ * Each member declares its [ring] and its [binding]. Both were settled by the
+ * SDK pass recorded in `.context/issue-586-domain-type-canon-v1.md`; the
+ * `wireName` is a stable serialization contract — renaming one breaks
+ * `PlaybackRelay` replay of any trace that already carries it.
+ */
+@Serializable
+enum class CanonType(
+    val wireName: String,
+    val ring: CanonRing,
+    val binding: CanonBinding,
+) {
+
+    // ---------------------------------------------------------------------
+    // Ring 1 — Interchange
+    // ---------------------------------------------------------------------
+
+    @SerialName("person")
+    PERSON(
+        wireName = "person",
+        ring = CanonRing.INTERCHANGE,
+        binding = CanonBinding(
+            apple = AppleSchemaBinding.SystemValueType("IntentPerson"),
+            lossyFields = listOf("relationships", "alternateHandles", "organization", "jobTitle"),
+        ),
+    ),
+
+    @SerialName("email_message")
+    EMAIL_MESSAGE(
+        wireName = "email_message",
+        ring = CanonRing.INTERCHANGE,
+        binding = CanonBinding(
+            apple = AppleSchemaBinding.EntitySchema("mail", "message", "MailMessageEntity"),
+            lossyFields = listOf(
+                "mimeStructure",
+                "rawHeaders",
+                "threadIdentifiers",
+                "providerLabels",
+                "attachmentBytes",
+            ),
+        ),
+    ),
+
+    @SerialName("email_draft")
+    EMAIL_DRAFT(
+        wireName = "email_draft",
+        ring = CanonRing.INTERCHANGE,
+        binding = CanonBinding(
+            apple = AppleSchemaBinding.EntitySchema("mail", "draft", "MailDraftEntity"),
+            lossyFields = listOf("mimeStructure", "rawHeaders", "sendState", "attachmentBytes"),
+        ),
+    ),
+
+    @SerialName("mailbox")
+    MAILBOX(
+        wireName = "mailbox",
+        ring = CanonRing.INTERCHANGE,
+        binding = CanonBinding(
+            apple = AppleSchemaBinding.EntitySchema("mail", "mailbox", "MailboxEntity"),
+            lossyFields = listOf("providerFolderSemantics", "syncState"),
+        ),
+    ),
+
+    @SerialName("photo")
+    PHOTO(
+        wireName = "photo",
+        ring = CanonRing.INTERCHANGE,
+        binding = CanonBinding(
+            apple = AppleSchemaBinding.EntitySchema("photos", "asset", "PhotoEntity"),
+            lossyFields = listOf("editStack", "adjustmentData", "livePhotoPair", "burstIdentity", "originalRendition"),
+        ),
+    ),
+
+    @SerialName("photo_album")
+    PHOTO_ALBUM(
+        wireName = "photo_album",
+        ring = CanonRing.INTERCHANGE,
+        binding = CanonBinding(
+            apple = AppleSchemaBinding.EntitySchema("photos", "album", "PhotoAlbumEntity"),
+            lossyFields = listOf("smartAlbumPredicate", "sharedParticipants"),
+        ),
+    ),
+
+    /**
+     * One canon type fans out to five Apple document domains — `wordProcessor`,
+     * `reader`, `spreadsheet`, `presentation`, `whiteboard` — plus `files.file`.
+     * The fan-out *is* the lossy axis: a projection that drops
+     * `CanonDocument.kind` cannot round-trip to the right Apple schema.
+     */
+    @SerialName("document")
+    DOCUMENT(
+        wireName = "document",
+        ring = CanonRing.INTERCHANGE,
+        binding = CanonBinding(
+            apple = AppleSchemaBinding.EntitySchema("files", "file", "FileEntity"),
+            lossyFields = listOf("documentKindSpecifics", "pageGeometry", "templateIdentity", "revisionHistory"),
+        ),
+    ),
+
+    @SerialName("place")
+    PLACE(
+        wireName = "place",
+        ring = CanonRing.INTERCHANGE,
+        binding = CanonBinding(
+            apple = AppleSchemaBinding.SystemValueType("CLPlacemark"),
+            lossyFields = listOf("venueIdentity", "openingHours", "category", "rating", "providerPlaceId"),
+        ),
+    ),
+
+    @SerialName("journal_entry")
+    JOURNAL_ENTRY(
+        wireName = "journal_entry",
+        ring = CanonRing.INTERCHANGE,
+        binding = CanonBinding(
+            apple = AppleSchemaBinding.EntitySchema("journal", "entry", "JournalEntity"),
+            lossyFields = listOf("attachedMedia", "suggestionMetadata"),
+        ),
+    ),
+
+    @SerialName("book")
+    BOOK(
+        wireName = "book",
+        ring = CanonRing.INTERCHANGE,
+        binding = CanonBinding(
+            apple = AppleSchemaBinding.EntitySchema("books", "book", "BookEntity"),
+            lossyFields = listOf("readingPosition", "annotations", "assetIdentity"),
+        ),
+    ),
+
+    @SerialName("web_bookmark")
+    WEB_BOOKMARK(
+        wireName = "web_bookmark",
+        ring = CanonRing.INTERCHANGE,
+        binding = CanonBinding(
+            apple = AppleSchemaBinding.EntitySchema("browser", "bookmark", "BookmarkEntity"),
+            lossyFields = listOf("folderHierarchy", "syncState", "favicon"),
+        ),
+    ),
+
+    @SerialName("browser_tab")
+    BROWSER_TAB(
+        wireName = "browser_tab",
+        ring = CanonRing.INTERCHANGE,
+        binding = CanonBinding(
+            apple = AppleSchemaBinding.EntitySchema("browser", "tab", "TabEntity"),
+            lossyFields = listOf("backForwardHistory", "windowMembership", "scrollState"),
+        ),
+    ),
+
+    // ---------------------------------------------------------------------
+    // Ring 2 — Platform
+    //
+    // CALENDAR_EVENT, REMINDER, ALARM and MEDIA_ITEM were Ring 1 candidates.
+    // They demoted because the shipped assistant-schema catalog has no
+    // calendar, reminders, clock or music/video domain — `Calendar.Recurrence-
+    // Rule` and `Date` bind *fields*, never the entity.
+    // ---------------------------------------------------------------------
+
+    @SerialName("calendar_event")
+    CALENDAR_EVENT(
+        wireName = "calendar_event",
+        ring = CanonRing.PLATFORM,
+        binding = CanonBinding(
+            apple = null,
+            lossyFields = listOf("eventKitAttendeeStatus", "alarms", "structuredLocation"),
+        ),
+    ),
+
+    @SerialName("reminder")
+    REMINDER(
+        wireName = "reminder",
+        ring = CanonRing.PLATFORM,
+        binding = CanonBinding(apple = null, lossyFields = listOf("eventKitAlarms", "recurrenceRules")),
+    ),
+
+    @SerialName("alarm")
+    ALARM(
+        wireName = "alarm",
+        ring = CanonRing.PLATFORM,
+        binding = CanonBinding(
+            apple = null,
+            lossyFields = listOf("alarmKitPresentation", "snoozeConfiguration"),
+        ),
+    ),
+
+    @SerialName("media_item")
+    MEDIA_ITEM(
+        wireName = "media_item",
+        ring = CanonRing.PLATFORM,
+        binding = CanonBinding(
+            apple = null,
+            lossyFields = listOf("playbackState", "libraryIdentity", "drmAssetHandle"),
+        ),
+    ),
+
+    @SerialName("health_sample")
+    HEALTH_SAMPLE(
+        wireName = "health_sample",
+        ring = CanonRing.PLATFORM,
+        binding = CanonBinding(apple = null, lossyFields = listOf("healthKitMetadata", "deviceProvenance")),
+    ),
+
+    @SerialName("home_accessory")
+    HOME_ACCESSORY(
+        wireName = "home_accessory",
+        ring = CanonRing.PLATFORM,
+        binding = CanonBinding(apple = null, lossyFields = listOf("serviceGraph", "roomAssignment")),
+    ),
+
+    @SerialName("transaction")
+    TRANSACTION(
+        wireName = "transaction",
+        ring = CanonRing.PLATFORM,
+        binding = CanonBinding(
+            apple = AppleSchemaBinding.SystemValueType("IntentCurrencyAmount"),
+            lossyFields = listOf("merchantIdentity", "financeKitAccount", "paymentMethod"),
+        ),
+    ),
+
+    @SerialName("pass")
+    PASS(
+        wireName = "pass",
+        ring = CanonRing.PLATFORM,
+        binding = CanonBinding(apple = null, lossyFields = listOf("passKitFields", "barcodePayload")),
+    ),
+
+    @SerialName("weather_forecast")
+    WEATHER_FORECAST(
+        wireName = "weather_forecast",
+        ring = CanonRing.PLATFORM,
+        binding = CanonBinding(
+            apple = AppleSchemaBinding.SystemValueType("Measurement"),
+            lossyFields = listOf("weatherKitAttribution", "hourlyBreakdown"),
+        ),
+    ),
+
+    @SerialName("bluetooth_peripheral")
+    BLUETOOTH_PERIPHERAL(
+        wireName = "bluetooth_peripheral",
+        ring = CanonRing.PLATFORM,
+        binding = CanonBinding(apple = null, lossyFields = listOf("gattServices", "advertisementData")),
+    ),
+
+    @SerialName("motion_sample")
+    MOTION_SAMPLE(
+        wireName = "motion_sample",
+        ring = CanonRing.PLATFORM,
+        binding = CanonBinding(apple = null, lossyFields = listOf("coreMotionRawVectors")),
+    ),
+
+    // ---------------------------------------------------------------------
+    // Ring 3 — Service
+    //
+    // MESSAGE and NOTE were Ring 1 candidates. Neither has an assistant-schema
+    // domain, and neither has a public iOS read API; their real sources are
+    // service Links (Slack, Twilio, Notion) and folder mounts (Obsidian).
+    // ---------------------------------------------------------------------
+
+    @SerialName("message")
+    MESSAGE(
+        wireName = "message",
+        ring = CanonRing.SERVICE,
+        binding = CanonBinding.UNBOUND,
+    ),
+
+    @SerialName("note")
+    NOTE(
+        wireName = "note",
+        ring = CanonRing.SERVICE,
+        binding = CanonBinding.UNBOUND,
+    ),
+
+    @SerialName("ride")
+    RIDE(
+        wireName = "ride",
+        ring = CanonRing.SERVICE,
+        binding = CanonBinding.UNBOUND,
+    ),
+
+    @SerialName("order")
+    ORDER(
+        wireName = "order",
+        ring = CanonRing.SERVICE,
+        binding = CanonBinding.UNBOUND,
+    ),
+
+    @SerialName("delivery")
+    DELIVERY(
+        wireName = "delivery",
+        ring = CanonRing.SERVICE,
+        binding = CanonBinding.UNBOUND,
+    ),
+
+    @SerialName("third_party_playlist")
+    THIRD_PARTY_PLAYLIST(
+        wireName = "third_party_playlist",
+        ring = CanonRing.SERVICE,
+        binding = CanonBinding.UNBOUND,
+    ),
+    ;
+
+    companion object {
+
+        /** Lookup by the stable [wireName]. Returns null rather than throwing. */
+        fun fromWireName(wireName: String): CanonType? = byWireName[wireName]
+
+        fun inRing(ring: CanonRing): Set<CanonType> = entries.filter { it.ring == ring }.toSet()
+
+        private val byWireName: Map<String, CanonType> by lazy {
+            entries.associateBy { it.wireName }
+        }
+    }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/adapter/CanonAdapter.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/adapter/CanonAdapter.kt
@@ -1,0 +1,193 @@
+package link.socket.ampere.canon.adapter
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import link.socket.ampere.canon.CanonEntity
+import link.socket.ampere.canon.CanonProvenance
+import link.socket.ampere.canon.CanonType
+import link.socket.ampere.canon.NativePayload
+import link.socket.ampere.canon.SourceHandle
+
+/**
+ * The transport-agnostic contract between a canon type and one native source.
+ *
+ * One adapter shape serves every wire: an AppFunction call, an MCP tool, a
+ * bespoke iOS integration, a Shortcuts/URI route, a direct API. Arc logic never
+ * learns which one carried the data — that is the Link's business, not the
+ * canon's.
+ *
+ * ## Preserve-and-merge is structural, not remembered
+ *
+ * A canon projection is lossy by design, so a naive write-back is destructive:
+ * writing a projected entity back to its source clobbers every native field the
+ * projection dropped. The usual fix — "adapters must remember to merge" — fails
+ * the first time someone writes an adapter in a hurry.
+ *
+ * So this SPI does not expose a write path that *can* clobber. Subclasses
+ * implement three narrow operations:
+ *
+ *  - [projectFields] — native fields in, canon entity out.
+ *  - [canonFields] — canon entity in, *only the fields this adapter owns* out.
+ *  - [writeNative] — a terminal write of an already-merged payload.
+ *
+ * [writeBack] is the only write entry point, it is final, and it always routes
+ * through [mergeForWriteBack]: resolve the native object, overlay the canon
+ * deltas onto it, hand the merged result to [writeNative]. An adapter author
+ * cannot write an unmerged entity without deleting a member of this class.
+ *
+ * The [ownedFields] declaration is the second half of that guarantee. If
+ * [canonFields] returns a key outside it, the merge fails with
+ * [CanonConversionFailure.UnownedFieldWrite] rather than quietly overwriting a
+ * native field nobody accounted for.
+ */
+abstract class CanonAdapter<E : CanonEntity> {
+
+    /** The canon type this adapter projects to. */
+    abstract val canonType: CanonType
+
+    /**
+     * The native shape identifier this adapter reads and writes, e.g.
+     * `MailMessageEntity`. Checked on every projection and every merge.
+     */
+    abstract val nativeSchema: String
+
+    /**
+     * Exactly the native field names this adapter's canon projection covers.
+     *
+     * Everything outside this set is preserved verbatim through write-back.
+     * Under-declaring is safe (the field is simply never written);
+     * over-declaring is not, because it re-opens the clobber path.
+     */
+    abstract val ownedFields: Set<String>
+
+    /**
+     * Native → canon. The provenance is built for you and cannot be omitted.
+     *
+     * @param fields The native object's fields, already schema-checked.
+     * @param provenance Carries the source handle, the observation time, and
+     *   the lossless native payload when the caller asked to retain it.
+     */
+    protected abstract fun projectFields(
+        fields: JsonObject,
+        provenance: CanonProvenance,
+    ): Result<E>
+
+    /**
+     * Canon → native deltas. Return only the fields named in [ownedFields].
+     *
+     * This is a *delta*, not a document: omit a key and the native value
+     * survives write-back untouched.
+     */
+    protected abstract fun canonFields(entity: E): Result<Map<String, JsonElement>>
+
+    /**
+     * Re-read the native object. Called only when the entity carries no native
+     * payload of its own, so the merge still has a base to overlay onto.
+     */
+    protected abstract suspend fun fetchNative(handle: SourceHandle): Result<NativePayload>
+
+    /** Terminal write. The payload handed in is already merged. */
+    protected abstract suspend fun writeNative(
+        handle: SourceHandle,
+        merged: NativePayload,
+    ): Result<Unit>
+
+    /**
+     * Native → canon, with the schema check and provenance wiring applied.
+     *
+     * @param carryNativePayload Retain the lossless native object on the
+     *   entity. Default on: it makes write-back a pure merge with no re-fetch.
+     *   Turn it off for payloads too large to carry, at the cost of a
+     *   [fetchNative] round trip on write.
+     */
+    fun project(
+        payload: NativePayload,
+        handle: SourceHandle,
+        observedAt: Instant,
+        carryNativePayload: Boolean = true,
+    ): Result<E> {
+        if (payload.schema != nativeSchema) {
+            return canonFailure(
+                CanonConversionFailure.SchemaMismatch(
+                    canonType = canonType,
+                    expectedSchema = nativeSchema,
+                    actualSchema = payload.schema,
+                ),
+            )
+        }
+
+        return projectFields(
+            fields = payload.fields,
+            provenance = CanonProvenance(
+                sourceHandle = handle,
+                observedAt = observedAt,
+                nativePayload = if (carryNativePayload) payload else null,
+            ),
+        )
+    }
+
+    /**
+     * Produce the payload [writeBack] would write, without writing it.
+     *
+     * Exposed so callers can inspect or diff a pending write — and so tests can
+     * assert field preservation without a live transport.
+     */
+    suspend fun mergeForWriteBack(entity: E): Result<NativePayload> {
+        val handle = entity.provenance.sourceHandle
+
+        val base = entity.provenance.nativePayload
+            ?: fetchNative(handle).getOrElse { error ->
+                return canonFailure(
+                    CanonConversionFailure.SourceUnavailable(
+                        canonType = canonType,
+                        nativeId = handle.nativeId,
+                        reason = error.message ?: error::class.simpleName.orEmpty(),
+                    ),
+                )
+            }
+
+        if (base.schema != nativeSchema) {
+            return canonFailure(
+                CanonConversionFailure.SchemaMismatch(
+                    canonType = canonType,
+                    expectedSchema = nativeSchema,
+                    actualSchema = base.schema,
+                ),
+            )
+        }
+
+        val deltas = canonFields(entity).getOrElse { return Result.failure(it) }
+
+        deltas.keys.firstOrNull { it !in ownedFields }?.let { stray ->
+            return canonFailure(
+                CanonConversionFailure.UnownedFieldWrite(
+                    canonType = canonType,
+                    field = stray,
+                    ownedFields = ownedFields,
+                ),
+            )
+        }
+
+        // The overlay is the whole preserve-and-merge guarantee: every native
+        // key the projection dropped is still in `base.fields` and survives.
+        return Result.success(
+            NativePayload(
+                schema = base.schema,
+                fields = JsonObject(base.fields + deltas),
+            ),
+        )
+    }
+
+    /**
+     * The only write path. Merges, then writes.
+     *
+     * Final by Kotlin default — overriding it would be the one way to
+     * reintroduce the destructive write this SPI exists to prevent.
+     */
+    suspend fun writeBack(entity: E): Result<Unit> =
+        mergeForWriteBack(entity).fold(
+            onSuccess = { merged -> writeNative(entity.provenance.sourceHandle, merged) },
+            onFailure = { Result.failure(it) },
+        )
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/adapter/CanonConversionFailure.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/adapter/CanonConversionFailure.kt
@@ -1,0 +1,83 @@
+package link.socket.ampere.canon.adapter
+
+import link.socket.ampere.canon.CanonType
+
+/**
+ * Why a canon projection or write-back could not complete.
+ *
+ * The list is closed; callers can rely on `when` being exhaustive.
+ */
+sealed interface CanonConversionFailure {
+
+    /**
+     * The native payload is not the shape this adapter handles.
+     *
+     * Caught before any write, because merging fields from one native schema
+     * into another is how a projection silently corrupts a record.
+     */
+    data class SchemaMismatch(
+        val canonType: CanonType,
+        val expectedSchema: String,
+        val actualSchema: String,
+    ) : CanonConversionFailure
+
+    /** A field the canon type requires was absent from the native payload. */
+    data class MissingRequiredField(
+        val canonType: CanonType,
+        val field: String,
+        val schema: String,
+    ) : CanonConversionFailure
+
+    /** A field was present but could not be read as the canon type expects. */
+    data class MalformedField(
+        val canonType: CanonType,
+        val field: String,
+        val reason: String,
+    ) : CanonConversionFailure
+
+    /**
+     * The adapter tried to write a native field it does not own.
+     *
+     * This is the guard that keeps preserve-and-merge honest: an adapter whose
+     * `canonFields` reaches outside its declared `ownedFields` is widening its
+     * write footprint past what the canon projection can account for, which is
+     * how "merge" degrades back into "clobber".
+     */
+    data class UnownedFieldWrite(
+        val canonType: CanonType,
+        val field: String,
+        val ownedFields: Set<String>,
+    ) : CanonConversionFailure
+
+    /**
+     * The native object could not be resolved for merging — the entity carried
+     * no native payload and the re-fetch failed.
+     */
+    data class SourceUnavailable(
+        val canonType: CanonType,
+        val nativeId: String,
+        val reason: String,
+    ) : CanonConversionFailure
+
+    /** The transport rejected the merged write. */
+    data class WriteRejected(
+        val canonType: CanonType,
+        val nativeId: String,
+        val reason: String,
+    ) : CanonConversionFailure
+}
+
+/**
+ * Carries a [CanonConversionFailure] through [Result.failure].
+ *
+ * Conversions are Result-typed; this exception exists so the typed failure
+ * survives the `kotlin.Result` boundary the rest of the repo uses, not so that
+ * anyone throws it.
+ */
+class CanonConversionException(
+    val failure: CanonConversionFailure,
+) : Exception("Canon conversion failed: $failure")
+
+/** Shorthand for the Result-typed failure path. */
+fun <T> canonFailure(failure: CanonConversionFailure): Result<T> =
+    Result.failure(CanonConversionException(failure))

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/link/Link.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/link/Link.kt
@@ -1,0 +1,86 @@
+package link.socket.ampere.link
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import link.socket.ampere.canon.CanonType
+
+/**
+ * The binding between a capability and its concrete medium — Socket's data-link
+ * layer.
+ *
+ * A Link is *shared*: one Google OAuth Link serves the Calendar Plug and the
+ * Gmail Plug. The user authenticates once; each Plug records its own grant
+ * against the same [id], and revoking the Link cascades to every grant that
+ * references it. That is why a Link carries no plug identity — it would be a
+ * lie about the one-to-many relationship.
+ *
+ * @property transport The wire. See [Transport] for why capability is
+ *   per-platform rather than per-enum-member.
+ * @property direction Read, write, or both. Enforced at resolution.
+ * @property egress Where data physically goes. The consent surface reads this.
+ * @property scope Exactly which canon types may flow through this wire.
+ *   Narrower than the transport can technically carry, on purpose.
+ * @property credentialRef A *reference*. Raw credentials never live in this
+ *   type, never reach a trace, and never cross the bus.
+ */
+@Serializable
+data class Link(
+    val id: LinkId,
+    val transport: Transport,
+    val direction: LinkDirection,
+    val egress: EgressClass,
+    val scope: Set<CanonType> = emptySet(),
+    val credentialRef: CredentialRef? = null,
+    val revokedAt: Instant? = null,
+) {
+    /** A revoked Link resolves for nobody, regardless of standing grants. */
+    val isRevoked: Boolean get() = revokedAt != null
+}
+
+/**
+ * Where data travels when it leaves the Plug.
+ *
+ * This is the fact a consent sheet is really asking about. "Read your
+ * calendar" means something very different for [OnDevice] EventKit than for a
+ * [ThirdParty] sync service, and the type keeps the distinction from collapsing
+ * into prose.
+ */
+@Serializable
+sealed interface EgressClass {
+
+    /** Never leaves the device. */
+    @Serializable
+    @SerialName("egress.on_device")
+    data object OnDevice : EgressClass
+
+    /** Reaches a Socket-operated service and nothing else. */
+    @Serializable
+    @SerialName("egress.first_party")
+    data object FirstParty : EgressClass
+
+    /** Reaches a named external provider. */
+    @Serializable
+    @SerialName("egress.third_party")
+    data class ThirdParty(val provider: String) : EgressClass
+}
+
+/**
+ * A pointer to credential material held by the platform keychain.
+ *
+ * Storage is platform-side and out of scope here; this type exists so a Link
+ * can *name* its credentials without ever carrying them. If a future change
+ * puts a token string on this class, the Link becomes a secret and every trace
+ * that recorded one becomes a breach.
+ *
+ * @property revokedAt Set when the credential itself is revoked, as distinct
+ *   from a Plug's grant being revoked. Both surface as
+ *   [LinkResolutionFailure.RevokedCredential]; they differ in blast radius.
+ */
+@Serializable
+data class CredentialRef(
+    val keychainAlias: String,
+    val revokedAt: Instant? = null,
+) {
+    val isRevoked: Boolean get() = revokedAt != null
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/link/LinkDirection.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/link/LinkDirection.kt
@@ -1,0 +1,61 @@
+package link.socket.ampere.link
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Which way data may flow over a [Link].
+ *
+ * **Links are directional endpoints, not sources.** APNS is a write-only sink;
+ * a folder mount is read/write; Calendar is read-mostly. Modelling direction on
+ * the Link is what makes "this Plug tried to Perceive through a push channel" a
+ * resolution-time failure instead of a runtime surprise.
+ */
+@Serializable
+enum class LinkDirection {
+
+    @SerialName("read")
+    READ,
+
+    @SerialName("write")
+    WRITE,
+
+    @SerialName("read_write")
+    READ_WRITE,
+    ;
+
+    val canRead: Boolean get() = this == READ || this == READ_WRITE
+
+    val canWrite: Boolean get() = this == WRITE || this == READ_WRITE
+
+    fun permits(operation: LinkOperation): Boolean = when (operation) {
+        LinkOperation.PERCEIVE -> canRead
+        LinkOperation.EXECUTE -> canWrite
+    }
+
+    /**
+     * Whether a Link with this direction can stand in for one a requirement
+     * asked for. `READ_WRITE` satisfies everything; `READ` satisfies only
+     * `READ`.
+     */
+    fun satisfies(required: LinkDirection): Boolean =
+        (!required.canRead || canRead) && (!required.canWrite || canWrite)
+}
+
+/**
+ * The two halves of the chassis boundary, named as directions.
+ *
+ * Perceive pulls; Execute pushes. Push-shaped sources (HealthKit observers,
+ * location updates, APNS delivery) are an adapter concern — the transport
+ * buffers into the bus and the chassis presents buffered emissions as discrete
+ * observations at the next Perceive.
+ */
+@Serializable
+enum class LinkOperation {
+
+    @SerialName("perceive")
+    PERCEIVE,
+
+    @SerialName("execute")
+    EXECUTE,
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/link/LinkGrants.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/link/LinkGrants.kt
@@ -1,0 +1,49 @@
+package link.socket.ampere.link
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.Serializable
+
+/**
+ * One Plug's standing on one Link.
+ *
+ * Grants are per-(Plug, Link), not per-Plug, because Links are shared. Granting
+ * Gmail access to a Google Link says nothing about Calendar's access to the
+ * same Link, and revoking one must not revoke the other.
+ *
+ * The consent ledger itself is Socket-side and out of scope; this is the
+ * Ampere-side shape that ledger has to be able to express.
+ */
+@Serializable
+data class LinkGrant(
+    val plugId: String,
+    val linkId: LinkId,
+    val grantedAt: Instant,
+    val revokedAt: Instant? = null,
+) {
+    val isRevoked: Boolean get() = revokedAt != null
+}
+
+/**
+ * Every grant a single Plug holds.
+ *
+ * **Revoked beats granted**, matching the invariant
+ * [link.socket.ampere.plug.permission.PlugPermissionGate] already enforces for
+ * permissions. A Link that appears in both sets is revoked.
+ */
+@Serializable
+data class LinkGrants(
+    val plugId: String,
+    val grants: List<LinkGrant> = emptyList(),
+) {
+    private val byLink: Map<LinkId, LinkGrant> = grants.associateBy { it.linkId }
+
+    fun grantFor(linkId: LinkId): LinkGrant? = byLink[linkId]
+
+    fun isGranted(linkId: LinkId): Boolean = byLink[linkId]?.isRevoked == false
+
+    fun isRevoked(linkId: LinkId): Boolean = byLink[linkId]?.isRevoked == true
+
+    companion object {
+        fun empty(plugId: String): LinkGrants = LinkGrants(plugId)
+    }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/link/LinkId.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/link/LinkId.kt
@@ -1,0 +1,17 @@
+package link.socket.ampere.link
+
+import kotlin.jvm.JvmInline
+import kotlinx.serialization.Serializable
+
+/**
+ * Identifier for a [Link] — the user-bound authorization scope a capability's
+ * credentials and traffic hang off.
+ *
+ * One Link is shared across Plugs: a single Google OAuth Link serves both the
+ * Calendar and Gmail Plugs. The user authenticates once; each Plug records its
+ * own grant against the same [LinkId], and revoking the Link cascades to every
+ * grant that references it.
+ */
+@JvmInline
+@Serializable
+value class LinkId(val value: String)

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/link/LinkRequirement.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/link/LinkRequirement.kt
@@ -1,0 +1,66 @@
+package link.socket.ampere.link
+
+import kotlinx.serialization.Serializable
+import link.socket.ampere.canon.CanonType
+
+/**
+ * What a Plug declares it needs, before any concrete Link exists.
+ *
+ * A requirement names a *kind* of wire, not an instance. Resolution to a
+ * concrete [Link] happens at Arc execution time, which is what keeps the Arc
+ * manifest lean: an Arc references Plugs, never Link bindings.
+ *
+ * @property name A symbolic handle the Plug uses to refer to this wire, e.g.
+ *   `"calendar"`. Mirrors [link.socket.ampere.plug.McpServerDependency.name].
+ *   Required because a Plug can need two Links of the same [transport].
+ * @property minimumScope The canon types that must be permitted for the Plug to
+ *   function. A Link may allow more; it may not allow less.
+ * @property role Which side the Plug acts as. Checked against the transport's
+ *   per-platform capability, so a consumer-role requirement fails on iOS for a
+ *   transport that has no iOS consumer path.
+ * @property optional A requirement the Plug can run without. It never blocks
+ *   resolution: with no candidate it reports [LinkResolution.Skipped], and a
+ *   candidate that fails a check is still announced on the bus but does not
+ *   fail the Plug.
+ */
+@Serializable
+data class LinkRequirement(
+    val name: String,
+    val transport: Transport,
+    val direction: LinkDirection,
+    val minimumScope: Set<CanonType> = emptySet(),
+    val role: TransportRole = TransportRole.CONSUMER,
+    val optional: Boolean = false,
+)
+
+/**
+ * The outcome of matching one [LinkRequirement] against the Links available to
+ * a Plug.
+ */
+sealed interface LinkResolution {
+
+    val requirement: LinkRequirement
+
+    data class Resolved(
+        override val requirement: LinkRequirement,
+        val link: Link,
+    ) : LinkResolution
+
+    data class Failed(
+        override val requirement: LinkRequirement,
+        val failure: LinkResolutionFailure,
+    ) : LinkResolution
+
+    /** An [LinkRequirement.optional] requirement with no matching Link. */
+    data class Skipped(
+        override val requirement: LinkRequirement,
+    ) : LinkResolution
+}
+
+/** Every resolved Link for a Plug, keyed by [LinkRequirement.name]. */
+data class ResolvedLinks(
+    val plugId: String,
+    val byRequirement: Map<String, Link>,
+) {
+    operator fun get(requirementName: String): Link? = byRequirement[requirementName]
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/link/LinkResolutionFailure.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/link/LinkResolutionFailure.kt
@@ -1,0 +1,122 @@
+package link.socket.ampere.link
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import link.socket.ampere.canon.CanonType
+
+/**
+ * Why a [LinkRequirement] could not be satisfied.
+ *
+ * The list is closed; callers can rely on `when` being exhaustive. Every
+ * variant is `@Serializable` because these travel on the bus as
+ * [link.socket.ampere.agents.domain.event.LinkEvent.LinkResolutionFailed] —
+ * a resolution that fails silently is worse than one that fails loudly.
+ */
+@Serializable
+sealed interface LinkResolutionFailure {
+
+    val requirementName: String
+
+    /** No Link of the required transport is available and granted to this Plug. */
+    @Serializable
+    @SerialName("link_failure.missing")
+    data class MissingLink(
+        override val requirementName: String,
+        val transport: Transport,
+        val direction: LinkDirection,
+    ) : LinkResolutionFailure
+
+    /**
+     * A Link exists but points the wrong way — the classic case being a Plug
+     * asking to Perceive through a write-only push sink.
+     */
+    @Serializable
+    @SerialName("link_failure.direction")
+    data class DirectionViolation(
+        override val requirementName: String,
+        val linkId: LinkId,
+        val required: LinkDirection,
+        val actual: LinkDirection,
+    ) : LinkResolutionFailure
+
+    /** A Link exists but is not permitted to carry every canon type required. */
+    @Serializable
+    @SerialName("link_failure.scope")
+    data class ScopeViolation(
+        override val requirementName: String,
+        val linkId: LinkId,
+        val missingScope: Set<CanonType>,
+    ) : LinkResolutionFailure
+
+    /**
+     * The Link, its credential, or this Plug's grant on it has been revoked.
+     *
+     * [scope][RevocationScope] distinguishes the blast radius: a revoked Link
+     * takes every Plug with it, a revoked grant takes only this one.
+     */
+    @Serializable
+    @SerialName("link_failure.revoked")
+    data class RevokedCredential(
+        override val requirementName: String,
+        val linkId: LinkId,
+        val scope: RevocationScope,
+    ) : LinkResolutionFailure
+
+    /**
+     * The transport cannot act in the requested role on this platform.
+     *
+     * The motivating case: a Plug requiring an `AppFunction` Link in
+     * `CONSUMER` role resolves on Android and fails here on iOS, because iOS
+     * has no AppIntent-consumer path — cross-app orchestration belongs to Siri.
+     */
+    @Serializable
+    @SerialName("link_failure.transport_unsupported")
+    data class TransportUnsupported(
+        override val requirementName: String,
+        val linkId: LinkId,
+        val transport: Transport,
+        val platform: PlatformTarget,
+        val role: TransportRole,
+    ) : LinkResolutionFailure
+}
+
+/** How far a revocation reaches. */
+@Serializable
+enum class RevocationScope {
+
+    /** The Link itself is gone. Cascades to every Plug that used it. */
+    @SerialName("link")
+    LINK,
+
+    /** The stored credential is gone. Cascades to every Plug that used it. */
+    @SerialName("credential")
+    CREDENTIAL,
+
+    /** Only this Plug's grant on the Link was revoked. */
+    @SerialName("plug_grant")
+    PLUG_GRANT,
+}
+
+/**
+ * Carries one or more [LinkResolutionFailure]s across a `kotlin.Result`
+ * boundary.
+ *
+ * Resolution never throws on its own; this type exists so a typed failure
+ * survives `Result.failure`, matching how the rest of the repo handles fallible
+ * service calls.
+ */
+class LinkResolutionException(
+    val failures: List<LinkResolutionFailure>,
+) : Exception("Link resolution failed: $failures")
+
+/**
+ * A [LinkId] was referenced that no [Link] exists for.
+ *
+ * Distinct from [LinkResolutionFailure.MissingLink], which means "no Link of
+ * the required *kind* is available to this Plug". This one means the caller
+ * named a Link that is not in the store at all — a programming error or a
+ * dangling reference, not a consent outcome.
+ */
+class UnknownLinkException(
+    val linkId: LinkId,
+) : Exception("No Link registered for id '${linkId.value}'")

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/link/LinkResolutionGate.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/link/LinkResolutionGate.kt
@@ -1,0 +1,143 @@
+package link.socket.ampere.link
+
+/**
+ * Deterministic, side-effect-free matching of a [LinkRequirement] against the
+ * Links a Plug could use.
+ *
+ * Modelled on [link.socket.ampere.plug.permission.PlugPermissionGate]: pure,
+ * never throws, returns a sealed result. Keeping it separate from
+ * [LinkResolutionService] means the whole matching policy is testable without a
+ * database, a bus, or a coroutine.
+ *
+ * ## Check precedence
+ *
+ * A candidate Link is evaluated in a fixed order, and the first failing check
+ * wins:
+ *
+ * 1. **Revocation** — revoked beats everything, mirroring the permission gate's
+ *    "revoked beats granted" invariant. A revoked Link must not produce a
+ *    scope-shaped error message that sends a reader looking in the wrong place.
+ * 2. **Transport capability** — if the platform cannot drive this transport in
+ *    the requested role, no amount of direction or scope makes it work.
+ * 3. **Direction** — the Link points the wrong way.
+ * 4. **Scope** — the Link points the right way but may not carry these types.
+ *
+ * When several Links share a transport, every candidate is tried and the first
+ * one that passes wins. If none passes, the failure reported is the *first
+ * candidate's*, in list order, so the result is deterministic.
+ */
+object LinkResolutionGate {
+
+    fun resolve(
+        requirement: LinkRequirement,
+        candidates: List<Link>,
+        grants: LinkGrants,
+        platform: PlatformTarget,
+    ): LinkResolution {
+        val matchingTransport = candidates.filter { it.transport == requirement.transport }
+
+        // A Link the Plug was never granted is not a candidate at all — it is
+        // invisible, not rejected. Revoked grants stay visible so the failure
+        // can say "revoked" rather than "missing".
+        val visible = matchingTransport.filter { link ->
+            grants.grantFor(link.id) != null
+        }
+
+        if (visible.isEmpty()) {
+            return if (requirement.optional) {
+                LinkResolution.Skipped(requirement)
+            } else {
+                LinkResolution.Failed(
+                    requirement = requirement,
+                    failure = LinkResolutionFailure.MissingLink(
+                        requirementName = requirement.name,
+                        transport = requirement.transport,
+                        direction = requirement.direction,
+                    ),
+                )
+            }
+        }
+
+        val evaluated = visible.map { link -> link to check(requirement, link, grants, platform) }
+
+        evaluated.firstOrNull { (_, failure) -> failure == null }?.let { (link, _) ->
+            return LinkResolution.Resolved(requirement, link)
+        }
+
+        return LinkResolution.Failed(
+            requirement = requirement,
+            failure = evaluated.first().second!!,
+        )
+    }
+
+    /** Null when the Link satisfies the requirement. */
+    private fun check(
+        requirement: LinkRequirement,
+        link: Link,
+        grants: LinkGrants,
+        platform: PlatformTarget,
+    ): LinkResolutionFailure? {
+        revocationOf(link, grants)?.let { scope ->
+            return LinkResolutionFailure.RevokedCredential(
+                requirementName = requirement.name,
+                linkId = link.id,
+                scope = scope,
+            )
+        }
+
+        if (!link.transport.capability(platform).permits(requirement.role)) {
+            return LinkResolutionFailure.TransportUnsupported(
+                requirementName = requirement.name,
+                linkId = link.id,
+                transport = link.transport,
+                platform = platform,
+                role = requirement.role,
+            )
+        }
+
+        if (!link.direction.satisfies(requirement.direction)) {
+            return LinkResolutionFailure.DirectionViolation(
+                requirementName = requirement.name,
+                linkId = link.id,
+                required = requirement.direction,
+                actual = link.direction,
+            )
+        }
+
+        val missingScope = requirement.minimumScope - link.scope
+        if (missingScope.isNotEmpty()) {
+            return LinkResolutionFailure.ScopeViolation(
+                requirementName = requirement.name,
+                linkId = link.id,
+                missingScope = missingScope,
+            )
+        }
+
+        return null
+    }
+
+    /**
+     * Widest revocation that applies, or null.
+     *
+     * Ordered widest-first so the reported blast radius is the true one: if the
+     * Link is gone, saying "your grant was revoked" would understate it.
+     */
+    private fun revocationOf(link: Link, grants: LinkGrants): RevocationScope? = when {
+        link.isRevoked -> RevocationScope.LINK
+        link.credentialRef?.isRevoked == true -> RevocationScope.CREDENTIAL
+        grants.isRevoked(link.id) -> RevocationScope.PLUG_GRANT
+        else -> null
+    }
+
+    /**
+     * Whether an already-resolved Link permits a chassis operation.
+     *
+     * Resolution proves the Link *can* satisfy the requirement; this is the
+     * per-call check that the specific operation is in-bounds. A write-only
+     * Link resolved for an Execute-shaped requirement still rejects Perceive.
+     */
+    fun permits(link: Link, operation: LinkOperation): Boolean =
+        !link.isRevoked &&
+            link.credentialRef?.isRevoked != true &&
+            link.direction.permits(operation)
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/link/LinkResolutionService.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/link/LinkResolutionService.kt
@@ -1,0 +1,226 @@
+package link.socket.ampere.link
+
+import kotlinx.datetime.Clock
+import link.socket.ampere.agents.definition.AgentId
+import link.socket.ampere.agents.domain.event.EventSource
+import link.socket.ampere.agents.domain.event.LinkEvent
+import link.socket.ampere.agents.events.bus.EventSerialBus
+import link.socket.ampere.agents.events.utils.generateUUID
+import link.socket.ampere.plug.PlugManifest
+
+/**
+ * Resolves a Plug's declared [LinkRequirement]s to concrete [Link]s at Arc
+ * execution time, and emits the lifecycle facts on the bus.
+ *
+ * Resolution is deliberately late. An Arc references Plugs, never Link
+ * bindings — that is what keeps the Arc manifest lean and what lets the same
+ * Arc run against a different Link (a different account, a different wire) with
+ * no edit. The Arc says "I need the Calendar Plug"; the Plug says "I need a
+ * read/write Link of kind `Mcp` scoped to `calendar_event`"; this service is
+ * where those two statements meet a real credentialed endpoint.
+ *
+ * Orchestration only: the matching policy lives in the pure
+ * [LinkResolutionGate], and all storage goes through [LinkStore]. Nothing here
+ * touches the database directly.
+ *
+ * @param eventBus Optional. Without it the service still resolves; it just goes
+ *   unobserved. Mirrors [link.socket.ampere.agents.domain.routing.CognitiveRelayImpl].
+ */
+class LinkResolutionService(
+    private val linkStore: LinkStore,
+    private val platform: PlatformTarget,
+    private val eventBus: EventSerialBus? = null,
+    private val clock: Clock = Clock.System,
+) {
+
+    /**
+     * Resolve every requirement in [manifest].
+     *
+     * Fails as a whole if any non-optional requirement fails, carrying *all*
+     * failures rather than just the first — a Plug missing three Links should
+     * take one round trip to fix, not three.
+     *
+     * Never throws. A missing Link is a [Result.failure] carrying
+     * [LinkResolutionException].
+     */
+    suspend fun resolve(
+        plugId: String,
+        manifest: PlugManifest,
+        agentId: AgentId? = null,
+    ): Result<ResolvedLinks> {
+        val links = linkStore.list().getOrElse { return Result.failure(it) }
+        val grants = linkStore.grantsForPlug(plugId).getOrElse { return Result.failure(it) }
+
+        val resolutions = manifest.requiredLinks.map { requirement ->
+            LinkResolutionGate.resolve(requirement, links, grants, platform)
+        }
+
+        // Optional requirements are still *reported* on the bus when they fail —
+        // a misconfigured optional Link is worth seeing — but they never block
+        // the Plug, which is the whole meaning of optional.
+        val failures = resolutions
+            .filterIsInstance<LinkResolution.Failed>()
+            .filterNot { it.requirement.optional }
+
+        resolutions.forEach { resolution ->
+            when (resolution) {
+                is LinkResolution.Resolved -> emitResolved(plugId, resolution, agentId)
+                is LinkResolution.Failed -> emitFailed(plugId, resolution, agentId)
+                is LinkResolution.Skipped -> Unit
+            }
+        }
+
+        if (failures.isNotEmpty()) {
+            return Result.failure(LinkResolutionException(failures.map { it.failure }))
+        }
+
+        return Result.success(
+            ResolvedLinks(
+                plugId = plugId,
+                byRequirement = resolutions
+                    .filterIsInstance<LinkResolution.Resolved>()
+                    .associate { it.requirement.name to it.link },
+            ),
+        )
+    }
+
+    /** Resolve a single requirement. Same rules, one result. */
+    suspend fun resolveOne(
+        plugId: String,
+        requirement: LinkRequirement,
+        agentId: AgentId? = null,
+    ): Result<LinkResolution> {
+        val links = linkStore.list().getOrElse { return Result.failure(it) }
+        val grants = linkStore.grantsForPlug(plugId).getOrElse { return Result.failure(it) }
+
+        val resolution = LinkResolutionGate.resolve(requirement, links, grants, platform)
+
+        when (resolution) {
+            is LinkResolution.Resolved -> emitResolved(plugId, resolution, agentId)
+            is LinkResolution.Failed -> emitFailed(plugId, resolution, agentId)
+            is LinkResolution.Skipped -> Unit
+        }
+
+        return Result.success(resolution)
+    }
+
+    /** Record a Plug's grant on a Link and announce it. */
+    suspend fun grant(
+        plugId: String,
+        linkId: LinkId,
+        agentId: AgentId? = null,
+    ): Result<Unit> {
+        val link = linkStore.get(linkId).getOrElse { return Result.failure(it) }
+            ?: return Result.failure(UnknownLinkException(linkId))
+
+        linkStore.grant(plugId, linkId, clock.now()).getOrElse { return Result.failure(it) }
+
+        eventBus?.publish(
+            LinkEvent.LinkGranted(
+                eventId = generateUUID("link"),
+                timestamp = clock.now(),
+                eventSource = sourceFor(agentId),
+                linkId = linkId,
+                plugId = plugId,
+                transport = link.transport,
+            ),
+        )
+
+        return Result.success(Unit)
+    }
+
+    /**
+     * Revoke the Link and cascade to every Plug holding a grant on it.
+     *
+     * Returns the plug ids that lost access.
+     */
+    suspend fun revokeLink(
+        linkId: LinkId,
+        agentId: AgentId? = null,
+    ): Result<List<String>> {
+        val now = clock.now()
+        val affected = linkStore.revokeLink(linkId, now).getOrElse { return Result.failure(it) }
+
+        eventBus?.publish(
+            LinkEvent.LinkRevoked(
+                eventId = generateUUID("link"),
+                timestamp = now,
+                eventSource = sourceFor(agentId),
+                linkId = linkId,
+                scope = RevocationScope.LINK,
+                affectedPlugIds = affected,
+            ),
+        )
+
+        return Result.success(affected)
+    }
+
+    /** Revoke one Plug's grant, leaving every other Plug on the Link intact. */
+    suspend fun revokeGrant(
+        plugId: String,
+        linkId: LinkId,
+        agentId: AgentId? = null,
+    ): Result<Unit> {
+        val now = clock.now()
+        linkStore.revokeGrant(plugId, linkId, now).getOrElse { return Result.failure(it) }
+
+        eventBus?.publish(
+            LinkEvent.LinkRevoked(
+                eventId = generateUUID("link"),
+                timestamp = now,
+                eventSource = sourceFor(agentId),
+                linkId = linkId,
+                scope = RevocationScope.PLUG_GRANT,
+                affectedPlugIds = listOf(plugId),
+            ),
+        )
+
+        return Result.success(Unit)
+    }
+
+    private suspend fun emitResolved(
+        plugId: String,
+        resolution: LinkResolution.Resolved,
+        agentId: AgentId?,
+    ) {
+        eventBus?.publish(
+            LinkEvent.LinkResolved(
+                eventId = generateUUID("link"),
+                timestamp = clock.now(),
+                eventSource = sourceFor(agentId),
+                linkId = resolution.link.id,
+                plugId = plugId,
+                requirementName = resolution.requirement.name,
+                transport = resolution.link.transport,
+            ),
+        )
+    }
+
+    private suspend fun emitFailed(
+        plugId: String,
+        resolution: LinkResolution.Failed,
+        agentId: AgentId?,
+    ) {
+        eventBus?.publish(
+            LinkEvent.LinkResolutionFailed(
+                eventId = generateUUID("link"),
+                timestamp = clock.now(),
+                eventSource = sourceFor(agentId),
+                linkId = linkIdOf(resolution.failure),
+                plugId = plugId,
+                failure = resolution.failure,
+            ),
+        )
+    }
+
+    private fun sourceFor(agentId: AgentId?): EventSource =
+        agentId?.let { EventSource.Agent(it) } ?: EventSource.Human
+
+    private fun linkIdOf(failure: LinkResolutionFailure): LinkId = when (failure) {
+        is LinkResolutionFailure.MissingLink -> LinkEvent.LinkResolutionFailed.NO_LINK
+        is LinkResolutionFailure.DirectionViolation -> failure.linkId
+        is LinkResolutionFailure.ScopeViolation -> failure.linkId
+        is LinkResolutionFailure.RevokedCredential -> failure.linkId
+        is LinkResolutionFailure.TransportUnsupported -> failure.linkId
+    }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/link/LinkStore.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/link/LinkStore.kt
@@ -1,0 +1,288 @@
+package link.socket.ampere.link
+
+import kotlinx.coroutines.withContext
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlinx.serialization.json.Json
+import link.socket.ampere.db.Database
+import link.socket.ampere.util.ioDispatcher
+
+/**
+ * Persistence boundary for [Link]s and the per-Plug grants on them.
+ *
+ * All fallible operations return [Result]; no exceptions cross this boundary.
+ * Agents never touch the database — they reach Links through
+ * [LinkResolutionService], which sits on top of this.
+ */
+interface LinkStore {
+
+    suspend fun upsert(link: Link, updatedAt: Instant = Clock.System.now()): Result<Unit>
+
+    suspend fun get(linkId: LinkId): Result<Link?>
+
+    suspend fun list(): Result<List<Link>>
+
+    suspend fun listByTransport(transport: Transport): Result<List<Link>>
+
+    suspend fun delete(linkId: LinkId): Result<Unit>
+
+    suspend fun grant(
+        plugId: String,
+        linkId: LinkId,
+        grantedAt: Instant = Clock.System.now(),
+    ): Result<Unit>
+
+    suspend fun revokeGrant(
+        plugId: String,
+        linkId: LinkId,
+        revokedAt: Instant = Clock.System.now(),
+    ): Result<Unit>
+
+    suspend fun grantsForPlug(plugId: String): Result<LinkGrants>
+
+    suspend fun grantsForLink(linkId: LinkId): Result<List<LinkGrant>>
+
+    /**
+     * Revoke the Link itself and cascade to every grant on it.
+     *
+     * Returns the plug ids that lost access, so the caller can report the true
+     * blast radius rather than a single row.
+     */
+    suspend fun revokeLink(
+        linkId: LinkId,
+        revokedAt: Instant = Clock.System.now(),
+    ): Result<List<String>>
+}
+
+class SqlDelightLinkStore(
+    private val database: Database,
+    private val json: Json = Json {
+        classDiscriminator = "type"
+        encodeDefaults = true
+        ignoreUnknownKeys = true
+    },
+) : LinkStore {
+
+    private val queries
+        get() = database.linksQueries
+
+    override suspend fun upsert(link: Link, updatedAt: Instant): Result<Unit> =
+        withContext(ioDispatcher) {
+            runCatching {
+                queries.upsertLink(
+                    link_id = link.id.value,
+                    transport = link.transport.name,
+                    link_json = encode(link),
+                    updated_at = updatedAt.toEpochMilliseconds(),
+                )
+            }.map { }
+        }
+
+    override suspend fun get(linkId: LinkId): Result<Link?> =
+        withContext(ioDispatcher) {
+            runCatching {
+                queries.selectLink(linkId.value).executeAsOneOrNull()?.let(::decode)
+            }
+        }
+
+    override suspend fun list(): Result<List<Link>> =
+        withContext(ioDispatcher) {
+            runCatching { queries.selectAllLinks().executeAsList().map(::decode) }
+        }
+
+    override suspend fun listByTransport(transport: Transport): Result<List<Link>> =
+        withContext(ioDispatcher) {
+            runCatching {
+                queries.selectLinksByTransport(transport.name).executeAsList().map(::decode)
+            }
+        }
+
+    override suspend fun delete(linkId: LinkId): Result<Unit> =
+        withContext(ioDispatcher) {
+            runCatching {
+                queries.deleteGrantsForLink(linkId.value)
+                queries.deleteLink(linkId.value)
+            }.map { }
+        }
+
+    override suspend fun grant(
+        plugId: String,
+        linkId: LinkId,
+        grantedAt: Instant,
+    ): Result<Unit> =
+        withContext(ioDispatcher) {
+            runCatching {
+                queries.upsertLinkGrant(
+                    plug_id = plugId,
+                    link_id = linkId.value,
+                    granted_at = grantedAt.toEpochMilliseconds(),
+                    revoked_at = null,
+                )
+            }.map { }
+        }
+
+    override suspend fun revokeGrant(
+        plugId: String,
+        linkId: LinkId,
+        revokedAt: Instant,
+    ): Result<Unit> =
+        withContext(ioDispatcher) {
+            runCatching {
+                val existing = queries.selectGrantsForPlug(plugId)
+                    .executeAsList()
+                    .firstOrNull { it.link_id == linkId.value }
+
+                queries.upsertLinkGrant(
+                    plug_id = plugId,
+                    link_id = linkId.value,
+                    granted_at = existing?.granted_at ?: revokedAt.toEpochMilliseconds(),
+                    revoked_at = revokedAt.toEpochMilliseconds(),
+                )
+            }.map { }
+        }
+
+    override suspend fun grantsForPlug(plugId: String): Result<LinkGrants> =
+        withContext(ioDispatcher) {
+            runCatching {
+                LinkGrants(
+                    plugId = plugId,
+                    grants = queries.selectGrantsForPlug(plugId).executeAsList().map { row ->
+                        LinkGrant(
+                            plugId = row.plug_id,
+                            linkId = LinkId(row.link_id),
+                            grantedAt = Instant.fromEpochMilliseconds(row.granted_at),
+                            revokedAt = row.revoked_at?.let(Instant::fromEpochMilliseconds),
+                        )
+                    },
+                )
+            }
+        }
+
+    override suspend fun grantsForLink(linkId: LinkId): Result<List<LinkGrant>> =
+        withContext(ioDispatcher) {
+            runCatching {
+                queries.selectGrantsForLink(linkId.value).executeAsList().map { row ->
+                    LinkGrant(
+                        plugId = row.plug_id,
+                        linkId = LinkId(row.link_id),
+                        grantedAt = Instant.fromEpochMilliseconds(row.granted_at),
+                        revokedAt = row.revoked_at?.let(Instant::fromEpochMilliseconds),
+                    )
+                }
+            }
+        }
+
+    override suspend fun revokeLink(
+        linkId: LinkId,
+        revokedAt: Instant,
+    ): Result<List<String>> =
+        withContext(ioDispatcher) {
+            runCatching {
+                val affected = queries.selectGrantsForLink(linkId.value)
+                    .executeAsList()
+                    .filter { it.revoked_at == null }
+                    .map { it.plug_id }
+
+                queries.revokeGrantsForLink(
+                    revoked_at = revokedAt.toEpochMilliseconds(),
+                    link_id = linkId.value,
+                )
+
+                queries.selectLink(linkId.value).executeAsOneOrNull()?.let { stored ->
+                    val revoked = decode(stored).copy(revokedAt = revokedAt)
+                    queries.upsertLink(
+                        link_id = revoked.id.value,
+                        transport = revoked.transport.name,
+                        link_json = encode(revoked),
+                        updated_at = revokedAt.toEpochMilliseconds(),
+                    )
+                }
+
+                affected
+            }
+        }
+
+    private fun encode(link: Link): String = json.encodeToString(Link.serializer(), link)
+
+    private fun decode(payload: String): Link = json.decodeFromString(Link.serializer(), payload)
+}
+
+/**
+ * In-memory [LinkStore] for tests and single-process environments.
+ *
+ * Mirrors [link.socket.ampere.mcp.InMemoryMcpCredentialBinding]: the persistent
+ * implementation is the real one, this exists so resolution can be exercised
+ * without a driver.
+ */
+class InMemoryLinkStore(
+    links: List<Link> = emptyList(),
+    grants: List<LinkGrant> = emptyList(),
+) : LinkStore {
+
+    private val links = links.associateBy { it.id }.toMutableMap()
+    private val grants = grants.associateBy { it.plugId to it.linkId }.toMutableMap()
+
+    override suspend fun upsert(link: Link, updatedAt: Instant): Result<Unit> {
+        links[link.id] = link
+        return Result.success(Unit)
+    }
+
+    override suspend fun get(linkId: LinkId): Result<Link?> = Result.success(links[linkId])
+
+    override suspend fun list(): Result<List<Link>> = Result.success(links.values.toList())
+
+    override suspend fun listByTransport(transport: Transport): Result<List<Link>> =
+        Result.success(links.values.filter { it.transport == transport })
+
+    override suspend fun delete(linkId: LinkId): Result<Unit> {
+        links.remove(linkId)
+        grants.keys.filter { it.second == linkId }.forEach(grants::remove)
+        return Result.success(Unit)
+    }
+
+    override suspend fun grant(
+        plugId: String,
+        linkId: LinkId,
+        grantedAt: Instant,
+    ): Result<Unit> {
+        grants[plugId to linkId] = LinkGrant(plugId, linkId, grantedAt)
+        return Result.success(Unit)
+    }
+
+    override suspend fun revokeGrant(
+        plugId: String,
+        linkId: LinkId,
+        revokedAt: Instant,
+    ): Result<Unit> {
+        val existing = grants[plugId to linkId]
+        grants[plugId to linkId] = LinkGrant(
+            plugId = plugId,
+            linkId = linkId,
+            grantedAt = existing?.grantedAt ?: revokedAt,
+            revokedAt = revokedAt,
+        )
+        return Result.success(Unit)
+    }
+
+    override suspend fun grantsForPlug(plugId: String): Result<LinkGrants> =
+        Result.success(
+            LinkGrants(plugId, grants.values.filter { it.plugId == plugId }),
+        )
+
+    override suspend fun grantsForLink(linkId: LinkId): Result<List<LinkGrant>> =
+        Result.success(grants.values.filter { it.linkId == linkId })
+
+    override suspend fun revokeLink(linkId: LinkId, revokedAt: Instant): Result<List<String>> {
+        val affected = grants.values
+            .filter { it.linkId == linkId && !it.isRevoked }
+            .map { it.plugId }
+
+        affected.forEach { plugId ->
+            grants[plugId to linkId] = grants.getValue(plugId to linkId).copy(revokedAt = revokedAt)
+        }
+
+        links[linkId]?.let { links[linkId] = it.copy(revokedAt = revokedAt) }
+
+        return Result.success(affected)
+    }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/link/Transport.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/link/Transport.kt
@@ -1,0 +1,182 @@
+package link.socket.ampere.link
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * The concrete medium a [Link] runs over.
+ *
+ * **Transport belongs to the Link, not the Plug.** The Uber Plug does not "have
+ * MCP transport"; it declares that it requires a Link of kind [MCP]. Memory
+ * requires [FOLDER_MOUNT]; Notify requires [APNS]. That inversion is what lets
+ * one authenticated Link serve several Plugs, and what keeps Arc logic ignorant
+ * of which wire carried the data.
+ *
+ * ## Capability is per-platform, not global
+ *
+ * The tempting model is one enum member per direction — `AppFunctionProvider`,
+ * `AppFunctionConsumer`. It is wrong, because the same transport has different
+ * powers on different targets:
+ *
+ *  - [APP_FUNCTION] is bidirectional on Android: Ampere can expose Arcs as
+ *    AppFunctions *and* call other apps' functions as Arc steps (the consumer
+ *    path is `EXECUTE_APP_FUNCTIONS`-gated and likely restricted at GA).
+ *  - iOS has **no consumer equivalent at all.** Cross-app orchestration belongs
+ *    to Siri — declare and defer. iOS app-to-app is limited to [URI_SCHEME] and
+ *    Shortcuts routes.
+ *
+ * So capability is a *function of (transport, platform)*, exposed through
+ * [capability]. A resolution that ignores it will happily hand an Arc a Link it
+ * can never actually drive.
+ */
+@Serializable
+enum class Transport {
+
+    @SerialName("mcp")
+    MCP,
+
+    @SerialName("oauth_rest")
+    OAUTH_REST,
+
+    @SerialName("native_framework")
+    NATIVE_FRAMEWORK,
+
+    @SerialName("uri_scheme")
+    URI_SCHEME,
+
+    @SerialName("folder_mount")
+    FOLDER_MOUNT,
+
+    @SerialName("apns")
+    APNS,
+
+    @SerialName("app_function")
+    APP_FUNCTION,
+
+    @SerialName("cli")
+    CLI,
+    ;
+
+    /**
+     * What Ampere may do over this transport on [platform].
+     *
+     * Unlisted combinations are [TransportCapability.NONE] — the conservative
+     * default, so a new platform target cannot silently inherit powers it does
+     * not have.
+     */
+    fun capability(platform: PlatformTarget): TransportCapability =
+        CAPABILITIES[this to platform] ?: TransportCapability.NONE
+
+    /**
+     * Whether a working transport implementation exists behind this member yet.
+     *
+     * Deliberately *not* consulted by [LinkResolutionGate]: this ticket ships
+     * the interface, and gating resolution on it would make every Link but MCP
+     * unresolvable before its transport ticket lands. It exists so tooling and
+     * the Plug authoring guide can say which wires are real today.
+     */
+    val hasImplementation: Boolean
+        get() = this == MCP
+
+    companion object {
+
+        private val CAPABILITIES: Map<Pair<Transport, PlatformTarget>, TransportCapability> = buildMap {
+            // MCP — Ampere is a client everywhere; hosting a server is only
+            // practical off-device.
+            putAll(everywhere(MCP, TransportCapability.CONSUME_ONLY))
+            put(MCP to PlatformTarget.JVM_DESKTOP, TransportCapability.BIDIRECTIONAL)
+            put(MCP to PlatformTarget.MACOS, TransportCapability.BIDIRECTIONAL)
+
+            // OAuth/REST — Ampere calls out; it is never the API provider.
+            putAll(everywhere(OAUTH_REST, TransportCapability.CONSUME_ONLY))
+
+            // Native frameworks exist only where the OS does.
+            put(NATIVE_FRAMEWORK to PlatformTarget.IOS, TransportCapability.CONSUME_ONLY)
+            put(NATIVE_FRAMEWORK to PlatformTarget.ANDROID, TransportCapability.CONSUME_ONLY)
+            put(NATIVE_FRAMEWORK to PlatformTarget.MACOS, TransportCapability.CONSUME_ONLY)
+
+            // URI schemes go both ways on mobile: Ampere can open another app
+            // and can register a scheme others open.
+            put(URI_SCHEME to PlatformTarget.IOS, TransportCapability.BIDIRECTIONAL)
+            put(URI_SCHEME to PlatformTarget.ANDROID, TransportCapability.BIDIRECTIONAL)
+            put(URI_SCHEME to PlatformTarget.MACOS, TransportCapability.BIDIRECTIONAL)
+            put(URI_SCHEME to PlatformTarget.JVM_DESKTOP, TransportCapability.CONSUME_ONLY)
+
+            // Folder mounts: iOS reads through the document picker but cannot
+            // publish a mount for other apps to consume.
+            put(FOLDER_MOUNT to PlatformTarget.IOS, TransportCapability.CONSUME_ONLY)
+            put(FOLDER_MOUNT to PlatformTarget.ANDROID, TransportCapability.BIDIRECTIONAL)
+            put(FOLDER_MOUNT to PlatformTarget.JVM_DESKTOP, TransportCapability.BIDIRECTIONAL)
+            put(FOLDER_MOUNT to PlatformTarget.MACOS, TransportCapability.BIDIRECTIONAL)
+
+            // APNS is a write-only sink, and *sending* is a server-side act.
+            put(APNS to PlatformTarget.JVM_DESKTOP, TransportCapability.CONSUME_ONLY)
+            put(APNS to PlatformTarget.MACOS, TransportCapability.CONSUME_ONLY)
+
+            // The headline asymmetry: bidirectional on Android, absent on iOS.
+            put(APP_FUNCTION to PlatformTarget.ANDROID, TransportCapability.BIDIRECTIONAL)
+
+            // CLI is a desktop story; macOS post-launch.
+            put(CLI to PlatformTarget.JVM_DESKTOP, TransportCapability.CONSUME_ONLY)
+            put(CLI to PlatformTarget.MACOS, TransportCapability.CONSUME_ONLY)
+        }
+
+        private fun everywhere(
+            transport: Transport,
+            capability: TransportCapability,
+        ): Map<Pair<Transport, PlatformTarget>, TransportCapability> =
+            PlatformTarget.entries.associate { (transport to it) to capability }
+    }
+}
+
+/** A platform Ampere runs on. Capability tables are keyed by this. */
+@Serializable
+enum class PlatformTarget {
+    @SerialName("ios")
+    IOS,
+
+    @SerialName("android")
+    ANDROID,
+
+    @SerialName("jvm_desktop")
+    JVM_DESKTOP,
+
+    @SerialName("macos")
+    MACOS,
+}
+
+/**
+ * Which side of a transport Ampere may act as, on one platform.
+ *
+ * @property canProvide Ampere may expose its own Arcs through this transport.
+ * @property canConsume Ampere may invoke someone else's capability through it.
+ */
+@Serializable
+data class TransportCapability(
+    val canProvide: Boolean,
+    val canConsume: Boolean,
+) {
+    fun permits(role: TransportRole): Boolean = when (role) {
+        TransportRole.PROVIDER -> canProvide
+        TransportRole.CONSUMER -> canConsume
+    }
+
+    companion object {
+        val NONE = TransportCapability(canProvide = false, canConsume = false)
+        val CONSUME_ONLY = TransportCapability(canProvide = false, canConsume = true)
+        val PROVIDE_ONLY = TransportCapability(canProvide = true, canConsume = false)
+        val BIDIRECTIONAL = TransportCapability(canProvide = true, canConsume = true)
+    }
+}
+
+/** The side a Plug intends to act as over a required Link. */
+@Serializable
+enum class TransportRole {
+    /** Ampere exposes an Arc through the Link. */
+    @SerialName("provider")
+    PROVIDER,
+
+    /** Ampere calls out through the Link. The common case. */
+    @SerialName("consumer")
+    CONSUMER,
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/mcp/McpClient.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/mcp/McpClient.kt
@@ -10,6 +10,7 @@ import link.socket.ampere.agents.tools.mcp.connection.HttpMcpConnection
 import link.socket.ampere.agents.tools.mcp.connection.McpServerConnection
 import link.socket.ampere.agents.tools.mcp.protocol.McpToolDescriptor
 import link.socket.ampere.agents.tools.mcp.protocol.ToolCallResult
+import link.socket.ampere.link.LinkId
 import link.socket.ampere.plug.McpServerDependency
 
 /**

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/mcp/McpCredentialBinding.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/mcp/McpCredentialBinding.kt
@@ -1,20 +1,9 @@
 package link.socket.ampere.mcp
 
-import kotlin.jvm.JvmInline
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.Serializable
-
-/**
- * Identifier for a Link — the user-bound authorization scope under which
- * an MCP credential is stored.
- *
- * The Link concept is upcoming work; modeling it as a value class lets the
- * eventual store interface match without a churn cycle.
- */
-@JvmInline
-@Serializable
-value class LinkId(val value: String)
+import link.socket.ampere.link.LinkId
 
 /**
  * Credential material a plug's [McpClient] surfaces into its connection

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/PlugContext.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/PlugContext.kt
@@ -4,7 +4,7 @@ import link.socket.ampere.agents.config.AgentActionAutonomy
 import link.socket.ampere.agents.execution.tools.McpTool
 import link.socket.ampere.agents.execution.tools.Tool
 import link.socket.ampere.agents.tools.mcp.connection.McpServerConnection
-import link.socket.ampere.mcp.LinkId
+import link.socket.ampere.link.LinkId
 import link.socket.ampere.mcp.McpClient
 import link.socket.ampere.mcp.McpCredential
 import link.socket.ampere.mcp.McpCredentialBinding

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/PlugManifest.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/PlugManifest.kt
@@ -1,13 +1,26 @@
 package link.socket.ampere.plug
 
 import kotlinx.serialization.Serializable
+import link.socket.ampere.canon.CanonType
+import link.socket.ampere.link.LinkRequirement
 import link.socket.ampere.plug.permission.PlugPermission
 
 /**
- * Manifest metadata for a plug and the permissions it requires at runtime.
+ * Manifest metadata for a plug: what it is, what it may do, and what it needs
+ * to be wired to.
  *
- * [requiredPermissions] and [mcpServers] default to empty so manifests created
- * before each schema addition continue to decode unchanged.
+ * The grammar this encodes is *a Plug connects through a Link and powers Arcs*.
+ * A Plug never names a concrete Link — it declares [requiredLinks], a list of
+ * *kinds* of wire, and resolution to a credentialed endpoint happens at Arc
+ * execution time. That is what lets one authenticated Google Link serve both
+ * the Calendar and Gmail Plugs, and what keeps Arc manifests lean.
+ *
+ * [emits] and [consumes] are the canon-level data contract: what this Plug can
+ * produce for other Arc steps, and what it needs handed to it. They are what a
+ * future planner reads to decide two Plugs can be chained.
+ *
+ * Every collection field defaults to empty so manifests written before each
+ * schema addition continue to decode unchanged.
  */
 @Serializable
 data class PlugManifest(
@@ -18,4 +31,7 @@ data class PlugManifest(
     val entrypoint: String? = null,
     val requiredPermissions: List<PlugPermission> = emptyList(),
     val mcpServers: List<McpServerDependency> = emptyList(),
+    val requiredLinks: List<LinkRequirement> = emptyList(),
+    val emits: Set<CanonType> = emptySet(),
+    val consumes: Set<CanonType> = emptySet(),
 )

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/PlugManifestValidator.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/PlugManifestValidator.kt
@@ -42,11 +42,43 @@ object PlugManifestValidator {
             }
         }
 
+        reasons += validateLinkRequirements(manifest)
+
         return if (reasons.isEmpty()) {
             ManifestValidationResult.Valid
         } else {
             ManifestValidationResult.Invalid(reasons)
         }
+    }
+
+    /**
+     * Structural checks on [PlugManifest.requiredLinks].
+     *
+     * Both rules exist because the failure they catch is silent otherwise: a
+     * duplicate requirement name means one of the two Links is unreachable
+     * through [link.socket.ampere.link.ResolvedLinks], and an empty scope means
+     * a wire that resolves successfully and then may carry nothing.
+     */
+    private fun validateLinkRequirements(
+        manifest: PlugManifest,
+    ): List<ManifestValidationReason> {
+        val reasons = mutableListOf<ManifestValidationReason>()
+
+        manifest.requiredLinks
+            .groupBy { it.name }
+            .filterValues { it.size > 1 }
+            .keys
+            .forEach { name ->
+                reasons += ManifestValidationReason.DuplicateLinkRequirementName(name)
+            }
+
+        manifest.requiredLinks
+            .filter { it.minimumScope.isEmpty() }
+            .forEach { requirement ->
+                reasons += ManifestValidationReason.EmptyLinkRequirementScope(requirement.name)
+            }
+
+        return reasons
     }
 }
 
@@ -74,5 +106,21 @@ sealed interface ManifestValidationReason {
     data class DependencyPermissionNotLifted(
         val dependencyName: String,
         val permission: PlugPermission,
+    ) : ManifestValidationReason
+
+    /**
+     * Two [link.socket.ampere.link.LinkRequirement]s share a name, so only one
+     * of them can ever be looked up after resolution.
+     */
+    data class DuplicateLinkRequirementName(
+        val name: String,
+    ) : ManifestValidationReason
+
+    /**
+     * A Link requirement declares no minimum scope, which would resolve to a
+     * wire permitted to carry nothing.
+     */
+    data class EmptyLinkRequirementScope(
+        val name: String,
     ) : ManifestValidationReason
 }

--- a/ampere-core/src/commonMain/sqldelight/link/socket/ampere/db/2.sqm
+++ b/ampere-core/src/commonMain/sqldelight/link/socket/ampere/db/2.sqm
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS Links (
+  link_id TEXT NOT NULL PRIMARY KEY,
+  transport TEXT NOT NULL,
+  link_json TEXT NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_links_transport ON Links(transport);
+
+CREATE TABLE IF NOT EXISTS LinkGrants (
+  plug_id TEXT NOT NULL,
+  link_id TEXT NOT NULL,
+  granted_at INTEGER NOT NULL,
+  revoked_at INTEGER,
+  PRIMARY KEY (plug_id, link_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_link_grants_link_id ON LinkGrants(link_id);

--- a/ampere-core/src/commonMain/sqldelight/link/socket/ampere/db/Links.sq
+++ b/ampere-core/src/commonMain/sqldelight/link/socket/ampere/db/Links.sq
@@ -1,0 +1,75 @@
+-- Links are Socket's data-link layer: the binding between a capability and its
+-- concrete medium. `link_json` is the source of truth; `transport` is a
+-- denormalized index column so resolution can narrow candidates without
+-- decoding every row. Keeping revocation inside `link_json` (rather than in a
+-- second column) means there is exactly one place that answers "is this Link
+-- revoked".
+CREATE TABLE Links (
+  link_id TEXT NOT NULL PRIMARY KEY,
+  transport TEXT NOT NULL,
+  link_json TEXT NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE INDEX idx_links_transport ON Links(transport);
+
+-- Grants are per-(Plug, Link) because Links are shared: granting Gmail access
+-- to a Google Link says nothing about Calendar's access to the same Link.
+CREATE TABLE LinkGrants (
+  plug_id TEXT NOT NULL,
+  link_id TEXT NOT NULL,
+  granted_at INTEGER NOT NULL,
+  revoked_at INTEGER,
+  PRIMARY KEY (plug_id, link_id)
+);
+
+CREATE INDEX idx_link_grants_link_id ON LinkGrants(link_id);
+
+upsertLink:
+INSERT OR REPLACE INTO Links(link_id, transport, link_json, updated_at)
+VALUES (?, ?, ?, ?);
+
+selectLink:
+SELECT link_json
+FROM Links
+WHERE link_id = ?;
+
+selectAllLinks:
+SELECT link_json
+FROM Links
+ORDER BY link_id ASC;
+
+selectLinksByTransport:
+SELECT link_json
+FROM Links
+WHERE transport = ?
+ORDER BY link_id ASC;
+
+deleteLink:
+DELETE FROM Links
+WHERE link_id = ?;
+
+upsertLinkGrant:
+INSERT OR REPLACE INTO LinkGrants(plug_id, link_id, granted_at, revoked_at)
+VALUES (?, ?, ?, ?);
+
+selectGrantsForPlug:
+SELECT plug_id, link_id, granted_at, revoked_at
+FROM LinkGrants
+WHERE plug_id = ?
+ORDER BY granted_at ASC;
+
+selectGrantsForLink:
+SELECT plug_id, link_id, granted_at, revoked_at
+FROM LinkGrants
+WHERE link_id = ?
+ORDER BY plug_id ASC;
+
+revokeGrantsForLink:
+UPDATE LinkGrants
+SET revoked_at = ?
+WHERE link_id = ? AND revoked_at IS NULL;
+
+deleteGrantsForLink:
+DELETE FROM LinkGrants
+WHERE link_id = ?;

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/canon/CanonSerializationTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/canon/CanonSerializationTest.kt
@@ -1,0 +1,165 @@
+package link.socket.ampere.canon
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.datetime.Instant
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import link.socket.ampere.link.LinkId
+
+/**
+ * Canon entities cross the wire and land in traces. A drifted `@SerialName`
+ * breaks `PlaybackRelay` replay of every trace already recorded, so the
+ * discriminators are pinned here as literal strings — this test is meant to
+ * fail loudly when someone renames one.
+ */
+class CanonSerializationTest {
+
+    private val json = Json {
+        prettyPrint = false
+        encodeDefaults = true
+        classDiscriminator = "type"
+        ignoreUnknownKeys = true
+    }
+
+    private val provenance = CanonProvenance(
+        sourceHandle = SourceHandle(
+            linkId = LinkId("link-1"),
+            sourceSystem = "apple.mail",
+            nativeId = "native-1",
+            etag = "etag-1",
+        ),
+        observedAt = Instant.fromEpochMilliseconds(1_700_000_000_000),
+        nativePayload = NativePayload(
+            schema = "MailMessageEntity",
+            fields = JsonObject(mapOf("subject" to JsonPrimitive("hi"))),
+        ),
+    )
+
+    private fun samples(): Map<String, CanonEntity> = mapOf(
+        "canon.person" to CanonPerson(CanonId("p"), provenance, displayName = "Ada"),
+        "canon.email_message" to CanonEmailMessage(CanonId("m"), provenance, subject = "hi", from = null),
+        "canon.email_draft" to CanonEmailDraft(CanonId("d"), provenance, subject = "wip"),
+        "canon.mailbox" to CanonMailbox(CanonId("b"), provenance, name = "Inbox"),
+        "canon.photo" to CanonPhoto(CanonId("ph"), provenance),
+        "canon.photo_album" to CanonPhotoAlbum(CanonId("al"), provenance, title = "Trip"),
+        "canon.document" to CanonDocument(
+            CanonId("doc"),
+            provenance,
+            title = "Spec",
+            kind = DocumentKind.WORD_PROCESSOR,
+        ),
+        "canon.place" to CanonPlace(CanonId("pl"), provenance, name = "Home"),
+        "canon.journal_entry" to CanonJournalEntry(CanonId("j"), provenance),
+        "canon.book" to CanonBook(CanonId("bk"), provenance, title = "SICP"),
+        "canon.web_bookmark" to CanonWebBookmark(CanonId("wb"), provenance, title = "Docs", url = "https://x"),
+        "canon.browser_tab" to CanonBrowserTab(CanonId("tb"), provenance, title = "Docs", url = "https://x"),
+        "canon.calendar_event" to CanonCalendarEvent(
+            CanonId("ce"),
+            provenance,
+            title = "Standup",
+            startsAt = Instant.fromEpochMilliseconds(1_700_000_100_000),
+        ),
+        "canon.reminder" to CanonReminder(CanonId("r"), provenance, title = "Pay rent"),
+        "canon.alarm" to CanonAlarm(CanonId("a"), provenance),
+        "canon.media_item" to CanonMediaItem(CanonId("mi"), provenance, title = "Track"),
+        "canon.health_sample" to CanonHealthSample(
+            CanonId("hs"),
+            provenance,
+            quantityType = "stepCount",
+            value = 1200.0,
+            unit = "count",
+            recordedAt = Instant.fromEpochMilliseconds(1_700_000_200_000),
+        ),
+        "canon.home_accessory" to CanonHomeAccessory(CanonId("ha"), provenance, name = "Lamp"),
+        "canon.transaction" to CanonTransaction(
+            CanonId("tx"),
+            provenance,
+            amountMinorUnits = 1250,
+            currencyCode = "USD",
+        ),
+        "canon.pass" to CanonPass(CanonId("pa"), provenance, description = "Boarding"),
+        "canon.weather_forecast" to CanonWeatherForecast(
+            CanonId("wf"),
+            provenance,
+            place = null,
+            validAt = Instant.fromEpochMilliseconds(1_700_000_300_000),
+        ),
+        "canon.bluetooth_peripheral" to CanonBluetoothPeripheral(CanonId("bp"), provenance),
+        "canon.motion_sample" to CanonMotionSample(
+            CanonId("ms"),
+            provenance,
+            activity = "walking",
+            recordedAt = Instant.fromEpochMilliseconds(1_700_000_400_000),
+        ),
+        "canon.message" to CanonMessage(CanonId("msg"), provenance, bodyText = "yo"),
+        "canon.note" to CanonNote(CanonId("n"), provenance),
+        "canon.ride" to CanonRide(CanonId("rd"), provenance, status = "requested"),
+        "canon.order" to CanonOrder(CanonId("or"), provenance, status = "placed"),
+        "canon.delivery" to CanonDelivery(CanonId("dl"), provenance, status = "in_transit"),
+        "canon.third_party_playlist" to CanonThirdPartyPlaylist(CanonId("pp"), provenance, title = "Focus"),
+    )
+
+    @Test
+    fun `every canon entity round-trips through the sealed serializer`() {
+        samples().forEach { (discriminator, entity) ->
+            val encoded = json.encodeToString(CanonEntity.serializer(), entity)
+            val decoded = json.decodeFromString(CanonEntity.serializer(), encoded)
+
+            assertEquals(entity, decoded, "round-trip changed $discriminator")
+        }
+    }
+
+    @Test
+    fun `every canon entity writes its pinned discriminator`() {
+        samples().forEach { (discriminator, entity) ->
+            val encoded = json.encodeToString(CanonEntity.serializer(), entity)
+
+            assertTrue(
+                encoded.contains("\"type\":\"$discriminator\""),
+                "expected discriminator $discriminator, got $encoded",
+            )
+        }
+    }
+
+    @Test
+    fun `the sample set covers every canon type`() {
+        val covered = samples().values.map { it.canonType }.toSet()
+
+        assertEquals(
+            CanonType.entries.toSet(),
+            covered,
+            "a canon type has no serialization sample; drift in it would go unnoticed",
+        )
+    }
+
+    @Test
+    fun `provenance survives serialization intact`() {
+        val entity = CanonEmailMessage(CanonId("m"), provenance, subject = "hi", from = null)
+
+        val decoded = json.decodeFromString(
+            CanonEntity.serializer(),
+            json.encodeToString(CanonEntity.serializer(), entity),
+        )
+
+        assertEquals(provenance.sourceHandle, decoded.provenance.sourceHandle)
+        assertEquals(provenance.nativePayload, decoded.provenance.nativePayload)
+        assertEquals(provenance.observedAt, decoded.provenance.observedAt)
+    }
+
+    @Test
+    fun `canon type wire names are stable`() {
+        // Spot-check the members most likely to be renamed in a refactor.
+        assertEquals("email_message", CanonType.EMAIL_MESSAGE.wireName)
+        assertEquals("calendar_event", CanonType.CALENDAR_EVENT.wireName)
+        assertEquals("third_party_playlist", CanonType.THIRD_PARTY_PLAYLIST.wireName)
+    }
+
+    @Test
+    fun `canon type serializes to its wire name`() {
+        val encoded = json.encodeToString(CanonType.serializer(), CanonType.JOURNAL_ENTRY)
+        assertEquals("\"journal_entry\"", encoded)
+    }
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/canon/CanonTypeTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/canon/CanonTypeTest.kt
@@ -103,7 +103,7 @@ class CanonTypeTest {
     }
 
     @Test
-    fun `Person and Place bind through system value types, not entity schemas`() {
+    fun `Person and Place bind through system value types rather than entity schemas`() {
         val person = CanonType.PERSON.binding.apple
         val place = CanonType.PLACE.binding.apple
 

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/canon/CanonTypeTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/canon/CanonTypeTest.kt
@@ -1,0 +1,151 @@
+package link.socket.ampere.canon
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class CanonTypeTest {
+
+    @Test
+    fun `wire names are unique across the whole canon`() {
+        val wireNames = CanonType.entries.map { it.wireName }
+
+        assertEquals(
+            wireNames.size,
+            wireNames.toSet().size,
+            "Duplicate wireName found; wire names are a serialization contract",
+        )
+    }
+
+    @Test
+    fun `fromWireName round-trips every canon type`() {
+        CanonType.entries.forEach { type ->
+            assertEquals(type, CanonType.fromWireName(type.wireName))
+        }
+    }
+
+    @Test
+    fun `fromWireName returns null for an unknown name rather than throwing`() {
+        assertNull(CanonType.fromWireName("definitely_not_a_canon_type"))
+    }
+
+    @Test
+    fun `every Ring 1 type has an Apple binding`() {
+        CanonType.inRing(CanonRing.INTERCHANGE).forEach { type ->
+            assertTrue(
+                type.binding.apple != null,
+                "${type.wireName} is Ring 1 but has no Apple binding — Ring 1 means it maps " +
+                    "to an assistant-schema entity or a system value type",
+            )
+        }
+    }
+
+    @Test
+    fun `no Ring 3 type claims an Apple binding`() {
+        CanonType.inRing(CanonRing.SERVICE).forEach { type ->
+            assertNull(
+                type.binding.apple,
+                "${type.wireName} is Ring 3 (service) but claims an Apple binding",
+            )
+        }
+    }
+
+    @Test
+    fun `Ring 1 entity-schema bindings only name domains the SDK actually ships`() {
+        // Enumerated from iPhoneOS 26.5 AppIntents.swiftinterface; see
+        // .context/recon/apple-assistant-schemas-ios265.tsv
+        val shippedDomains = setOf(
+            "assistant", "books", "browser", "camera", "files", "journal", "mail",
+            "photos", "presentation", "reader", "spreadsheet", "system",
+            "visualIntelligence", "whiteboard", "wordProcessor",
+        )
+
+        CanonType.entries
+            .mapNotNull { it.binding.apple as? AppleSchemaBinding.EntitySchema }
+            .forEach { binding ->
+                assertTrue(
+                    binding.domain in shippedDomains,
+                    "${binding.qualifiedName} names a domain that does not exist in the SDK",
+                )
+            }
+    }
+
+    @Test
+    fun `DocumentKind domains are all real Apple document domains`() {
+        val documentDomains = setOf(
+            "files",
+            "wordProcessor",
+            "spreadsheet",
+            "presentation",
+            "reader",
+            "whiteboard",
+        )
+
+        DocumentKind.entries.forEach { kind ->
+            assertTrue(kind.appleDomain in documentDomains, "${kind.name} -> ${kind.appleDomain}")
+        }
+    }
+
+    @Test
+    fun `the six recon demotions stay demoted`() {
+        // These were proposed as Ring 1 and failed the no-contortion rule: the
+        // shipped Apple catalog has no calendar, reminders, clock, music/video,
+        // messages, or notes domain. Re-promoting one without a new SDK pass is
+        // the regression this test exists to catch.
+        assertEquals(CanonRing.PLATFORM, CanonType.CALENDAR_EVENT.ring)
+        assertEquals(CanonRing.PLATFORM, CanonType.REMINDER.ring)
+        assertEquals(CanonRing.PLATFORM, CanonType.ALARM.ring)
+        assertEquals(CanonRing.PLATFORM, CanonType.MEDIA_ITEM.ring)
+        assertEquals(CanonRing.SERVICE, CanonType.MESSAGE.ring)
+        assertEquals(CanonRing.SERVICE, CanonType.NOTE.ring)
+    }
+
+    @Test
+    fun `Person and Place bind through system value types, not entity schemas`() {
+        val person = CanonType.PERSON.binding.apple
+        val place = CanonType.PLACE.binding.apple
+
+        assertIs<AppleSchemaBinding.SystemValueType>(person)
+        assertIs<AppleSchemaBinding.SystemValueType>(place)
+
+        assertEquals("IntentPerson", person.identifier)
+        assertEquals("CLPlacemark", place.identifier)
+    }
+
+    @Test
+    fun `every lossy binding names at least one dropped field`() {
+        CanonType.entries
+            .filter { it.binding.apple != null }
+            .forEach { type ->
+                assertTrue(
+                    type.binding.lossyFields.isNotEmpty(),
+                    "${type.wireName} has an Apple binding but declares no lossy fields — " +
+                        "a projection with nothing to preserve is almost certainly under-documented",
+                )
+            }
+    }
+
+    @Test
+    fun `Android bindings are all still marked unverified`() {
+        // androidx.appfunctions is not on this repo's classpath, so
+        // AppFunctionSchemaDefinition could not be enumerated during recon.
+        // When it lands, this test flips to assert real bindings.
+        CanonType.entries.forEach { type ->
+            assertTrue(
+                type.binding.android is AndroidSchemaBinding.PendingSdkVerification ||
+                    type.binding.android is AndroidSchemaBinding.None,
+                "${type.wireName} claims a verified Android binding without an SDK pass",
+            )
+        }
+    }
+
+    @Test
+    fun `qualified name renders the dotted Apple address`() {
+        val mail = CanonType.EMAIL_MESSAGE.binding.apple
+        assertIs<AppleSchemaBinding.EntitySchema>(mail)
+        assertEquals("mail.message", mail.qualifiedName)
+        assertEquals("MailMessageEntity", mail.identifier)
+    }
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/canon/adapter/CanonAdapterFixtures.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/canon/adapter/CanonAdapterFixtures.kt
@@ -1,0 +1,198 @@
+package link.socket.ampere.canon.adapter
+
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+import link.socket.ampere.canon.CanonDocument
+import link.socket.ampere.canon.CanonEmailMessage
+import link.socket.ampere.canon.CanonId
+import link.socket.ampere.canon.CanonProvenance
+import link.socket.ampere.canon.CanonType
+import link.socket.ampere.canon.DocumentKind
+import link.socket.ampere.canon.NativePayload
+import link.socket.ampere.canon.SourceHandle
+
+/**
+ * Reference adapters used to exercise the [CanonAdapter] contract.
+ *
+ * They live in the test source set on purpose. AMPR-222 ships the *SPI*; real
+ * adapters are per-Plug work that lands with each transport. These fixtures
+ * cover the three binding shapes a real adapter has to handle:
+ *
+ *  - [MailMessageAdapter] — an entity-schema binding with a write path.
+ *  - [FileDocumentAdapter] — the `Document` fan-out, where the discriminator is
+ *    itself the lossy axis.
+ *  - [OverreachingMailAdapter] — a deliberately broken adapter that writes
+ *    outside its declared `ownedFields`, to prove the guard fires.
+ */
+
+/** A tiny in-memory stand-in for a native mail store. */
+class FakeNativeStore(
+    initial: Map<String, NativePayload> = emptyMap(),
+) {
+    private val rows = initial.toMutableMap()
+    var failNextFetch: String? = null
+
+    fun read(nativeId: String): NativePayload? = rows[nativeId]
+
+    fun write(nativeId: String, payload: NativePayload) {
+        rows[nativeId] = payload
+    }
+
+    fun fetch(nativeId: String): Result<NativePayload> {
+        failNextFetch?.let { reason ->
+            failNextFetch = null
+            return Result.failure(IllegalStateException(reason))
+        }
+        return rows[nativeId]
+            ?.let { Result.success(it) }
+            ?: Result.failure(IllegalStateException("no such native object: $nativeId"))
+    }
+}
+
+class MailMessageAdapter(
+    private val store: FakeNativeStore,
+) : CanonAdapter<CanonEmailMessage>() {
+
+    override val canonType: CanonType = CanonType.EMAIL_MESSAGE
+    override val nativeSchema: String = "MailMessageEntity"
+    override val ownedFields: Set<String> = setOf("subject", "bodyText", "isRead")
+
+    override fun projectFields(
+        fields: JsonObject,
+        provenance: CanonProvenance,
+    ): Result<CanonEmailMessage> {
+        val subject = fields["subject"]?.jsonPrimitive?.contentOrNull
+            ?: return canonFailure(
+                CanonConversionFailure.MissingRequiredField(canonType, "subject", nativeSchema),
+            )
+
+        return Result.success(
+            CanonEmailMessage(
+                canonId = CanonId(provenance.sourceHandle.nativeId),
+                provenance = provenance,
+                subject = subject,
+                from = null,
+                bodyText = fields["bodyText"]?.jsonPrimitive?.contentOrNull,
+                isRead = fields["isRead"]?.jsonPrimitive?.booleanOrNull ?: false,
+            ),
+        )
+    }
+
+    override fun canonFields(entity: CanonEmailMessage): Result<Map<String, JsonElement>> =
+        Result.success(
+            buildMap {
+                put("subject", JsonPrimitive(entity.subject))
+                entity.bodyText?.let { put("bodyText", JsonPrimitive(it)) }
+                put("isRead", JsonPrimitive(entity.isRead))
+            },
+        )
+
+    override suspend fun fetchNative(handle: SourceHandle): Result<NativePayload> =
+        store.fetch(handle.nativeId)
+
+    override suspend fun writeNative(
+        handle: SourceHandle,
+        merged: NativePayload,
+    ): Result<Unit> = runCatching { store.write(handle.nativeId, merged) }
+}
+
+class FileDocumentAdapter(
+    private val store: FakeNativeStore,
+) : CanonAdapter<CanonDocument>() {
+
+    override val canonType: CanonType = CanonType.DOCUMENT
+    override val nativeSchema: String = "FileEntity"
+    override val ownedFields: Set<String> = setOf("title", "documentKind", "mimeType")
+
+    override fun projectFields(
+        fields: JsonObject,
+        provenance: CanonProvenance,
+    ): Result<CanonDocument> {
+        val title = fields["title"]?.jsonPrimitive?.contentOrNull
+            ?: return canonFailure(
+                CanonConversionFailure.MissingRequiredField(canonType, "title", nativeSchema),
+            )
+
+        val rawKind = fields["documentKind"]?.jsonPrimitive?.contentOrNull ?: "file"
+        val kind = DocumentKind.entries.firstOrNull { it.appleDomain == rawKind }
+            ?: return canonFailure(
+                CanonConversionFailure.MalformedField(
+                    canonType,
+                    "documentKind",
+                    "no DocumentKind maps to Apple domain '$rawKind'",
+                ),
+            )
+
+        return Result.success(
+            CanonDocument(
+                canonId = CanonId(provenance.sourceHandle.nativeId),
+                provenance = provenance,
+                title = title,
+                kind = kind,
+                mimeType = fields["mimeType"]?.jsonPrimitive?.contentOrNull,
+            ),
+        )
+    }
+
+    override fun canonFields(entity: CanonDocument): Result<Map<String, JsonElement>> =
+        Result.success(
+            buildMap {
+                put("title", JsonPrimitive(entity.title))
+                put("documentKind", JsonPrimitive(entity.kind.appleDomain))
+                entity.mimeType?.let { put("mimeType", JsonPrimitive(it)) }
+            },
+        )
+
+    override suspend fun fetchNative(handle: SourceHandle): Result<NativePayload> =
+        store.fetch(handle.nativeId)
+
+    override suspend fun writeNative(
+        handle: SourceHandle,
+        merged: NativePayload,
+    ): Result<Unit> = runCatching { store.write(handle.nativeId, merged) }
+}
+
+/**
+ * Writes `providerLabels` — a field its canon projection never read and which
+ * is not in [ownedFields]. Exists to prove the merge refuses it.
+ */
+class OverreachingMailAdapter(
+    private val store: FakeNativeStore,
+) : CanonAdapter<CanonEmailMessage>() {
+
+    override val canonType: CanonType = CanonType.EMAIL_MESSAGE
+    override val nativeSchema: String = "MailMessageEntity"
+    override val ownedFields: Set<String> = setOf("subject")
+
+    override fun projectFields(
+        fields: JsonObject,
+        provenance: CanonProvenance,
+    ): Result<CanonEmailMessage> = Result.success(
+        CanonEmailMessage(
+            canonId = CanonId(provenance.sourceHandle.nativeId),
+            provenance = provenance,
+            subject = fields["subject"]?.jsonPrimitive?.contentOrNull.orEmpty(),
+            from = null,
+        ),
+    )
+
+    override fun canonFields(entity: CanonEmailMessage): Result<Map<String, JsonElement>> =
+        Result.success(
+            mapOf(
+                "subject" to JsonPrimitive(entity.subject),
+                "providerLabels" to JsonPrimitive("clobbered"),
+            ),
+        )
+
+    override suspend fun fetchNative(handle: SourceHandle): Result<NativePayload> =
+        store.fetch(handle.nativeId)
+
+    override suspend fun writeNative(
+        handle: SourceHandle,
+        merged: NativePayload,
+    ): Result<Unit> = runCatching { store.write(handle.nativeId, merged) }
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/canon/adapter/CanonAdapterTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/canon/adapter/CanonAdapterTest.kt
@@ -1,0 +1,310 @@
+package link.socket.ampere.canon.adapter
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import link.socket.ampere.canon.CanonRing
+import link.socket.ampere.canon.CanonType
+import link.socket.ampere.canon.DocumentKind
+import link.socket.ampere.canon.NativePayload
+import link.socket.ampere.canon.SourceHandle
+import link.socket.ampere.link.LinkId
+
+class CanonAdapterTest {
+
+    private val observedAt = Instant.fromEpochMilliseconds(1_700_000_000_000)
+
+    private val handle = SourceHandle(
+        linkId = LinkId("google-oauth-1"),
+        sourceSystem = "apple.mail",
+        nativeId = "msg-42",
+    )
+
+    /**
+     * A realistic native object: three fields the canon projection covers and
+     * four it does not. The four are the ones a naive write-back destroys.
+     */
+    private fun nativeMail() = NativePayload(
+        schema = "MailMessageEntity",
+        fields = JsonObject(
+            mapOf(
+                "subject" to JsonPrimitive("Quarterly review"),
+                "bodyText" to JsonPrimitive("See attached."),
+                "isRead" to JsonPrimitive(false),
+                "mimeStructure" to JsonPrimitive("multipart/mixed"),
+                "rawHeaders" to JsonPrimitive("Received: from mx.example"),
+                "providerLabels" to JsonPrimitive("IMPORTANT,CATEGORY_UPDATES"),
+                "threadId" to JsonPrimitive("thread-7"),
+            ),
+        ),
+    )
+
+    private fun failureOf(result: Result<*>): CanonConversionFailure {
+        val error = result.exceptionOrNull()
+        assertIs<CanonConversionException>(error)
+        return error.failure
+    }
+
+    // -----------------------------------------------------------------
+    // Projection
+    // -----------------------------------------------------------------
+
+    @Test
+    fun `projection carries provenance the adapter cannot omit`() {
+        val adapter = MailMessageAdapter(FakeNativeStore())
+        val payload = nativeMail()
+
+        val entity = adapter.project(payload, handle, observedAt).getOrThrow()
+
+        assertEquals(handle, entity.provenance.sourceHandle)
+        assertEquals(observedAt, entity.provenance.observedAt)
+        assertEquals(payload, entity.provenance.nativePayload)
+        assertEquals(CanonType.EMAIL_MESSAGE, entity.canonType)
+        assertEquals(CanonRing.INTERCHANGE, entity.ring)
+    }
+
+    @Test
+    fun `projection reads the fields the canon type owns`() {
+        val adapter = MailMessageAdapter(FakeNativeStore())
+
+        val entity = adapter.project(nativeMail(), handle, observedAt).getOrThrow()
+
+        assertEquals("Quarterly review", entity.subject)
+        assertEquals("See attached.", entity.bodyText)
+        assertEquals(false, entity.isRead)
+    }
+
+    @Test
+    fun `projection can drop the native payload when the caller asks`() {
+        val adapter = MailMessageAdapter(FakeNativeStore())
+
+        val entity = adapter
+            .project(nativeMail(), handle, observedAt, carryNativePayload = false)
+            .getOrThrow()
+
+        assertNull(entity.provenance.nativePayload)
+    }
+
+    @Test
+    fun `projecting the wrong native schema fails rather than guessing`() {
+        val adapter = MailMessageAdapter(FakeNativeStore())
+        val wrongShape = NativePayload("CalendarEventEntity", JsonObject(emptyMap()))
+
+        val failure = failureOf(adapter.project(wrongShape, handle, observedAt))
+
+        assertIs<CanonConversionFailure.SchemaMismatch>(failure)
+        assertEquals("MailMessageEntity", failure.expectedSchema)
+        assertEquals("CalendarEventEntity", failure.actualSchema)
+    }
+
+    @Test
+    fun `a missing required field is a typed failure, never a throw`() {
+        val adapter = MailMessageAdapter(FakeNativeStore())
+        val empty = NativePayload("MailMessageEntity", JsonObject(emptyMap()))
+
+        val failure = failureOf(adapter.project(empty, handle, observedAt))
+
+        assertIs<CanonConversionFailure.MissingRequiredField>(failure)
+        assertEquals("subject", failure.field)
+    }
+
+    // -----------------------------------------------------------------
+    // Round-trip
+    // -----------------------------------------------------------------
+
+    @Test
+    fun `canon to native round-trip is byte-identical when nothing changed`() = runTest {
+        val adapter = MailMessageAdapter(FakeNativeStore())
+        val original = nativeMail()
+
+        val entity = adapter.project(original, handle, observedAt).getOrThrow()
+        val merged = adapter.mergeForWriteBack(entity).getOrThrow()
+
+        assertEquals(original, merged)
+    }
+
+    @Test
+    fun `document round-trip preserves the fan-out discriminator`() = runTest {
+        val adapter = FileDocumentAdapter(FakeNativeStore())
+        val original = NativePayload(
+            schema = "FileEntity",
+            fields = JsonObject(
+                mapOf(
+                    "title" to JsonPrimitive("Roadmap"),
+                    "documentKind" to JsonPrimitive("presentation"),
+                    "mimeType" to JsonPrimitive("application/vnd.apple.keynote"),
+                    "revisionHistory" to JsonPrimitive("r1,r2,r3"),
+                ),
+            ),
+        )
+
+        val entity = adapter.project(original, handle, observedAt).getOrThrow()
+        assertEquals(DocumentKind.PRESENTATION, entity.kind)
+
+        val merged = adapter.mergeForWriteBack(entity).getOrThrow()
+        assertEquals(original, merged)
+    }
+
+    @Test
+    fun `an unmappable document kind is a typed failure`() {
+        val adapter = FileDocumentAdapter(FakeNativeStore())
+        val payload = NativePayload(
+            schema = "FileEntity",
+            fields = JsonObject(
+                mapOf(
+                    "title" to JsonPrimitive("Mystery"),
+                    "documentKind" to JsonPrimitive("hologram"),
+                ),
+            ),
+        )
+
+        val failure = failureOf(adapter.project(payload, handle, observedAt))
+
+        assertIs<CanonConversionFailure.MalformedField>(failure)
+        assertEquals("documentKind", failure.field)
+    }
+
+    // -----------------------------------------------------------------
+    // Preserve-and-merge write-back — the non-negotiable
+    // -----------------------------------------------------------------
+
+    @Test
+    fun `write-back preserves every native field the projection dropped`() = runTest {
+        val store = FakeNativeStore(mapOf("msg-42" to nativeMail()))
+        val adapter = MailMessageAdapter(store)
+
+        val entity = adapter.project(nativeMail(), handle, observedAt).getOrThrow()
+        val mutated = entity.copy(subject = "Quarterly review (revised)", isRead = true)
+
+        adapter.writeBack(mutated).getOrThrow()
+
+        val written = store.read("msg-42")!!
+
+        // Canon-owned fields changed...
+        assertEquals(JsonPrimitive("Quarterly review (revised)"), written.fields["subject"])
+        assertEquals(JsonPrimitive(true), written.fields["isRead"])
+
+        // ...and everything the projection never saw is byte-identical.
+        assertEquals(JsonPrimitive("multipart/mixed"), written.fields["mimeStructure"])
+        assertEquals(JsonPrimitive("Received: from mx.example"), written.fields["rawHeaders"])
+        assertEquals(JsonPrimitive("IMPORTANT,CATEGORY_UPDATES"), written.fields["providerLabels"])
+        assertEquals(JsonPrimitive("thread-7"), written.fields["threadId"])
+    }
+
+    @Test
+    fun `write-back leaves an owned field alone when the canon value is absent`() = runTest {
+        val store = FakeNativeStore(mapOf("msg-42" to nativeMail()))
+        val adapter = MailMessageAdapter(store)
+
+        val entity = adapter.project(nativeMail(), handle, observedAt).getOrThrow()
+
+        // bodyText is owned but null on the canon entity — a delta, not a document.
+        adapter.writeBack(entity.copy(bodyText = null)).getOrThrow()
+
+        assertEquals(JsonPrimitive("See attached."), store.read("msg-42")!!.fields["bodyText"])
+    }
+
+    @Test
+    fun `an adapter writing outside its owned fields is refused`() = runTest {
+        val store = FakeNativeStore(mapOf("msg-42" to nativeMail()))
+        val adapter = OverreachingMailAdapter(store)
+
+        val entity = adapter.project(nativeMail(), handle, observedAt).getOrThrow()
+        val failure = failureOf(adapter.writeBack(entity))
+
+        assertIs<CanonConversionFailure.UnownedFieldWrite>(failure)
+        assertEquals("providerLabels", failure.field)
+
+        // And nothing was written.
+        assertEquals(JsonPrimitive("IMPORTANT,CATEGORY_UPDATES"), store.read("msg-42")!!.fields["providerLabels"])
+    }
+
+    @Test
+    fun `write-back re-fetches when the entity carries no native payload`() = runTest {
+        val store = FakeNativeStore(mapOf("msg-42" to nativeMail()))
+        val adapter = MailMessageAdapter(store)
+
+        val entity = adapter
+            .project(nativeMail(), handle, observedAt, carryNativePayload = false)
+            .getOrThrow()
+        assertNull(entity.provenance.nativePayload)
+
+        adapter.writeBack(entity.copy(subject = "Re-fetched")).getOrThrow()
+
+        val written = store.read("msg-42")!!
+        assertEquals(JsonPrimitive("Re-fetched"), written.fields["subject"])
+        assertEquals(JsonPrimitive("thread-7"), written.fields["threadId"])
+    }
+
+    @Test
+    fun `a failed re-fetch is a typed failure and writes nothing`() = runTest {
+        val store = FakeNativeStore(mapOf("msg-42" to nativeMail()))
+        val adapter = MailMessageAdapter(store)
+
+        val entity = adapter
+            .project(nativeMail(), handle, observedAt, carryNativePayload = false)
+            .getOrThrow()
+
+        store.failNextFetch = "network down"
+        val failure = failureOf(adapter.writeBack(entity.copy(subject = "Never written")))
+
+        assertIs<CanonConversionFailure.SourceUnavailable>(failure)
+        assertEquals("msg-42", failure.nativeId)
+        assertTrue(failure.reason.contains("network down"))
+
+        assertEquals(JsonPrimitive("Quarterly review"), store.read("msg-42")!!.fields["subject"])
+    }
+
+    @Test
+    fun `merging against a mismatched native schema is refused`() = runTest {
+        val adapter = MailMessageAdapter(FakeNativeStore())
+
+        val entity = adapter.project(nativeMail(), handle, observedAt).getOrThrow()
+        val corrupted = entity.copy(
+            provenance = entity.provenance.copy(
+                nativePayload = NativePayload("CalendarEventEntity", JsonObject(emptyMap())),
+            ),
+        )
+
+        val failure = failureOf(adapter.mergeForWriteBack(corrupted))
+
+        assertIs<CanonConversionFailure.SchemaMismatch>(failure)
+    }
+
+    // -----------------------------------------------------------------
+    // Coverage bookkeeping
+    // -----------------------------------------------------------------
+
+    @Test
+    fun `reference adapter coverage of Ring 1 is stated, not assumed`() {
+        // AMPR-222 ships the SPI; concrete adapters land per-Plug with each
+        // transport. This test names which Ring 1 types have a reference
+        // adapter today so the gap is visible instead of silently absent.
+        val covered = setOf(CanonType.EMAIL_MESSAGE, CanonType.DOCUMENT)
+        val ring1 = CanonType.inRing(CanonRing.INTERCHANGE)
+
+        assertTrue(covered.all { it in ring1 })
+        assertEquals(
+            setOf(
+                CanonType.PERSON,
+                CanonType.EMAIL_DRAFT,
+                CanonType.MAILBOX,
+                CanonType.PHOTO,
+                CanonType.PHOTO_ALBUM,
+                CanonType.PLACE,
+                CanonType.JOURNAL_ENTRY,
+                CanonType.BOOK,
+                CanonType.WEB_BOOKMARK,
+                CanonType.BROWSER_TAB,
+            ),
+            ring1 - covered,
+            "Ring 1 membership changed; update the reference-adapter coverage list",
+        )
+    }
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/canon/adapter/CanonAdapterTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/canon/adapter/CanonAdapterTest.kt
@@ -104,7 +104,7 @@ class CanonAdapterTest {
     }
 
     @Test
-    fun `a missing required field is a typed failure, never a throw`() {
+    fun `a missing required field is a typed failure and never a throw`() {
         val adapter = MailMessageAdapter(FakeNativeStore())
         val empty = NativePayload("MailMessageEntity", JsonObject(emptyMap()))
 
@@ -282,7 +282,7 @@ class CanonAdapterTest {
     // -----------------------------------------------------------------
 
     @Test
-    fun `reference adapter coverage of Ring 1 is stated, not assumed`() {
+    fun `reference adapter coverage of Ring 1 is stated rather than assumed`() {
         // AMPR-222 ships the SPI; concrete adapters land per-Plug with each
         // transport. This test names which Ring 1 types have a reference
         // adapter today so the gap is visible instead of silently absent.

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/link/LinkResolutionGateTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/link/LinkResolutionGateTest.kt
@@ -1,0 +1,347 @@
+package link.socket.ampere.link
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlinx.datetime.Instant
+import link.socket.ampere.canon.CanonType
+
+class LinkResolutionGateTest {
+
+    private val grantedAt = Instant.fromEpochMilliseconds(1_700_000_000_000)
+    private val revokedAt = Instant.fromEpochMilliseconds(1_700_000_500_000)
+
+    private val googleLink = Link(
+        id = LinkId("google-oauth"),
+        transport = Transport.OAUTH_REST,
+        direction = LinkDirection.READ_WRITE,
+        egress = EgressClass.ThirdParty("google"),
+        scope = setOf(CanonType.CALENDAR_EVENT, CanonType.EMAIL_MESSAGE, CanonType.PERSON),
+        credentialRef = CredentialRef("keychain://google"),
+    )
+
+    private val apnsLink = Link(
+        id = LinkId("apns"),
+        transport = Transport.APNS,
+        direction = LinkDirection.WRITE,
+        egress = EgressClass.FirstParty,
+        scope = setOf(CanonType.MESSAGE),
+    )
+
+    private fun grants(plugId: String, links: List<LinkId>) = LinkGrants(
+        plugId = plugId,
+        grants = links.map { LinkGrant(plugId, it, grantedAt) },
+    )
+
+    private fun grants(plugId: String, link: LinkId) = grants(plugId, listOf(link))
+
+    private fun requirement(
+        name: String = "calendar",
+        transport: Transport = Transport.OAUTH_REST,
+        direction: LinkDirection = LinkDirection.READ,
+        scope: Set<CanonType> = setOf(CanonType.CALENDAR_EVENT),
+        role: TransportRole = TransportRole.CONSUMER,
+        optional: Boolean = false,
+    ) = LinkRequirement(name, transport, direction, scope, role, optional)
+
+    // -----------------------------------------------------------------
+    // Sharing — the property the whole design exists for
+    // -----------------------------------------------------------------
+
+    @Test
+    fun `one Link resolves for two different Plugs`() {
+        val calendarPlug = LinkResolutionGate.resolve(
+            requirement = requirement(name = "calendar", scope = setOf(CanonType.CALENDAR_EVENT)),
+            candidates = listOf(googleLink),
+            grants = grants("calendar-plug", googleLink.id),
+            platform = PlatformTarget.ANDROID,
+        )
+
+        val gmailPlug = LinkResolutionGate.resolve(
+            requirement = requirement(name = "mail", scope = setOf(CanonType.EMAIL_MESSAGE)),
+            candidates = listOf(googleLink),
+            grants = grants("gmail-plug", googleLink.id),
+            platform = PlatformTarget.ANDROID,
+        )
+
+        assertIs<LinkResolution.Resolved>(calendarPlug)
+        assertIs<LinkResolution.Resolved>(gmailPlug)
+        assertEquals(googleLink.id, calendarPlug.link.id)
+        assertEquals(googleLink.id, gmailPlug.link.id)
+    }
+
+    @Test
+    fun `a Link the Plug was never granted is invisible, not rejected`() {
+        val result = LinkResolutionGate.resolve(
+            requirement = requirement(),
+            candidates = listOf(googleLink),
+            grants = LinkGrants.empty("stranger-plug"),
+            platform = PlatformTarget.ANDROID,
+        )
+
+        val failed = assertIs<LinkResolution.Failed>(result)
+        assertIs<LinkResolutionFailure.MissingLink>(failed.failure)
+    }
+
+    // -----------------------------------------------------------------
+    // Direction
+    // -----------------------------------------------------------------
+
+    @Test
+    fun `a write-only Link rejects a Perceive-shaped requirement`() {
+        val result = LinkResolutionGate.resolve(
+            requirement = requirement(
+                name = "notify",
+                transport = Transport.APNS,
+                direction = LinkDirection.READ,
+                scope = setOf(CanonType.MESSAGE),
+            ),
+            candidates = listOf(apnsLink),
+            grants = grants("notify-plug", apnsLink.id),
+            platform = PlatformTarget.JVM_DESKTOP,
+        )
+
+        val failed = assertIs<LinkResolution.Failed>(result)
+        val failure = assertIs<LinkResolutionFailure.DirectionViolation>(failed.failure)
+        assertEquals(LinkDirection.READ, failure.required)
+        assertEquals(LinkDirection.WRITE, failure.actual)
+    }
+
+    @Test
+    fun `a write-only Link satisfies an Execute-shaped requirement`() {
+        val result = LinkResolutionGate.resolve(
+            requirement = requirement(
+                name = "notify",
+                transport = Transport.APNS,
+                direction = LinkDirection.WRITE,
+                scope = setOf(CanonType.MESSAGE),
+            ),
+            candidates = listOf(apnsLink),
+            grants = grants("notify-plug", apnsLink.id),
+            platform = PlatformTarget.JVM_DESKTOP,
+        )
+
+        assertIs<LinkResolution.Resolved>(result)
+    }
+
+    @Test
+    fun `a read-write Link satisfies every direction`() {
+        LinkDirection.entries.forEach { required ->
+            assertTrue(LinkDirection.READ_WRITE.satisfies(required), "READ_WRITE vs $required")
+        }
+    }
+
+    @Test
+    fun `an already-resolved write-only Link still refuses Perceive`() {
+        assertTrue(LinkResolutionGate.permits(apnsLink, LinkOperation.EXECUTE))
+        assertTrue(!LinkResolutionGate.permits(apnsLink, LinkOperation.PERCEIVE))
+    }
+
+    // -----------------------------------------------------------------
+    // Scope
+    // -----------------------------------------------------------------
+
+    @Test
+    fun `a Link that may not carry a required canon type is refused`() {
+        val result = LinkResolutionGate.resolve(
+            requirement = requirement(scope = setOf(CanonType.CALENDAR_EVENT, CanonType.HEALTH_SAMPLE)),
+            candidates = listOf(googleLink),
+            grants = grants("calendar-plug", googleLink.id),
+            platform = PlatformTarget.ANDROID,
+        )
+
+        val failed = assertIs<LinkResolution.Failed>(result)
+        val failure = assertIs<LinkResolutionFailure.ScopeViolation>(failed.failure)
+        assertEquals(setOf(CanonType.HEALTH_SAMPLE), failure.missingScope)
+    }
+
+    @Test
+    fun `a Link permitted more than the requirement needs still resolves`() {
+        val result = LinkResolutionGate.resolve(
+            requirement = requirement(scope = setOf(CanonType.CALENDAR_EVENT)),
+            candidates = listOf(googleLink),
+            grants = grants("calendar-plug", googleLink.id),
+            platform = PlatformTarget.ANDROID,
+        )
+
+        assertIs<LinkResolution.Resolved>(result)
+    }
+
+    // -----------------------------------------------------------------
+    // Revocation
+    // -----------------------------------------------------------------
+
+    @Test
+    fun `a revoked Link reports LINK scope, not the Plug grant`() {
+        val result = LinkResolutionGate.resolve(
+            requirement = requirement(),
+            candidates = listOf(googleLink.copy(revokedAt = revokedAt)),
+            grants = grants("calendar-plug", googleLink.id),
+            platform = PlatformTarget.ANDROID,
+        )
+
+        val failed = assertIs<LinkResolution.Failed>(result)
+        val failure = assertIs<LinkResolutionFailure.RevokedCredential>(failed.failure)
+        assertEquals(RevocationScope.LINK, failure.scope)
+    }
+
+    @Test
+    fun `a revoked credential reports CREDENTIAL scope`() {
+        val result = LinkResolutionGate.resolve(
+            requirement = requirement(),
+            candidates = listOf(
+                googleLink.copy(credentialRef = CredentialRef("keychain://google", revokedAt)),
+            ),
+            grants = grants("calendar-plug", googleLink.id),
+            platform = PlatformTarget.ANDROID,
+        )
+
+        val failed = assertIs<LinkResolution.Failed>(result)
+        val failure = assertIs<LinkResolutionFailure.RevokedCredential>(failed.failure)
+        assertEquals(RevocationScope.CREDENTIAL, failure.scope)
+    }
+
+    @Test
+    fun `a revoked Plug grant reports PLUG_GRANT scope and spares other Plugs`() {
+        val revokedGrants = LinkGrants(
+            plugId = "calendar-plug",
+            grants = listOf(LinkGrant("calendar-plug", googleLink.id, grantedAt, revokedAt)),
+        )
+
+        val revokedPlug = LinkResolutionGate.resolve(
+            requirement = requirement(),
+            candidates = listOf(googleLink),
+            grants = revokedGrants,
+            platform = PlatformTarget.ANDROID,
+        )
+
+        val stillGranted = LinkResolutionGate.resolve(
+            requirement = requirement(name = "mail", scope = setOf(CanonType.EMAIL_MESSAGE)),
+            candidates = listOf(googleLink),
+            grants = grants("gmail-plug", googleLink.id),
+            platform = PlatformTarget.ANDROID,
+        )
+
+        val failed = assertIs<LinkResolution.Failed>(revokedPlug)
+        val failure = assertIs<LinkResolutionFailure.RevokedCredential>(failed.failure)
+        assertEquals(RevocationScope.PLUG_GRANT, failure.scope)
+        assertIs<LinkResolution.Resolved>(stillGranted)
+    }
+
+    @Test
+    fun `revocation is reported ahead of a scope violation on the same Link`() {
+        // Precedence matters: a "scope" error on a revoked Link would send the
+        // reader looking in the wrong place entirely.
+        val result = LinkResolutionGate.resolve(
+            requirement = requirement(scope = setOf(CanonType.HEALTH_SAMPLE)),
+            candidates = listOf(googleLink.copy(revokedAt = revokedAt)),
+            grants = grants("calendar-plug", googleLink.id),
+            platform = PlatformTarget.ANDROID,
+        )
+
+        val failed = assertIs<LinkResolution.Failed>(result)
+        assertIs<LinkResolutionFailure.RevokedCredential>(failed.failure)
+    }
+
+    // -----------------------------------------------------------------
+    // Per-platform transport capability
+    // -----------------------------------------------------------------
+
+    private val appFunctionLink = Link(
+        id = LinkId("app-function"),
+        transport = Transport.APP_FUNCTION,
+        direction = LinkDirection.READ_WRITE,
+        egress = EgressClass.OnDevice,
+        scope = setOf(CanonType.CALENDAR_EVENT),
+    )
+
+    @Test
+    fun `an AppFunction consumer requirement resolves on Android`() {
+        val result = LinkResolutionGate.resolve(
+            requirement = requirement(transport = Transport.APP_FUNCTION),
+            candidates = listOf(appFunctionLink),
+            grants = grants("calendar-plug", appFunctionLink.id),
+            platform = PlatformTarget.ANDROID,
+        )
+
+        assertIs<LinkResolution.Resolved>(result)
+    }
+
+    @Test
+    fun `the same AppFunction consumer requirement is refused on iOS`() {
+        // iOS has no AppIntent-consumer path: cross-app orchestration belongs
+        // to Siri. This is the asymmetry the capability flags exist to model.
+        val result = LinkResolutionGate.resolve(
+            requirement = requirement(transport = Transport.APP_FUNCTION),
+            candidates = listOf(appFunctionLink),
+            grants = grants("calendar-plug", appFunctionLink.id),
+            platform = PlatformTarget.IOS,
+        )
+
+        val failed = assertIs<LinkResolution.Failed>(result)
+        val failure = assertIs<LinkResolutionFailure.TransportUnsupported>(failed.failure)
+        assertEquals(PlatformTarget.IOS, failure.platform)
+        assertEquals(TransportRole.CONSUMER, failure.role)
+    }
+
+    @Test
+    fun `a provider-role requirement is refused where the transport cannot provide`() {
+        val result = LinkResolutionGate.resolve(
+            requirement = requirement(role = TransportRole.PROVIDER),
+            candidates = listOf(googleLink),
+            grants = grants("calendar-plug", googleLink.id),
+            platform = PlatformTarget.ANDROID,
+        )
+
+        val failed = assertIs<LinkResolution.Failed>(result)
+        val failure = assertIs<LinkResolutionFailure.TransportUnsupported>(failed.failure)
+        assertEquals(TransportRole.PROVIDER, failure.role)
+    }
+
+    // -----------------------------------------------------------------
+    // Optionality and multi-candidate behaviour
+    // -----------------------------------------------------------------
+
+    @Test
+    fun `an optional requirement with no candidate is skipped, not failed`() {
+        val result = LinkResolutionGate.resolve(
+            requirement = requirement(optional = true),
+            candidates = emptyList(),
+            grants = LinkGrants.empty("calendar-plug"),
+            platform = PlatformTarget.ANDROID,
+        )
+
+        assertIs<LinkResolution.Skipped>(result)
+    }
+
+    @Test
+    fun `a later candidate wins when an earlier one does not satisfy the requirement`() {
+        val narrow = googleLink.copy(id = LinkId("google-narrow"), scope = setOf(CanonType.PERSON))
+        val wide = googleLink.copy(id = LinkId("google-wide"))
+
+        val result = LinkResolutionGate.resolve(
+            requirement = requirement(),
+            candidates = listOf(narrow, wide),
+            grants = grants("calendar-plug", listOf(narrow.id, wide.id)),
+            platform = PlatformTarget.ANDROID,
+        )
+
+        val resolved = assertIs<LinkResolution.Resolved>(result)
+        assertEquals(LinkId("google-wide"), resolved.link.id)
+    }
+
+    @Test
+    fun `a Link of a different transport is never a candidate`() {
+        val result = LinkResolutionGate.resolve(
+            requirement = requirement(transport = Transport.MCP),
+            candidates = listOf(googleLink),
+            grants = grants("calendar-plug", googleLink.id),
+            platform = PlatformTarget.ANDROID,
+        )
+
+        val failed = assertIs<LinkResolution.Failed>(result)
+        val failure = assertIs<LinkResolutionFailure.MissingLink>(failed.failure)
+        assertEquals(Transport.MCP, failure.transport)
+    }
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/link/LinkResolutionGateTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/link/LinkResolutionGateTest.kt
@@ -72,7 +72,7 @@ class LinkResolutionGateTest {
     }
 
     @Test
-    fun `a Link the Plug was never granted is invisible, not rejected`() {
+    fun `a Link the Plug was never granted is invisible rather than rejected`() {
         val result = LinkResolutionGate.resolve(
             requirement = requirement(),
             candidates = listOf(googleLink),
@@ -173,7 +173,7 @@ class LinkResolutionGateTest {
     // -----------------------------------------------------------------
 
     @Test
-    fun `a revoked Link reports LINK scope, not the Plug grant`() {
+    fun `a revoked Link reports LINK scope rather than the Plug grant`() {
         val result = LinkResolutionGate.resolve(
             requirement = requirement(),
             candidates = listOf(googleLink.copy(revokedAt = revokedAt)),
@@ -304,7 +304,7 @@ class LinkResolutionGateTest {
     // -----------------------------------------------------------------
 
     @Test
-    fun `an optional requirement with no candidate is skipped, not failed`() {
+    fun `an optional requirement with no candidate is skipped rather than failed`() {
         val result = LinkResolutionGate.resolve(
             requirement = requirement(optional = true),
             candidates = emptyList(),

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/link/LinkResolutionServiceTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/link/LinkResolutionServiceTest.kt
@@ -1,0 +1,299 @@
+package link.socket.ampere.link
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import kotlinx.datetime.Instant
+import link.socket.ampere.agents.domain.event.LinkEvent
+import link.socket.ampere.agents.events.bus.EventSerialBus
+import link.socket.ampere.agents.events.bus.subscribe
+import link.socket.ampere.agents.events.subscription.EventSubscription
+import link.socket.ampere.canon.CanonType
+import link.socket.ampere.plug.PlugManifest
+
+class LinkResolutionServiceTest {
+
+    private val googleLink = Link(
+        id = LinkId("google-oauth"),
+        transport = Transport.OAUTH_REST,
+        direction = LinkDirection.READ_WRITE,
+        egress = EgressClass.ThirdParty("google"),
+        scope = setOf(CanonType.CALENDAR_EVENT, CanonType.EMAIL_MESSAGE),
+        credentialRef = CredentialRef("keychain://google"),
+    )
+
+    private val calendarRequirement = LinkRequirement(
+        name = "calendar",
+        transport = Transport.OAUTH_REST,
+        direction = LinkDirection.READ_WRITE,
+        minimumScope = setOf(CanonType.CALENDAR_EVENT),
+    )
+
+    private fun manifest(vararg requirements: LinkRequirement) = PlugManifest(
+        id = "calendar-plug",
+        name = "Calendar Plug",
+        version = "1.0.0",
+        requiredLinks = requirements.toList(),
+        consumes = setOf(CanonType.CALENDAR_EVENT),
+        emits = setOf(CanonType.CALENDAR_EVENT),
+    )
+
+    private fun service(
+        store: LinkStore,
+        platform: PlatformTarget = PlatformTarget.ANDROID,
+        bus: EventSerialBus? = null,
+    ) = LinkResolutionService(linkStore = store, platform = platform, eventBus = bus)
+
+    @Test
+    fun `resolution returns the Link keyed by requirement name`() = runTest {
+        val store = InMemoryLinkStore(listOf(googleLink))
+        store.grant("calendar-plug", googleLink.id, Instant.fromEpochMilliseconds(1))
+
+        val resolved = service(store)
+            .resolve("calendar-plug", manifest(calendarRequirement))
+            .getOrThrow()
+
+        assertEquals(googleLink, resolved["calendar"])
+        assertNull(resolved["nonexistent"])
+    }
+
+    @Test
+    fun `a missing Link is a Result failure, never a throw`() = runTest {
+        val store = InMemoryLinkStore()
+
+        val result = service(store).resolve("calendar-plug", manifest(calendarRequirement))
+
+        assertTrue(result.isFailure)
+        val error = assertIs<LinkResolutionException>(result.exceptionOrNull())
+        assertIs<LinkResolutionFailure.MissingLink>(error.failures.single())
+    }
+
+    @Test
+    fun `every failure is reported, not just the first`() = runTest {
+        val store = InMemoryLinkStore(listOf(googleLink))
+        store.grant("calendar-plug", googleLink.id, Instant.fromEpochMilliseconds(1))
+
+        val result = service(store).resolve(
+            plugId = "calendar-plug",
+            manifest = manifest(
+                calendarRequirement.copy(
+                    name = "health",
+                    minimumScope = setOf(CanonType.HEALTH_SAMPLE),
+                ),
+                LinkRequirement(
+                    name = "notify",
+                    transport = Transport.APNS,
+                    direction = LinkDirection.WRITE,
+                    minimumScope = setOf(CanonType.MESSAGE),
+                ),
+            ),
+        )
+
+        val error = assertIs<LinkResolutionException>(result.exceptionOrNull())
+        assertEquals(2, error.failures.size)
+        assertContentEquals(
+            listOf("health", "notify"),
+            error.failures.map { it.requirementName },
+        )
+    }
+
+    @Test
+    fun `an optional requirement does not fail the whole resolution`() = runTest {
+        val store = InMemoryLinkStore(listOf(googleLink))
+        store.grant("calendar-plug", googleLink.id, Instant.fromEpochMilliseconds(1))
+
+        val resolved = service(store).resolve(
+            plugId = "calendar-plug",
+            manifest = manifest(
+                calendarRequirement,
+                LinkRequirement(
+                    name = "notify",
+                    transport = Transport.APNS,
+                    direction = LinkDirection.WRITE,
+                    minimumScope = setOf(CanonType.MESSAGE),
+                    optional = true,
+                ),
+            ),
+        ).getOrThrow()
+
+        assertNotNull(resolved["calendar"])
+        assertNull(resolved["notify"])
+    }
+
+    @Test
+    fun `an optional requirement whose Link is misconfigured still does not block`() = runTest {
+        val writeOnly = Link(
+            id = LinkId("apns"),
+            transport = Transport.APNS,
+            direction = LinkDirection.WRITE,
+            egress = EgressClass.FirstParty,
+            scope = setOf(CanonType.MESSAGE),
+        )
+        val store = InMemoryLinkStore(listOf(googleLink, writeOnly))
+        store.grant("calendar-plug", googleLink.id, Instant.fromEpochMilliseconds(1))
+        store.grant("calendar-plug", writeOnly.id, Instant.fromEpochMilliseconds(2))
+
+        val resolved = service(store, platform = PlatformTarget.JVM_DESKTOP).resolve(
+            plugId = "calendar-plug",
+            manifest = manifest(
+                calendarRequirement,
+                LinkRequirement(
+                    name = "notify",
+                    transport = Transport.APNS,
+                    // Asking to read from a write-only sink: a real
+                    // DirectionViolation, on an optional requirement.
+                    direction = LinkDirection.READ,
+                    minimumScope = setOf(CanonType.MESSAGE),
+                    optional = true,
+                ),
+            ),
+        ).getOrThrow()
+
+        assertNotNull(resolved["calendar"])
+        assertNull(resolved["notify"])
+    }
+
+    @Test
+    fun `granting an unknown Link fails without touching the store`() = runTest {
+        val store = InMemoryLinkStore()
+
+        val result = service(store).grant("calendar-plug", LinkId("ghost"))
+
+        assertIs<UnknownLinkException>(result.exceptionOrNull())
+        assertTrue(store.grantsForPlug("calendar-plug").getOrThrow().grants.isEmpty())
+    }
+
+    // -----------------------------------------------------------------
+    // Revocation cascade
+    // -----------------------------------------------------------------
+
+    @Test
+    fun `revoking a Link cascades to every Plug that held a grant`() = runTest {
+        val store = InMemoryLinkStore(listOf(googleLink))
+        store.grant("calendar-plug", googleLink.id, Instant.fromEpochMilliseconds(1))
+        store.grant("gmail-plug", googleLink.id, Instant.fromEpochMilliseconds(2))
+
+        val affected = service(store).revokeLink(googleLink.id).getOrThrow()
+
+        assertEquals(setOf("calendar-plug", "gmail-plug"), affected.toSet())
+        assertTrue(store.get(googleLink.id).getOrThrow()!!.isRevoked)
+        assertTrue(store.grantsForPlug("gmail-plug").getOrThrow().isRevoked(googleLink.id))
+    }
+
+    @Test
+    fun `revoking one Plug's grant leaves the other Plug working`() = runTest {
+        val store = InMemoryLinkStore(listOf(googleLink))
+        store.grant("calendar-plug", googleLink.id, Instant.fromEpochMilliseconds(1))
+        store.grant("gmail-plug", googleLink.id, Instant.fromEpochMilliseconds(2))
+
+        val svc = service(store)
+        svc.revokeGrant("calendar-plug", googleLink.id).getOrThrow()
+
+        assertTrue(svc.resolve("calendar-plug", manifest(calendarRequirement)).isFailure)
+        assertTrue(
+            svc.resolve(
+                "gmail-plug",
+                manifest(calendarRequirement.copy(name = "mail", minimumScope = setOf(CanonType.EMAIL_MESSAGE))),
+            ).isSuccess,
+        )
+    }
+
+    // -----------------------------------------------------------------
+    // Bus lifecycle
+    // -----------------------------------------------------------------
+
+    @Test
+    fun `a successful resolution announces itself on the bus`() = runTest {
+        coroutineScope {
+            val bus = EventSerialBus(scope = this)
+            val received = CompletableDeferred<LinkEvent.LinkResolved>()
+
+            bus.subscribe<LinkEvent.LinkResolved, EventSubscription.ByEventClassType>(
+                agentId = "observer",
+                eventType = LinkEvent.LinkResolved.EVENT_TYPE,
+            ) { event, _ ->
+                if (!received.isCompleted) received.complete(event)
+            }
+
+            val store = InMemoryLinkStore(listOf(googleLink))
+            store.grant("calendar-plug", googleLink.id, Instant.fromEpochMilliseconds(1))
+
+            service(store, bus = bus)
+                .resolve("calendar-plug", manifest(calendarRequirement))
+                .getOrThrow()
+
+            val seen = withTimeout(5.seconds) { received.await() }
+            assertEquals("calendar", seen.requirementName)
+            assertEquals(googleLink.id, seen.linkId)
+            assertEquals(Transport.OAUTH_REST, seen.transport)
+        }
+    }
+
+    @Test
+    fun `a failed resolution is never silent`() = runTest {
+        coroutineScope {
+            val bus = EventSerialBus(scope = this)
+            val received = CompletableDeferred<LinkEvent.LinkResolutionFailed>()
+
+            bus.subscribe<LinkEvent.LinkResolutionFailed, EventSubscription.ByEventClassType>(
+                agentId = "observer",
+                eventType = LinkEvent.LinkResolutionFailed.EVENT_TYPE,
+            ) { event, _ ->
+                if (!received.isCompleted) received.complete(event)
+            }
+
+            service(InMemoryLinkStore(), bus = bus)
+                .resolve("calendar-plug", manifest(calendarRequirement))
+
+            val seen = withTimeout(5.seconds) { received.await() }
+            assertIs<LinkResolutionFailure.MissingLink>(seen.failure)
+            assertEquals(LinkEvent.LinkResolutionFailed.NO_LINK, seen.linkId)
+        }
+    }
+
+    @Test
+    fun `a revocation announces its blast radius`() = runTest {
+        coroutineScope {
+            val bus = EventSerialBus(scope = this)
+            val received = CompletableDeferred<LinkEvent.LinkRevoked>()
+
+            bus.subscribe<LinkEvent.LinkRevoked, EventSubscription.ByEventClassType>(
+                agentId = "observer",
+                eventType = LinkEvent.LinkRevoked.EVENT_TYPE,
+            ) { event, _ ->
+                if (!received.isCompleted) received.complete(event)
+            }
+
+            val store = InMemoryLinkStore(listOf(googleLink))
+            store.grant("calendar-plug", googleLink.id, Instant.fromEpochMilliseconds(1))
+            store.grant("gmail-plug", googleLink.id, Instant.fromEpochMilliseconds(2))
+
+            service(store, bus = bus).revokeLink(googleLink.id).getOrThrow()
+
+            val seen = withTimeout(5.seconds) { received.await() }
+            assertEquals(RevocationScope.LINK, seen.scope)
+            assertEquals(setOf("calendar-plug", "gmail-plug"), seen.affectedPlugIds.toSet())
+        }
+    }
+
+    @Test
+    fun `resolution works with no bus wired`() = runTest {
+        val store = InMemoryLinkStore(listOf(googleLink))
+        store.grant("calendar-plug", googleLink.id, Instant.fromEpochMilliseconds(1))
+
+        assertTrue(
+            service(store, bus = null)
+                .resolve("calendar-plug", manifest(calendarRequirement))
+                .isSuccess,
+        )
+    }
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/link/LinkResolutionServiceTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/link/LinkResolutionServiceTest.kt
@@ -67,7 +67,7 @@ class LinkResolutionServiceTest {
     }
 
     @Test
-    fun `a missing Link is a Result failure, never a throw`() = runTest {
+    fun `a missing Link is a Result failure and never a throw`() = runTest {
         val store = InMemoryLinkStore()
 
         val result = service(store).resolve("calendar-plug", manifest(calendarRequirement))
@@ -78,7 +78,7 @@ class LinkResolutionServiceTest {
     }
 
     @Test
-    fun `every failure is reported, not just the first`() = runTest {
+    fun `every failure is reported rather than just the first`() = runTest {
         val store = InMemoryLinkStore(listOf(googleLink))
         store.grant("calendar-plug", googleLink.id, Instant.fromEpochMilliseconds(1))
 

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/link/LinkSerializationTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/link/LinkSerializationTest.kt
@@ -1,0 +1,203 @@
+package link.socket.ampere.link
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.datetime.Instant
+import kotlinx.serialization.json.Json
+import link.socket.ampere.agents.domain.event.EventRegistry
+import link.socket.ampere.agents.domain.event.EventSource
+import link.socket.ampere.agents.domain.event.LinkEvent
+import link.socket.ampere.canon.CanonType
+
+/**
+ * Links persist as JSON in `Links.link_json` and their lifecycle events land in
+ * traces. Both are wire contracts, so the discriminators are pinned.
+ */
+class LinkSerializationTest {
+
+    private val json = Json {
+        prettyPrint = false
+        encodeDefaults = true
+        classDiscriminator = "type"
+        ignoreUnknownKeys = true
+    }
+
+    private val now = Instant.fromEpochMilliseconds(1_700_000_000_000)
+
+    private val link = Link(
+        id = LinkId("google-oauth"),
+        transport = Transport.OAUTH_REST,
+        direction = LinkDirection.READ_WRITE,
+        egress = EgressClass.ThirdParty("google"),
+        scope = setOf(CanonType.CALENDAR_EVENT, CanonType.EMAIL_MESSAGE),
+        credentialRef = CredentialRef("keychain://google"),
+    )
+
+    @Test
+    fun `a Link round-trips with its scope and egress intact`() {
+        val decoded = json.decodeFromString(
+            Link.serializer(),
+            json.encodeToString(Link.serializer(), link),
+        )
+
+        assertEquals(link, decoded)
+    }
+
+    @Test
+    fun `every egress class round-trips`() {
+        listOf(
+            EgressClass.OnDevice,
+            EgressClass.FirstParty,
+            EgressClass.ThirdParty("uber"),
+        ).forEach { egress ->
+            val encoded = json.encodeToString(EgressClass.serializer(), egress)
+            assertEquals(egress, json.decodeFromString(EgressClass.serializer(), encoded))
+        }
+    }
+
+    @Test
+    fun `egress discriminators are pinned`() {
+        assertTrue(
+            json.encodeToString(EgressClass.serializer(), EgressClass.OnDevice)
+                .contains("\"type\":\"egress.on_device\""),
+        )
+        assertTrue(
+            json.encodeToString(EgressClass.serializer(), EgressClass.ThirdParty("uber"))
+                .contains("\"type\":\"egress.third_party\""),
+        )
+    }
+
+    @Test
+    fun `a credential ref never carries the credential`() {
+        val encoded = json.encodeToString(CredentialRef.serializer(), link.credentialRef!!)
+
+        // The alias is a pointer; if a token ever appears in this type, every
+        // trace that recorded a Link becomes a breach.
+        assertTrue(encoded.contains("keychain://google"))
+        assertEquals(
+            setOf("keychainAlias", "revokedAt"),
+            Regex("\"(\\w+)\":").findAll(encoded).map { it.groupValues[1] }.toSet(),
+        )
+    }
+
+    @Test
+    fun `every resolution failure round-trips`() {
+        val failures = listOf<LinkResolutionFailure>(
+            LinkResolutionFailure.MissingLink("calendar", Transport.MCP, LinkDirection.READ),
+            LinkResolutionFailure.DirectionViolation(
+                "notify",
+                LinkId("apns"),
+                LinkDirection.READ,
+                LinkDirection.WRITE,
+            ),
+            LinkResolutionFailure.ScopeViolation(
+                "calendar",
+                LinkId("google-oauth"),
+                setOf(CanonType.HEALTH_SAMPLE),
+            ),
+            LinkResolutionFailure.RevokedCredential(
+                "calendar",
+                LinkId("google-oauth"),
+                RevocationScope.PLUG_GRANT,
+            ),
+            LinkResolutionFailure.TransportUnsupported(
+                "calendar",
+                LinkId("app-function"),
+                Transport.APP_FUNCTION,
+                PlatformTarget.IOS,
+                TransportRole.CONSUMER,
+            ),
+        )
+
+        failures.forEach { failure ->
+            val encoded = json.encodeToString(LinkResolutionFailure.serializer(), failure)
+            assertEquals(
+                failure,
+                json.decodeFromString(LinkResolutionFailure.serializer(), encoded),
+            )
+        }
+    }
+
+    @Test
+    fun `every LinkEvent variant is registered on the bus`() {
+        listOf(
+            LinkEvent.LinkGranted.EVENT_TYPE,
+            LinkEvent.LinkRevoked.EVENT_TYPE,
+            LinkEvent.LinkResolved.EVENT_TYPE,
+            LinkEvent.LinkResolutionFailed.EVENT_TYPE,
+        ).forEach { eventType ->
+            assertTrue(
+                eventType in EventRegistry.allEventTypes,
+                "$eventType is missing from EventRegistry — trace capture would never see it",
+            )
+        }
+    }
+
+    @Test
+    fun `LinkEvent variants round-trip through the sealed Event serializer`() {
+        val events = mapOf(
+            "LinkEvent.LinkGranted" to LinkEvent.LinkGranted(
+                eventId = "e1",
+                timestamp = now,
+                eventSource = EventSource.Human,
+                linkId = link.id,
+                plugId = "calendar-plug",
+                transport = Transport.OAUTH_REST,
+            ),
+            "LinkEvent.LinkRevoked" to LinkEvent.LinkRevoked(
+                eventId = "e2",
+                timestamp = now,
+                eventSource = EventSource.Human,
+                linkId = link.id,
+                scope = RevocationScope.LINK,
+                affectedPlugIds = listOf("calendar-plug", "gmail-plug"),
+            ),
+            "LinkEvent.LinkResolved" to LinkEvent.LinkResolved(
+                eventId = "e3",
+                timestamp = now,
+                eventSource = EventSource.Agent("agent-1"),
+                linkId = link.id,
+                plugId = "calendar-plug",
+                requirementName = "calendar",
+                transport = Transport.OAUTH_REST,
+            ),
+            "LinkEvent.LinkResolutionFailed" to LinkEvent.LinkResolutionFailed(
+                eventId = "e4",
+                timestamp = now,
+                eventSource = EventSource.Agent("agent-1"),
+                linkId = LinkEvent.LinkResolutionFailed.NO_LINK,
+                plugId = "calendar-plug",
+                failure = LinkResolutionFailure.MissingLink(
+                    "calendar",
+                    Transport.MCP,
+                    LinkDirection.READ,
+                ),
+            ),
+        )
+
+        events.forEach { (discriminator, event) ->
+            val encoded = json.encodeToString(LinkEvent.serializer(), event)
+            assertTrue(encoded.contains("\"type\":\"$discriminator\""), encoded)
+            assertEquals(event, json.decodeFromString(LinkEvent.serializer(), encoded))
+        }
+    }
+
+    @Test
+    fun `summaries name the plug, the link, and the reason`() {
+        val failed = LinkEvent.LinkResolutionFailed(
+            eventId = "e4",
+            timestamp = now,
+            eventSource = EventSource.Agent("agent-1"),
+            linkId = LinkEvent.LinkResolutionFailed.NO_LINK,
+            plugId = "calendar-plug",
+            failure = LinkResolutionFailure.MissingLink("calendar", Transport.MCP, LinkDirection.READ),
+        )
+
+        val summary = failed.getSummary({ "[urgency]" }, { "agent-1" })
+
+        assertTrue(summary.contains("calendar-plug"))
+        assertTrue(summary.contains("calendar"))
+        assertTrue(summary.contains("MissingLink"))
+    }
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/link/LinkSerializationTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/link/LinkSerializationTest.kt
@@ -184,7 +184,7 @@ class LinkSerializationTest {
     }
 
     @Test
-    fun `summaries name the plug, the link, and the reason`() {
+    fun `summaries name the plug and the link and the reason`() {
         val failed = LinkEvent.LinkResolutionFailed(
             eventId = "e4",
             timestamp = now,

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/link/TransportCapabilityTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/link/TransportCapabilityTest.kt
@@ -29,7 +29,7 @@ class TransportCapabilityTest {
     }
 
     @Test
-    fun `iOS app-to-app runs through UriScheme, not AppFunction`() {
+    fun `iOS app-to-app runs through UriScheme rather than AppFunction`() {
         assertFalse(Transport.APP_FUNCTION.capability(PlatformTarget.IOS).canConsume)
         assertTrue(Transport.URI_SCHEME.capability(PlatformTarget.IOS).canConsume)
     }
@@ -71,7 +71,7 @@ class TransportCapabilityTest {
     }
 
     @Test
-    fun `APNS sends from the server side, not from the handset`() {
+    fun `APNS sends from the server side rather than from the handset`() {
         assertTrue(Transport.APNS.capability(PlatformTarget.JVM_DESKTOP).canConsume)
         assertEquals(TransportCapability.NONE, Transport.APNS.capability(PlatformTarget.IOS))
     }

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/link/TransportCapabilityTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/link/TransportCapabilityTest.kt
@@ -1,0 +1,103 @@
+package link.socket.ampere.link
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The per-platform capability table is the modelling decision AMPR-223 exists
+ * to get right, so it is pinned rather than left to be rediscovered in an
+ * integration test on a device.
+ */
+class TransportCapabilityTest {
+
+    @Test
+    fun `AppFunction is bidirectional on Android and absent everywhere else`() {
+        assertEquals(
+            TransportCapability.BIDIRECTIONAL,
+            Transport.APP_FUNCTION.capability(PlatformTarget.ANDROID),
+        )
+
+        listOf(PlatformTarget.IOS, PlatformTarget.JVM_DESKTOP, PlatformTarget.MACOS).forEach { target ->
+            assertEquals(
+                TransportCapability.NONE,
+                Transport.APP_FUNCTION.capability(target),
+                "AppFunction must have no capability on $target",
+            )
+        }
+    }
+
+    @Test
+    fun `iOS app-to-app runs through UriScheme, not AppFunction`() {
+        assertFalse(Transport.APP_FUNCTION.capability(PlatformTarget.IOS).canConsume)
+        assertTrue(Transport.URI_SCHEME.capability(PlatformTarget.IOS).canConsume)
+    }
+
+    @Test
+    fun `Ampere consumes MCP everywhere but only hosts it off-device`() {
+        PlatformTarget.entries.forEach { target ->
+            assertTrue(Transport.MCP.capability(target).canConsume, "MCP consume on $target")
+        }
+
+        assertFalse(Transport.MCP.capability(PlatformTarget.IOS).canProvide)
+        assertFalse(Transport.MCP.capability(PlatformTarget.ANDROID).canProvide)
+        assertTrue(Transport.MCP.capability(PlatformTarget.JVM_DESKTOP).canProvide)
+        assertTrue(Transport.MCP.capability(PlatformTarget.MACOS).canProvide)
+    }
+
+    @Test
+    fun `Ampere is never an OAuth provider`() {
+        PlatformTarget.entries.forEach { target ->
+            assertFalse(Transport.OAUTH_REST.capability(target).canProvide, "on $target")
+        }
+    }
+
+    @Test
+    fun `native frameworks are unreachable from a plain JVM`() {
+        assertEquals(
+            TransportCapability.NONE,
+            Transport.NATIVE_FRAMEWORK.capability(PlatformTarget.JVM_DESKTOP),
+        )
+        assertTrue(Transport.NATIVE_FRAMEWORK.capability(PlatformTarget.IOS).canConsume)
+    }
+
+    @Test
+    fun `CLI is a desktop story only`() {
+        assertTrue(Transport.CLI.capability(PlatformTarget.JVM_DESKTOP).canConsume)
+        assertTrue(Transport.CLI.capability(PlatformTarget.MACOS).canConsume)
+        assertEquals(TransportCapability.NONE, Transport.CLI.capability(PlatformTarget.IOS))
+        assertEquals(TransportCapability.NONE, Transport.CLI.capability(PlatformTarget.ANDROID))
+    }
+
+    @Test
+    fun `APNS sends from the server side, not from the handset`() {
+        assertTrue(Transport.APNS.capability(PlatformTarget.JVM_DESKTOP).canConsume)
+        assertEquals(TransportCapability.NONE, Transport.APNS.capability(PlatformTarget.IOS))
+    }
+
+    @Test
+    fun `permits maps a role onto the capability flags`() {
+        val android = Transport.APP_FUNCTION.capability(PlatformTarget.ANDROID)
+        assertTrue(android.permits(TransportRole.PROVIDER))
+        assertTrue(android.permits(TransportRole.CONSUMER))
+
+        val ios = Transport.APP_FUNCTION.capability(PlatformTarget.IOS)
+        assertFalse(ios.permits(TransportRole.PROVIDER))
+        assertFalse(ios.permits(TransportRole.CONSUMER))
+    }
+
+    @Test
+    fun `only MCP has a transport implementation today`() {
+        // Cli and AppFunction are explicitly enum members with no implementation
+        // (macOS post-launch; Android consumer path gated on AMPR-226). The rest
+        // land with their own tickets.
+        Transport.entries.forEach { transport ->
+            assertEquals(
+                transport == Transport.MCP,
+                transport.hasImplementation,
+                "${transport.name}.hasImplementation",
+            )
+        }
+    }
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/mcp/McpCredentialBindingTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/mcp/McpCredentialBindingTest.kt
@@ -4,6 +4,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlinx.coroutines.test.runTest
+import link.socket.ampere.link.LinkId
 
 class McpCredentialBindingTest {
 

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/plug/PlugManifestValidationTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/plug/PlugManifestValidationTest.kt
@@ -4,6 +4,10 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
+import link.socket.ampere.canon.CanonType
+import link.socket.ampere.link.LinkDirection
+import link.socket.ampere.link.LinkRequirement
+import link.socket.ampere.link.Transport
 import link.socket.ampere.plug.permission.PlugPermission
 
 class PlugManifestValidationTest {
@@ -119,5 +123,94 @@ class PlugManifestValidationTest {
             .map { it.uri }
         assertTrue("mcp://b" in missingUris)
         assertTrue("mcp://a" !in missingUris)
+    }
+
+    // -----------------------------------------------------------------
+    // Link requirements
+    // -----------------------------------------------------------------
+
+    private fun linkRequirement(
+        name: String,
+        scope: Set<CanonType> = setOf(CanonType.CALENDAR_EVENT),
+    ) = LinkRequirement(
+        name = name,
+        transport = Transport.OAUTH_REST,
+        direction = LinkDirection.READ,
+        minimumScope = scope,
+    )
+
+    @Test
+    fun `a manifest declaring well-formed link requirements validates`() {
+        val manifest = PlugManifest(
+            id = "calendar-plug",
+            name = "Calendar Plug",
+            version = "1.0.0",
+            requiredLinks = listOf(
+                linkRequirement("calendar"),
+                linkRequirement("mail", setOf(CanonType.EMAIL_MESSAGE)),
+            ),
+            emits = setOf(CanonType.CALENDAR_EVENT),
+            consumes = setOf(CanonType.PERSON),
+        )
+
+        assertEquals(ManifestValidationResult.Valid, PlugManifestValidator.validate(manifest))
+    }
+
+    @Test
+    fun `two link requirements sharing a name are rejected`() {
+        // Both would collapse onto one key in ResolvedLinks, so one Link would
+        // be silently unreachable at execution time.
+        val manifest = PlugManifest(
+            id = "calendar-plug",
+            name = "Calendar Plug",
+            version = "1.0.0",
+            requiredLinks = listOf(
+                linkRequirement("calendar"),
+                linkRequirement("calendar", setOf(CanonType.EMAIL_MESSAGE)),
+            ),
+        )
+
+        val invalid = assertIs<ManifestValidationResult.Invalid>(
+            PlugManifestValidator.validate(manifest),
+        )
+
+        assertEquals(
+            listOf("calendar"),
+            invalid.reasons
+                .filterIsInstance<ManifestValidationReason.DuplicateLinkRequirementName>()
+                .map { it.name },
+        )
+    }
+
+    @Test
+    fun `a link requirement with an empty scope is rejected`() {
+        val manifest = PlugManifest(
+            id = "calendar-plug",
+            name = "Calendar Plug",
+            version = "1.0.0",
+            requiredLinks = listOf(linkRequirement("calendar", emptySet())),
+        )
+
+        val invalid = assertIs<ManifestValidationResult.Invalid>(
+            PlugManifestValidator.validate(manifest),
+        )
+
+        assertEquals(
+            listOf("calendar"),
+            invalid.reasons
+                .filterIsInstance<ManifestValidationReason.EmptyLinkRequirementScope>()
+                .map { it.name },
+        )
+    }
+
+    @Test
+    fun `a manifest written before link requirements existed still decodes`() {
+        // The defaults are what keep pre-AMPR-223 manifests valid.
+        val manifest = PlugManifest(id = "legacy", name = "Legacy", version = "0.1.0")
+
+        assertTrue(manifest.requiredLinks.isEmpty())
+        assertTrue(manifest.emits.isEmpty())
+        assertTrue(manifest.consumes.isEmpty())
+        assertEquals(ManifestValidationResult.Valid, PlugManifestValidator.validate(manifest))
     }
 }

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/link/SqlDelightLinkStoreTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/link/SqlDelightLinkStoreTest.kt
@@ -1,0 +1,172 @@
+package link.socket.ampere.link
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import link.socket.ampere.canon.CanonType
+import link.socket.ampere.db.Database
+
+class SqlDelightLinkStoreTest {
+
+    private lateinit var driver: JdbcSqliteDriver
+    private lateinit var store: LinkStore
+
+    private val at = Instant.fromEpochMilliseconds(1_700_000_000_000)
+    private val later = Instant.fromEpochMilliseconds(1_700_000_500_000)
+
+    private val googleLink = Link(
+        id = LinkId("google-oauth"),
+        transport = Transport.OAUTH_REST,
+        direction = LinkDirection.READ_WRITE,
+        egress = EgressClass.ThirdParty("google"),
+        scope = setOf(CanonType.CALENDAR_EVENT, CanonType.EMAIL_MESSAGE),
+        credentialRef = CredentialRef("keychain://google"),
+    )
+
+    private val vaultLink = Link(
+        id = LinkId("obsidian-vault"),
+        transport = Transport.FOLDER_MOUNT,
+        direction = LinkDirection.READ_WRITE,
+        egress = EgressClass.OnDevice,
+        scope = setOf(CanonType.NOTE),
+    )
+
+    @BeforeTest
+    fun setUp() {
+        driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        Database.Schema.create(driver)
+        store = SqlDelightLinkStore(Database(driver))
+    }
+
+    @AfterTest
+    fun tearDown() {
+        driver.close()
+    }
+
+    @Test
+    fun `a Link survives a persistence round-trip unchanged`() = runTest {
+        store.upsert(googleLink, at).getOrThrow()
+
+        assertEquals(googleLink, store.get(googleLink.id).getOrThrow())
+    }
+
+    @Test
+    fun `an absent Link reads back as null rather than failing`() = runTest {
+        assertNull(store.get(LinkId("nope")).getOrThrow())
+    }
+
+    @Test
+    fun `upsert replaces rather than duplicating`() = runTest {
+        store.upsert(googleLink, at).getOrThrow()
+        store.upsert(googleLink.copy(direction = LinkDirection.READ), later).getOrThrow()
+
+        val all = store.list().getOrThrow()
+        assertEquals(1, all.size)
+        assertEquals(LinkDirection.READ, all.single().direction)
+    }
+
+    @Test
+    fun `listByTransport uses the denormalized index column`() = runTest {
+        store.upsert(googleLink, at).getOrThrow()
+        store.upsert(vaultLink, at).getOrThrow()
+
+        assertEquals(
+            listOf(vaultLink),
+            store.listByTransport(Transport.FOLDER_MOUNT).getOrThrow(),
+        )
+        assertEquals(2, store.list().getOrThrow().size)
+    }
+
+    @Test
+    fun `grants round-trip per Plug`() = runTest {
+        store.upsert(googleLink, at).getOrThrow()
+        store.grant("calendar-plug", googleLink.id, at).getOrThrow()
+
+        val grants = store.grantsForPlug("calendar-plug").getOrThrow()
+
+        assertTrue(grants.isGranted(googleLink.id))
+        assertFalse(grants.isRevoked(googleLink.id))
+        assertEquals(at, grants.grantFor(googleLink.id)?.grantedAt)
+    }
+
+    @Test
+    fun `revoking a grant preserves the original grant timestamp`() = runTest {
+        store.upsert(googleLink, at).getOrThrow()
+        store.grant("calendar-plug", googleLink.id, at).getOrThrow()
+        store.revokeGrant("calendar-plug", googleLink.id, later).getOrThrow()
+
+        val grant = store.grantsForPlug("calendar-plug").getOrThrow().grantFor(googleLink.id)
+
+        assertEquals(at, grant?.grantedAt)
+        assertEquals(later, grant?.revokedAt)
+    }
+
+    @Test
+    fun `revoking a Link cascades across Plugs and persists on the Link itself`() = runTest {
+        store.upsert(googleLink, at).getOrThrow()
+        store.grant("calendar-plug", googleLink.id, at).getOrThrow()
+        store.grant("gmail-plug", googleLink.id, at).getOrThrow()
+
+        val affected = store.revokeLink(googleLink.id, later).getOrThrow()
+
+        assertEquals(setOf("calendar-plug", "gmail-plug"), affected.toSet())
+        assertTrue(store.get(googleLink.id).getOrThrow()!!.isRevoked)
+        assertTrue(store.grantsForPlug("calendar-plug").getOrThrow().isRevoked(googleLink.id))
+        assertTrue(store.grantsForPlug("gmail-plug").getOrThrow().isRevoked(googleLink.id))
+    }
+
+    @Test
+    fun `an already-revoked grant is not re-reported by a second cascade`() = runTest {
+        store.upsert(googleLink, at).getOrThrow()
+        store.grant("calendar-plug", googleLink.id, at).getOrThrow()
+
+        store.revokeLink(googleLink.id, later).getOrThrow()
+        val second = store.revokeLink(googleLink.id, later).getOrThrow()
+
+        assertTrue(second.isEmpty())
+    }
+
+    @Test
+    fun `deleting a Link removes its grants too`() = runTest {
+        store.upsert(googleLink, at).getOrThrow()
+        store.grant("calendar-plug", googleLink.id, at).getOrThrow()
+
+        store.delete(googleLink.id).getOrThrow()
+
+        assertNull(store.get(googleLink.id).getOrThrow())
+        assertTrue(store.grantsForLink(googleLink.id).getOrThrow().isEmpty())
+    }
+
+    @Test
+    fun `a Link persisted through the store resolves through the service`() = runTest {
+        store.upsert(googleLink, at).getOrThrow()
+        store.grant("calendar-plug", googleLink.id, at).getOrThrow()
+
+        val service = LinkResolutionService(
+            linkStore = store,
+            platform = PlatformTarget.ANDROID,
+        )
+
+        val resolution = service.resolveOne(
+            plugId = "calendar-plug",
+            requirement = LinkRequirement(
+                name = "calendar",
+                transport = Transport.OAUTH_REST,
+                direction = LinkDirection.READ_WRITE,
+                minimumScope = setOf(CanonType.CALENDAR_EVENT),
+            ),
+        ).getOrThrow()
+
+        assertEquals(
+            googleLink,
+            (resolution as LinkResolution.Resolved).link,
+        )
+    }
+}

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/mcp/McpClientTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/mcp/McpClientTest.kt
@@ -15,6 +15,7 @@ import link.socket.ampere.agents.tools.mcp.protocol.McpToolDescriptor
 import link.socket.ampere.agents.tools.mcp.protocol.ServerCapabilities
 import link.socket.ampere.agents.tools.mcp.protocol.ServerInfo
 import link.socket.ampere.agents.tools.mcp.protocol.ToolCallResult
+import link.socket.ampere.link.LinkId
 import link.socket.ampere.plug.McpServerDependency
 
 class McpClientTest {

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/plug/PlugContextEndToEndTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/plug/PlugContextEndToEndTest.kt
@@ -13,8 +13,8 @@ import link.socket.ampere.agents.tools.mcp.protocol.McpToolDescriptor
 import link.socket.ampere.agents.tools.mcp.protocol.ServerCapabilities
 import link.socket.ampere.agents.tools.mcp.protocol.ServerInfo
 import link.socket.ampere.agents.tools.mcp.protocol.ToolCallResult
+import link.socket.ampere.link.LinkId
 import link.socket.ampere.mcp.InMemoryMcpCredentialBinding
-import link.socket.ampere.mcp.LinkId
 import link.socket.ampere.plug.permission.PlugPermission
 import link.socket.ampere.plug.permission.UserGrants
 import link.socket.ampere.propel.ExecuteResult

--- a/docs/concepts/_index.md
+++ b/docs/concepts/_index.md
@@ -44,4 +44,6 @@ How the cognitive substrate meets the user, the platform, and the plug ecosystem
 | [Emission](emission.md) | experimental | The unifying CHI primitive. Typed domain object + `EmissionEvent` family on the bus. Four kinds (Prose, Decision, Confirmation, Sensor). AMPERE owns the noun; Socket owns rendering. |
 | [EmissionDedup](emission-dedup.md) | experimental | Content-based dedup via `dedupKey` (SHA-256, 16 hex chars). Optional and never overloaded onto `EmissionId`. Window length is a consumer-side policy. |
 | [PlugPermissions](plug-permissions.md) | stable | Deterministic gate that runs *before* any plug tool dispatch. Compares manifest + tool-requested permissions against user grants. |
+| [LinkLayer](link-layer.md) | stable | A Plug connects through a Link and powers Arcs. Transport belongs to the Link; Links are directional, shared across Plugs, and resolved at Arc execution time. |
+| [DomainCanon](domain-canon.md) | stable | Closed catalogue of provenance-carrying domain types in three rings. The IR Arc logic compiles against. Write-back preserves-and-merges by construction. |
 | [Ampere](ampere.md) | stable | The meta-concept: what makes a framework an AMPERE framework. Glass brain, AniMA agents, electrical metaphor, event-first coordination. |

--- a/docs/concepts/domain-canon.md
+++ b/docs/concepts/domain-canon.md
@@ -1,0 +1,80 @@
+---
+concept: DomainCanon
+status: stable
+tracked_sources:
+  - ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/**
+related: [LinkLayer, PlugPermissions, AgentSurface, CognitionTrace]
+last_verified: 2026-07-28
+---
+
+# Domain Canon
+
+## What it is
+
+`CanonType` is Ampere's closed catalogue of domain nouns — Person, EmailMessage,
+CalendarEvent, Note, Ride — and `CanonEntity` is a provenance-carrying instance
+of one. Every canon entity knows where it came from: which Link it travelled
+over, which native object it was projected from, and when it was observed.
+Types are grouped into three **rings** by where that provenance originates.
+
+The canon is an **intermediate representation**, not a DTO set. Arc logic
+compiles against the IR, which is why one Arc can run on iOS and Android
+without branching.
+
+## Why it exists
+
+Apps are frontends and backends. Without an IR, every Plug hands agents a
+different shape for the same idea and the LLM is left to reconcile them at
+runtime — guessing that "a Things task" and "a Reminders reminder" are the same
+kind of thing. With the IR, Ampere *knows* it, with provenance.
+
+The platform asymmetry is the load-bearing rationale. Apple ships a canonical
+schema registry, so there the IR partly duplicates it and integration is a
+mapping table. Android's AppFunctions has **no** noun catalogue — per-app data
+classes reconciled by an LLM at runtime. That void is the shape of this IR.
+
+An SDK pass against iPhoneOS 26.5 (`.context/issue-586-domain-type-canon-v1.md`)
+found Apple's catalogue narrower than expected: 15 domains, 26 entity schemas,
+all documents-and-content shaped. **There is no calendar, messages, reminders,
+notes, places, media, or alarm domain.** Six proposed Ring 1 types demoted as a
+result. The canon earns its keep precisely where Apple's registry stops.
+
+## Where it lives
+
+- `canon/CanonType.kt` — the closed enum; each member carries its ring and binding.
+- `canon/CanonRing.kt` — `INTERCHANGE` / `PLATFORM` / `SERVICE`.
+- `canon/CanonBinding.kt` — `AppleSchemaBinding` (entity schema or system value type), `AndroidSchemaBinding`.
+- `canon/CanonProvenance.kt` — `CanonId`, `SourceHandle`, `NativePayload`, `CanonProvenance`.
+- `canon/CanonEntity.kt` — the sealed hierarchy; `CanonRing1Entities.kt`, `CanonRing2Entities.kt`, `CanonRing3Entities.kt`.
+- `canon/adapter/CanonAdapter.kt` — the transport-agnostic adapter SPI.
+- `canon/adapter/CanonConversionFailure.kt` — the closed failure set.
+- `ampere-core/src/commonTest/.../canon/` — round-trip, write-back-merge, and serialization-stability tests.
+- `.context/recon/apple-assistant-schemas-ios265.tsv` — the raw SDK enumeration.
+
+## Invariants
+
+- **The canon set is closed for v1.** New nouns are a versioned change, not a Plug-declared extension. The escape hatch is `CanonProvenance.nativePayload`, not a new member.
+- **Every canon entity carries provenance.** An entity with no `SourceHandle` is a guess, not a canon entity.
+- **Write-back merges; it never replaces.** `CanonAdapter.writeBack` is the only write path and always routes through `mergeForWriteBack`, which overlays canon deltas onto the native payload. Adding a write path that bypasses the merge silently destroys every native field the projection dropped.
+- **An adapter may only write fields it declares in `ownedFields`.** A `canonFields` result reaching outside that set fails with `UnownedFieldWrite` rather than widening the write footprint.
+- **Ring membership is a binding-provenance claim, not a support level.** A Ring 1 type maps to an Apple assistant-schema entity or system value type *without contortion*. Promoting a type into Ring 1 requires an SDK pass, not an opinion.
+- **`@SerialName` and `wireName` are wire contracts.** These types cross the wire and land in traces; renaming a discriminator breaks `PlaybackRelay` replay of every trace already recorded.
+- **Conversions are `Result`-typed.** No adapter throws.
+- **`SourceHandle.nativeId` is opaque.** Parsing it makes a provider's identifier format a contract Ampere has to honour.
+
+## Common operations
+
+- **Add a canon type** — add the `CanonType` member with a stable `wireName`, ring, and `CanonBinding`; add the `@Serializable` entity with a stable `@SerialName`; add a sample to `CanonSerializationTest.samples()` (the coverage test fails otherwise).
+- **Write an adapter** — subclass `CanonAdapter<E>`, implement `projectFields`, `canonFields`, `fetchNative`, `writeNative`, and declare `nativeSchema` + `ownedFields`. Never add a public write method.
+- **Preview a pending write** — `adapter.mergeForWriteBack(entity)` returns the merged payload without writing.
+- **Check a binding** — `CanonType.EMAIL_MESSAGE.binding.apple` gives the `mail.message` address and the fields the projection drops.
+- **Re-run the SDK pass** — the extraction commands are in the Appendix of `.context/issue-586-domain-type-canon-v1.md`; diff against the committed TSV.
+
+## Anti-patterns
+
+- **"Just write the projected entity back."** This is the destructive default the SPI exists to prevent — it clobbers MIME structure, edit stacks, provider labels, everything the projection dropped.
+- **Promoting `CalendarEvent` to Ring 1 because calendars feel like interchange.** No calendar assistant-schema domain exists. `Calendar.RecurrenceRule` binds a field, not the entity.
+- **Adding a `Custom(payload)` canon member.** It would make the `when` non-exhaustive and hand the reconciliation problem back to the LLM. Use the native payload on a typed entity.
+- **Declaring a wide `ownedFields` "to be safe".** Over-declaring re-opens the clobber path; under-declaring merely means the field is never written.
+- **Parsing `nativeId` to extract structure.** It is opaque by design.
+- **Reading bindings via annotations/reflection.** `kotlin-reflect` is JVM-only and Kotlin/Native cannot read annotations reflectively; bindings are data for exactly this reason.

--- a/docs/concepts/event-serial-bus.md
+++ b/docs/concepts/event-serial-bus.md
@@ -10,8 +10,8 @@ tracked_sources:
   - ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/subscription/**
   - ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/**
   - ampere-core/src/commonMain/sqldelight/link/socket/ampere/db/events/**
-related: [PropelLoop, AgentSurface, CognitionTrace, MemoryProvenance]
-last_verified: 2026-06-04
+related: [PropelLoop, AgentSurface, CognitionTrace, MemoryProvenance, LinkLayer]
+last_verified: 2026-07-28
 ---
 
 # EventSerialBus
@@ -59,6 +59,7 @@ properties for free:
 - `agents/events/subscription/EventSubscription.kt`, `Subscription.kt` — the handle returned to subscribers.
 - `agents/domain/event/Event.kt` and the `event/` package — the sealed `Event` hierarchy.
 - `agents/domain/event/CognitivePhaseEvent.kt` — phase transition events emitted by `PhaseSparkManager` when a bus is wired.
+- `agents/domain/event/LinkEvent.kt` — Link lifecycle (granted, revoked, resolved, resolution failed); see [LinkLayer](link-layer.md).
 - `ampere-core/src/commonMain/sqldelight/link/socket/ampere/db/events/EventStore.sq` — persistence schema (with `run_id` indexes for trace queries).
 
 ## Invariants

--- a/docs/concepts/link-layer.md
+++ b/docs/concepts/link-layer.md
@@ -1,0 +1,92 @@
+---
+concept: LinkLayer
+status: stable
+tracked_sources:
+  - ampere-core/src/commonMain/kotlin/link/socket/ampere/link/**
+  - ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/LinkEvent.kt
+  - ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/PlugManifest.kt
+  - ampere-core/src/commonMain/sqldelight/link/socket/ampere/db/Links.sq
+related: [DomainCanon, PlugPermissions, EventSerialBus]
+last_verified: 2026-07-28
+---
+
+# Link Layer
+
+## What it is
+
+A `Link` is the binding between a capability and its concrete medium — Socket's
+data-link layer. It carries a `Transport` (the wire), a `LinkDirection`
+(read/write/both), an `EgressClass` (where data goes), a `scope` of `CanonType`s
+(what may flow), and a `CredentialRef` (a pointer, never a secret).
+
+The grammar: *a Plug connects through a Link and powers Arcs.* A Plug declares
+`LinkRequirement`s — kinds of wire — and `LinkResolutionService` matches them to
+concrete Links at **Arc execution time**.
+
+## Why it exists
+
+Three inversions, each load-bearing:
+
+1. **Transport belongs to the Link, not the Plug.** The Uber Plug doesn't "have
+   MCP transport"; it requires a Link of kind `Mcp`. Memory requires
+   `FolderMount`; Notify requires `Apns`. This is what lets one authenticated
+   Google Link serve both the Calendar and Gmail Plugs.
+2. **Links are directional endpoints, not sources.** APNS is a write-only sink;
+   a folder mount is read/write. Modelling direction on the Link turns "this
+   Plug tried to Perceive through a push channel" into a resolution-time
+   failure instead of a runtime surprise.
+3. **Resolution is late.** An Arc references Plugs, never Link bindings. That is
+   what keeps Arc manifests lean and lets the same Arc run against a different
+   account or a different wire with no edit.
+
+**Transport capability is per-platform, not global.** The tempting model is one
+enum member per direction (`AppFunctionProvider`, `AppFunctionConsumer`). It is
+wrong: `AppFunction` is bidirectional on Android and *absent* on iOS, where
+cross-app orchestration belongs to Siri and app-to-app is limited to
+`UriScheme`/Shortcuts. Capability is therefore a function of (transport,
+platform), exposed as `canProvide`/`canConsume` flags.
+
+## Where it lives
+
+- `link/Link.kt` — `Link`, `EgressClass`, `CredentialRef`.
+- `link/LinkId.kt` — the shared identifier (moved here from `mcp/` in AMPR-223).
+- `link/Transport.kt` — `Transport`, `PlatformTarget`, `TransportCapability`, `TransportRole`, and the capability table.
+- `link/LinkDirection.kt` — `LinkDirection`, `LinkOperation` (Perceive/Execute).
+- `link/LinkRequirement.kt` — `LinkRequirement`, `LinkResolution`, `ResolvedLinks`.
+- `link/LinkResolutionFailure.kt` — the closed failure set + `RevocationScope`.
+- `link/LinkResolutionGate.kt` — the pure, deterministic matching policy.
+- `link/LinkGrants.kt` — per-(Plug, Link) grants.
+- `link/LinkStore.kt` — persistence boundary; `SqlDelightLinkStore` and `InMemoryLinkStore`.
+- `link/LinkResolutionService.kt` — orchestration + bus emission.
+- `agents/domain/event/LinkEvent.kt` — `LinkGranted`, `LinkRevoked`, `LinkResolved`, `LinkResolutionFailed`.
+- `commonMain/sqldelight/link/socket/ampere/db/Links.sq` — schema (migration `2.sqm`).
+- `plug/PlugManifest.kt` — `requiredLinks`, `emits`, `consumes`.
+
+## Invariants
+
+- **Raw credentials never live on a `Link`.** `CredentialRef` is a keychain alias. A token on this type would put secrets into every trace that recorded a Link.
+- **Resolution never throws.** A missing Link is `Result.failure(LinkResolutionException(...))` carrying typed failures. `LinkResolutionGate` returns a sealed result and is side-effect-free.
+- **Revoked beats granted**, matching `PlugPermissionGate`. `LinkResolutionGate` checks revocation *first*, then transport capability, then direction, then scope — a revoked Link must not produce a scope-shaped error.
+- **Link revocation cascades; grant revocation does not.** Revoking a Link revokes every Plug's grant on it and reports the affected plug ids. Revoking one Plug's grant leaves the others working.
+- **A Link the Plug was never granted is invisible, not rejected** — it yields `MissingLink`. A *revoked* grant stays visible so the failure can say "revoked".
+- **Transport capability is consulted before dispatch.** A consumer-role requirement on a transport whose platform capability is false fails with `TransportUnsupported`.
+- **Every resolution outcome reaches the bus.** A Plug that quietly does nothing because its Link was revoked is the opacity the glass brain exists to prevent.
+- **`Link` and `LinkResolutionFailure` are wire types** — stable `@SerialName`s; `Links.link_json` and trace payloads both depend on them.
+- **Agents never touch `LinkStore` directly.** They go through `LinkResolutionService`.
+
+## Common operations
+
+- **Declare a requirement** — add a `LinkRequirement(name, transport, direction, minimumScope)` to `PlugManifest.requiredLinks`. Names must be unique within a manifest and scope must be non-empty; `PlugManifestValidator` enforces both.
+- **Resolve at execution time** — `linkResolutionService.resolve(plugId, manifest)` → `ResolvedLinks`, indexed by requirement name.
+- **Check an operation against a resolved Link** — `LinkResolutionGate.permits(link, LinkOperation.PERCEIVE)`.
+- **Grant / revoke** — `service.grant(plugId, linkId)`, `service.revokeGrant(plugId, linkId)`, `service.revokeLink(linkId)` (cascading).
+- **Add a transport** — add the enum member, add its per-platform row to `Transport.CAPABILITIES`, and pin the row in `TransportCapabilityTest`. Unlisted combinations default to `TransportCapability.NONE`.
+
+## Anti-patterns
+
+- **Putting transport on the Plug.** "The Uber Plug is an MCP plug" — then the same MCP credentials get re-authenticated per Plug and Link sharing is impossible.
+- **Separate enum members per direction** (`AppFunctionConsumer` / `AppFunctionProvider`). Direction is per-platform; enum members are not.
+- **Binding Links in the Arc manifest.** It couples the Arc to an account and defeats late resolution.
+- **Gating resolution on `Transport.hasImplementation`.** Only MCP has a transport implementation today; gating on it would make every other Link unresolvable before its transport ticket lands. The flag is metadata for tooling.
+- **Treating `MissingLink` as an error to throw.** Every resolution failure is a consent-shaped fact the user may be able to fix; it belongs in a `Result` and on the bus.
+- **Checking scope before revocation.** The reader is sent looking in the wrong place entirely.

--- a/docs/concepts/plug-permissions.md
+++ b/docs/concepts/plug-permissions.md
@@ -6,8 +6,8 @@ tracked_sources:
   - ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/PlugManifest.kt
   - ampere-core/src/commonMain/sqldelight/link/socket/ampere/db/PlugGrants.sq
   - ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/execution/ToolExecutionEngine.kt
-related: [SparkSystem, AgentSurface, EventSerialBus]
-last_verified: 2026-04-29
+related: [SparkSystem, AgentSurface, EventSerialBus, LinkLayer]
+last_verified: 2026-07-28
 ---
 
 # Plug Permissions
@@ -53,7 +53,7 @@ Two design pressures shaped the gate:
 - `plug/permission/PlugPermission.kt` — the sealed permission types.
 - `plug/permission/PlugPermissionGate.kt` — `check(toolCall, manifest, userGrants): GateResult`.
 - `plug/permission/UserGrantStore.kt` — persistence facade.
-- `plug/PlugManifest.kt` — declares `requiredPermissions`.
+- `plug/PlugManifest.kt` — declares `requiredPermissions`, plus the `requiredLinks` / `emits` / `consumes` declarations owned by [LinkLayer](link-layer.md).
 - `commonMain/sqldelight/link/socket/ampere/db/PlugGrants.sq` — schema for user grants.
 - `agents/execution/ToolExecutionEngine.kt` — the call site that gates dispatch.
 - `agents/domain/event/PermissionDeniedEvent.kt` — emitted on `Deny*` results.


### PR DESCRIPTION
Ships both children of the Chassis SPI epic (#585) in one commit — the closed domain-type canon and the Link/PlugManifest primitives — because they are mutually dependent at the type level (canon provenance carries a `LinkId`; a Link's scope is a set of `CanonType`s), so neither compiles alone.

Canon recon ran against the AppIntents SDK this machine actually has (Xcode 26.6 / iPhoneOS 26.5) rather than blog coverage, and found the shipped assistant-schema catalogue is documents-and-content shaped with **no calendar, messages, reminders, notes, places, media or alarm domain** — so six proposed Ring 1 types are demoted (`CalendarEvent`, `Reminder`, `Alarm`, `MediaItem` → Ring 2; `Message`, `Note` → Ring 3) and three the ticket missed are added (`Book`, `WebBookmark`, `BrowserTab`).

`CanonAdapter` enforces preserve-and-merge write-back structurally rather than by convention: `writeBack` is the only write path, it is final, and it always routes through a merge, so an adapter reaching outside its declared `ownedFields` fails with `UnownedFieldWrite` instead of clobbering the native fields the projection dropped.

On the Link side, transport capability is a `(Transport, PlatformTarget)` table rather than per-direction enum members — `AppFunction` is bidirectional on Android and `NONE` on iOS, where cross-app orchestration belongs to Siri — and `LinkResolutionGate` is pure, never throws, and checks revocation ahead of capability, direction and scope; `PlugManifest` gains `requiredLinks`/`emits`/`consumes` (all defaulted, so existing manifests decode unchanged), `LinkId` moves from `mcp/` to `link/` as its own KDoc anticipated, and `LinkEvent` is registered at all five required points including the CLI renderer.

Two caveats worth reviewing, both documented in the new `DomainCanon` and `LinkLayer` concept cells: the Android binding column is entirely unverified because `androidx.appfunctions` is not on this repo's classpath, and `2.sqm` will not reach existing databases because nothing calls `Schema.migrate` — pre-existing, not introduced here.

Verified: `ktlintCheck`, `jvmTest` (1501 tests, 0 failures; 113 in the new surface), and `:ampere-core:compileCommonMainKotlinMetadata` all pass.

Closes #586
Closes #587

🤖 Generated with [Claude Code](https://claude.com/claude-code)
