### PR TITLE
AMPR-232 #597: Per-call rung override + ArcConfig rung propagation

### DIFF
--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/SparkAgentFactory.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/SparkAgentFactory.kt
@@ -11,7 +11,12 @@ import link.socket.ampere.agents.domain.cognition.sparks.ProjectSpark
 import link.socket.ampere.agents.domain.cognition.sparks.RoleSparkIds
 import link.socket.ampere.agents.domain.cognition.sparks.SparkRegistry
 import link.socket.ampere.agents.domain.memory.AgentMemoryService
+import link.socket.ampere.agents.domain.routing.CapabilityRoutingDefaults
 import link.socket.ampere.agents.domain.routing.CognitiveRelay
+import link.socket.ampere.agents.domain.routing.CognitiveRelayImpl
+import link.socket.ampere.agents.domain.routing.RelayConfig
+import link.socket.ampere.agents.domain.routing.capability.CapabilityRung
+import link.socket.ampere.agents.domain.routing.capability.InMemoryModelDescriptorRegistry
 import link.socket.ampere.agents.events.api.AgentEventApi
 import link.socket.ampere.agents.events.utils.generateUUID
 import link.socket.ampere.agents.execution.executor.Executor
@@ -53,6 +58,30 @@ class SparkAgentFactory(
 ) {
     private val effectiveSparkRegistry: SparkRegistry
         get() = sparkRegistry ?: DefaultSparkCatalog.registry
+
+    /**
+     * Fallback relay used only for agents that declare a rung floor (AMPR-232).
+     *
+     * A floor is enforced by the relay, so an agent carrying one but no relay
+     * would have its floor silently ignored —
+     * [AgentLLMService][link.socket.ampere.agents.domain.reasoning.AgentLLMService]
+     * merges the floor into the `RoutingContext` and then, with no relay, resolves
+     * straight to the agent's static configuration. Rather than accept that, a
+     * declared floor gets a real [CognitiveRelayImpl] over the bundled catalog —
+     * the same construction [AgentFactory] uses for the activated CODE path.
+     *
+     * Built lazily and shared across every agent this factory makes. Routing events
+     * are not published here (no bus is available at this seam); inject
+     * [cognitiveRelay] with a bus-backed relay when the Arc run needs them.
+     *
+     * Floorless agents keep the pre-AMPR-232 behavior (relay only if injected).
+     */
+    private val floorEnforcingRelay: CognitiveRelay by lazy {
+        CognitiveRelayImpl(
+            initialConfig = RelayConfig(rules = CapabilityRoutingDefaults.defaultCapabilityRules()),
+            registry = InMemoryModelDescriptorRegistry(),
+        )
+    }
 
     /**
      * Creates a code-focused agent with ANALYTICAL affinity.
@@ -171,11 +200,16 @@ class SparkAgentFactory(
      *
      * @param id Agent ID
      * @param affinity The cognitive affinity for this agent
+     * @param minimumRung Capability-rung floor for this agent (AMPR-232). Threaded onto the agent's
+     *   `AgentDefinition` so the relay refuses to route below it; an agent declaring one is given
+     *   [floorEnforcingRelay] when no relay was injected, so the floor is enforced rather than ignored.
+     *   Null declares no floor and leaves the agent unconstrained.
      * @return A bare agent ready for custom Spark configuration
      */
     fun createAgent(
         id: AgentId,
         affinity: CognitiveAffinity,
+        minimumRung: CapabilityRung? = null,
     ): SparkBasedAgent<CodeState> {
         val eventApi = eventApiFactory?.invoke(id)
         val memoryService = memoryServiceFactory?.invoke(id)
@@ -188,7 +222,8 @@ class SparkAgentFactory(
             _memoryService = memoryService,
             _aiConfiguration = defaultAiConfiguration,
             _observabilityScope = scope,
-            _cognitiveRelay = cognitiveRelay,
+            _cognitiveRelay = cognitiveRelay ?: minimumRung?.let { floorEnforcingRelay },
+            _minimumRung = minimumRung,
             _executor = executor,
             _upstreamLlmClient = upstreamLlmClient,
         )

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/SparkBasedAgent.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/SparkBasedAgent.kt
@@ -24,6 +24,7 @@ import link.socket.ampere.agents.domain.reasoning.Perception
 import link.socket.ampere.agents.domain.reasoning.Plan
 import link.socket.ampere.agents.domain.reasoning.StepResult
 import link.socket.ampere.agents.domain.routing.CognitiveRelay
+import link.socket.ampere.agents.domain.routing.capability.CapabilityRequirement
 import link.socket.ampere.agents.domain.routing.capability.CapabilityRung
 import link.socket.ampere.agents.domain.state.AgentState
 import link.socket.ampere.agents.domain.task.Task
@@ -343,9 +344,21 @@ open class SparkBasedAgent<S : AgentState>(
         plan: Plan,
     ): Knowledge = reasoning.extractKnowledge(outcome, task, plan)
 
-    override fun callLLM(prompt: String): String = runBlockingCompat(ioDispatcher) {
+    override fun callLLM(prompt: String): String = callLLM(prompt, requirements = null)
+
+    /**
+     * Calls the LLM with a per-call capability requirement (AMPR-232).
+     *
+     * The requirement's [CapabilityRequirement.minRung] composes with the agent's
+     * declared [_minimumRung] as the stricter of the two, so a call site can raise
+     * the floor for one call without ever lowering the agent's own.
+     */
+    fun callLLM(
+        prompt: String,
+        requirements: CapabilityRequirement?,
+    ): String = runBlockingCompat(ioDispatcher) {
         withTimeout(60000) {
-            reasoning.callLLM(prompt)
+            reasoning.callLLM(prompt, requirements = requirements)
         }
     }
 

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/reasoning/AgentReasoning.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/reasoning/AgentReasoning.kt
@@ -9,6 +9,7 @@ import link.socket.ampere.agents.domain.memory.KnowledgeWithScore
 import link.socket.ampere.agents.domain.outcome.ExecutionOutcome
 import link.socket.ampere.agents.domain.outcome.Outcome
 import link.socket.ampere.agents.domain.routing.RoutingContext
+import link.socket.ampere.agents.domain.routing.capability.CapabilityRequirement
 import link.socket.ampere.agents.domain.state.AgentState
 import link.socket.ampere.agents.domain.task.Task
 import link.socket.ampere.agents.events.api.AgentEventApi
@@ -226,10 +227,21 @@ class AgentReasoning private constructor(
 
     /**
      * Calls the LLM directly with a prompt.
+     *
+     * @param requirements Per-call capability requirement (AMPR-232). A caller that
+     *   knows this particular call needs more than the agent's standing contract —
+     *   a stricter [CapabilityRequirement.minRung], a longer context window — supplies
+     *   it here and it lands on the [RoutingContext] the relay resolves against.
+     *   Rung floors compose as the stricter of this and the agent's declared
+     *   `AgentDefinition.minimumRung` (AMPR-229), so a per-call floor only ever
+     *   *raises* the bar: agent `THREE` + call-site `FOUR` resolves against `FOUR`,
+     *   and agent `FOUR` + call-site `THREE` still resolves against `FOUR`. Neither
+     *   direction downgrades. Null keeps the agent's own floor.
      */
     suspend fun callLLM(
         prompt: String,
         systemMessage: String? = null,
+        requirements: CapabilityRequirement? = null,
     ): String {
         // Use mock response if available
         mockResponses?.llmCall?.let { call ->
@@ -239,26 +251,32 @@ class AgentReasoning private constructor(
         return llmService?.call(
             prompt = prompt,
             systemMessage = systemMessage ?: "You are a ${settings.agentRole} agent.",
-            routingContext = RoutingContext(
-                agentId = settings.executorId,
-                agentRole = settings.agentRole,
-            ),
+            routingContext = routingContext(requirements),
         ) ?: throw IllegalStateException("No LLM service configured")
     }
 
     /**
      * Calls the LLM expecting a JSON response.
+     *
+     * @param requirements Per-call capability requirement (AMPR-232); see [callLLM].
      */
-    suspend fun callLLMForJson(prompt: String): LLMJsonResponse {
+    suspend fun callLLMForJson(
+        prompt: String,
+        requirements: CapabilityRequirement? = null,
+    ): LLMJsonResponse {
         return llmService?.callForJson(
             prompt = prompt,
-            routingContext = RoutingContext(
-                agentId = settings.executorId,
-                agentRole = settings.agentRole,
-            ),
+            routingContext = routingContext(requirements),
         )
             ?: throw IllegalStateException("No LLM service configured")
     }
+
+    private fun routingContext(requirements: CapabilityRequirement?): RoutingContext =
+        RoutingContext(
+            agentId = settings.executorId,
+            agentRole = settings.agentRole,
+            requirements = requirements,
+        )
 
     companion object {
         /**

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/arc/ArcAgentConfig.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/arc/ArcAgentConfig.kt
@@ -1,9 +1,24 @@
 package link.socket.ampere.domain.arc
 
 import kotlinx.serialization.Serializable
+import link.socket.ampere.agents.domain.routing.capability.CapabilityRung
 
 @Serializable
 data class ArcAgentConfig(
     val role: String,
     val sparks: List<String> = emptyList(),
+    /**
+     * Per-step capability-rung floor (AMPR-232).
+     *
+     * Declares the minimum rung the model backing this Arc step must clear.
+     * Propagated by the Arc agent spawner (`ChargePhase`) into the spawned
+     * agent's `AgentDefinition.minimumRung`, where
+     * [AgentLLMService][link.socket.ampere.agents.domain.reasoning.AgentLLMService]
+     * merges it into the `RoutingContext` and the relay refuses to route below it.
+     *
+     * Composes with [ArcConfig.minimumRung] as the *stricter* of the two — see
+     * [minimumRungFor]. Floors only ever raise: null declares no floor and leaves
+     * the step unconstrained.
+     */
+    val minimumRung: CapabilityRung? = null,
 )

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/arc/ArcConfig.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/arc/ArcConfig.kt
@@ -1,6 +1,7 @@
 package link.socket.ampere.domain.arc
 
 import kotlinx.serialization.Serializable
+import link.socket.ampere.agents.domain.routing.capability.CapabilityRung
 
 @Serializable
 data class ArcConfig(
@@ -8,4 +9,35 @@ data class ArcConfig(
     val description: String? = null,
     val agents: List<ArcAgentConfig>,
     val orchestration: OrchestrationConfig = OrchestrationConfig(),
+    /**
+     * Arc-wide capability-rung floor (AMPR-232).
+     *
+     * Applies to every step that does not declare its own
+     * [ArcAgentConfig.minimumRung]. A step *may* raise this floor but never
+     * lowers it — see [minimumRungFor]. Null leaves the Arc unconstrained.
+     */
+    val minimumRung: CapabilityRung? = null,
 )
+
+/**
+ * The capability-rung floor in force for [agent] within this Arc (AMPR-232).
+ *
+ * Floors compose as the stricter of the Arc-wide [ArcConfig.minimumRung] and the
+ * per-step [ArcAgentConfig.minimumRung], mirroring how a call-site floor composes
+ * with an agent's declared floor in
+ * [AgentLLMService][link.socket.ampere.agents.domain.reasoning.AgentLLMService]
+ * (AMPR-229). Declaring a floor can only ever raise the bar: a step asking for
+ * `TWO` inside an Arc declaring `THREE` still routes against `THREE`, because the
+ * alternative is a silent downgrade of a floor someone deliberately set.
+ *
+ * Returns null when neither declares a floor, which leaves the step unconstrained.
+ */
+fun ArcConfig.minimumRungFor(agent: ArcAgentConfig): CapabilityRung? {
+    val arcFloor = minimumRung
+    val stepFloor = agent.minimumRung
+    return when {
+        arcFloor == null -> stepFloor
+        stepFloor == null -> arcFloor
+        else -> maxOf(arcFloor, stepFloor)
+    }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/arc/ChargePhase.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/arc/ChargePhase.kt
@@ -315,6 +315,9 @@ internal class ArcAgentSpawner(
             val agent = agentFactory.createAgent(
                 id = generateUUID("ArcAgent-${agentConfig.role}"),
                 affinity = roleProfile.affinity,
+                // AMPR-232: the step's floor, raised by the Arc-wide one if it is
+                // stricter. Null leaves the step unconstrained, as before.
+                minimumRung = arcConfig.minimumRungFor(agentConfig),
             )
 
             agent.spark<SparkBasedAgent<CodeState>>(projectSpark)

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/domain/arc/ArcRungPropagationTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/domain/arc/ArcRungPropagationTest.kt
@@ -1,0 +1,294 @@
+package link.socket.ampere.domain.arc
+
+import com.aallam.openai.api.chat.ChatChoice
+import com.aallam.openai.api.chat.ChatCompletion
+import com.aallam.openai.api.chat.ChatCompletionRequest
+import com.aallam.openai.api.chat.ChatMessage
+import com.aallam.openai.api.chat.ChatRole
+import com.aallam.openai.api.model.ModelId
+import com.charleskorn.kaml.Yaml
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.io.path.createTempDirectory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlinx.serialization.encodeToString
+import link.socket.ampere.agents.definition.SparkAgentFactory
+import link.socket.ampere.agents.domain.routing.RoutingFloorUnmetException
+import link.socket.ampere.agents.domain.routing.capability.CapabilityRung
+import link.socket.ampere.domain.ai.configuration.AIConfiguration
+import link.socket.ampere.domain.ai.configuration.AIConfiguration_Default
+import link.socket.ampere.domain.ai.model.AIModel_Gemini
+import link.socket.ampere.domain.ai.model.AIModel_OpenAI
+import link.socket.ampere.domain.ai.provider.AIProvider_OpenAI
+import link.socket.ampere.llm.UpstreamLlmClient
+import okio.Path.Companion.toPath
+
+/**
+ * AMPR-232: rung declaration on the Arc path.
+ *
+ * Before this ticket the whole Arc path was dormant w.r.t. rungs — `ArcAgentConfig`
+ * carried no floor and `SparkAgentFactory.createAgent` built agents without one, so
+ * an Arc could not express "this step needs a capable model". These tests cover the
+ * declaration (`ArcConfig`/`ArcAgentConfig`), its composition
+ * ([minimumRungFor]), its propagation into the spawned agent, and the enforcement
+ * that makes a declared floor mean something rather than being silently ignored.
+ */
+class ArcRungPropagationTest {
+
+    // The agent's static fallback. If the relay ever resolved to this on a
+    // floored step, the floor would have been ignored — which is the bug.
+    private val agentFallback = AIConfiguration_Default(AIProvider_OpenAI, AIModel_OpenAI.GPT_4_1)
+
+    private fun projectContext(): ProjectContext {
+        val projectRoot = createTempDirectory("arc-rung").toString().toPath()
+        return ProjectContext(
+            projectId = "demo",
+            description = "Demo project",
+            repositoryRoot = projectRoot,
+            architecture = "Layered",
+            conventions = "Use Kotlin",
+            techStack = listOf("Kotlin"),
+            sources = listOf(ProjectContextSource(projectRoot / "README.md", "Demo")),
+        )
+    }
+
+    // ========================================================================
+    // Declaration + composition
+    // ========================================================================
+
+    @Test
+    fun `a step declaring no floor and an Arc declaring none leaves the step unconstrained`() {
+        val arc = ArcConfig(name = "arc", agents = listOf(ArcAgentConfig(role = "code")))
+
+        assertNull(arc.minimumRungFor(arc.agents[0]))
+    }
+
+    @Test
+    fun `a step floor applies when the Arc declares none`() {
+        val step = ArcAgentConfig(role = "code", minimumRung = CapabilityRung.THREE)
+        val arc = ArcConfig(name = "arc", agents = listOf(step))
+
+        assertEquals(CapabilityRung.THREE, arc.minimumRungFor(step))
+    }
+
+    @Test
+    fun `the Arc-wide floor applies to a step declaring none`() {
+        val step = ArcAgentConfig(role = "code")
+        val arc = ArcConfig(name = "arc", agents = listOf(step), minimumRung = CapabilityRung.THREE)
+
+        assertEquals(CapabilityRung.THREE, arc.minimumRungFor(step))
+    }
+
+    @Test
+    fun `a step may raise the Arc-wide floor`() {
+        val step = ArcAgentConfig(role = "code", minimumRung = CapabilityRung.FOUR)
+        val arc = ArcConfig(name = "arc", agents = listOf(step), minimumRung = CapabilityRung.TWO)
+
+        assertEquals(CapabilityRung.FOUR, arc.minimumRungFor(step))
+    }
+
+    @Test
+    fun `a step may not lower the Arc-wide floor`() {
+        val step = ArcAgentConfig(role = "code", minimumRung = CapabilityRung.TWO)
+        val arc = ArcConfig(name = "arc", agents = listOf(step), minimumRung = CapabilityRung.FOUR)
+
+        assertEquals(CapabilityRung.FOUR, arc.minimumRungFor(step))
+    }
+
+    @Test
+    fun `rung floors survive a YAML round trip`() {
+        val arc = ArcConfig(
+            name = "yaml-arc",
+            agents = listOf(
+                ArcAgentConfig(role = "code", minimumRung = CapabilityRung.FOUR),
+                ArcAgentConfig(role = "pm"),
+            ),
+            minimumRung = CapabilityRung.TWO,
+        )
+
+        val decoded = Yaml.default.decodeFromString(
+            ArcConfig.serializer(),
+            Yaml.default.encodeToString(arc),
+        )
+
+        assertEquals(arc, decoded)
+        assertEquals(CapabilityRung.TWO, decoded.minimumRung)
+        assertEquals(CapabilityRung.FOUR, decoded.agents[0].minimumRung)
+        assertNull(decoded.agents[1].minimumRung)
+    }
+
+    @Test
+    fun `a YAML Arc omitting rungs decodes to no floor`() {
+        val yaml = """
+            name: legacy-arc
+            agents:
+              - role: code
+                sparks:
+                  - kotlin
+        """.trimIndent()
+
+        val decoded = Yaml.default.decodeFromString(ArcConfig.serializer(), yaml)
+
+        assertNull(decoded.minimumRung)
+        assertNull(decoded.agents[0].minimumRung)
+    }
+
+    // ========================================================================
+    // Propagation into the spawned agent
+    // ========================================================================
+
+    @Test
+    fun `the spawner threads each step's floor onto the spawned agent`() {
+        val arc = ArcConfig(
+            name = "arc",
+            agents = listOf(
+                ArcAgentConfig(role = "code", minimumRung = CapabilityRung.THREE),
+                ArcAgentConfig(role = "pm"),
+            ),
+        )
+
+        val agents = ArcAgentSpawner().spawn(arc, projectContext())
+
+        assertEquals(
+            CapabilityRung.THREE,
+            agents[0].agentConfiguration.agentDefinition.minimumRung,
+            "a step declaring a floor must carry it onto the agent it spawns",
+        )
+        assertNull(
+            agents[1].agentConfiguration.agentDefinition.minimumRung,
+            "a step declaring no floor stays unconstrained",
+        )
+    }
+
+    @Test
+    fun `the spawner raises a step floor to the stricter Arc-wide one`() {
+        val arc = ArcConfig(
+            name = "arc",
+            agents = listOf(ArcAgentConfig(role = "code", minimumRung = CapabilityRung.ONE)),
+            minimumRung = CapabilityRung.THREE,
+        )
+
+        val agents = ArcAgentSpawner().spawn(arc, projectContext())
+
+        assertEquals(CapabilityRung.THREE, agents[0].agentConfiguration.agentDefinition.minimumRung)
+    }
+
+    @Test
+    fun `a floored Arc step gets a relay so the floor is enforced rather than ignored`() {
+        val arc = ArcConfig(
+            name = "arc",
+            agents = listOf(
+                ArcAgentConfig(role = "code", minimumRung = CapabilityRung.THREE),
+                ArcAgentConfig(role = "pm"),
+            ),
+        )
+
+        val agents = ArcAgentSpawner().spawn(arc, projectContext())
+
+        assertNotNull(
+            agents[0].agentConfiguration.cognitiveRelay,
+            "a declared floor is enforced by the relay; without one it would be silently ignored",
+        )
+        assertNull(
+            agents[1].agentConfiguration.cognitiveRelay,
+            "a floorless step keeps the pre-existing dormant behavior",
+        )
+    }
+
+    // ========================================================================
+    // End-to-end enforcement
+    // ========================================================================
+
+    @Test
+    fun `an Arc step declaring a floor routes to a model that clears it`() {
+        val client = RecordingUpstreamClient("arc-response")
+        val arc = ArcConfig(
+            name = "arc",
+            agents = listOf(ArcAgentConfig(role = "code", minimumRung = CapabilityRung.THREE)),
+        )
+
+        val agent = ArcAgentSpawner(
+            agentFactory = SparkAgentFactory(
+                defaultAiConfiguration = agentFallback,
+                upstreamLlmClient = client,
+            ),
+        ).spawn(arc, projectContext()).single()
+
+        assertEquals("arc-response", agent.callLLM("Implement the feature."))
+
+        // The cheapest catalog model clearing THREE — Gemini 2.5 Pro — not the
+        // agent's own static fallback (GPT-4.1), which the relay would have used
+        // had the floor never reached it.
+        val selected = client.lastConfig.get()
+        assertNotNull(selected, "the outbound client must have been called with a resolved config")
+        assertEquals(AIModel_Gemini.Pro_2_5.name, selected.model.name)
+    }
+
+    @Test
+    fun `an Arc step whose floor no model meets fails rather than routing lower`() {
+        val client = RecordingUpstreamClient("must-not-be-called")
+        // Above anything in the bundled catalog, which tops out at FOUR.
+        val unsatisfiableFloor = CapabilityRung(CapabilityRung.FOUR.ordinal + 1)
+        val arc = ArcConfig(
+            name = "arc",
+            agents = listOf(ArcAgentConfig(role = "code", minimumRung = unsatisfiableFloor)),
+        )
+
+        val agent = ArcAgentSpawner(
+            agentFactory = SparkAgentFactory(
+                defaultAiConfiguration = agentFallback,
+                upstreamLlmClient = client,
+            ),
+        ).spawn(arc, projectContext()).single()
+
+        val failure = assertFailsWith<RoutingFloorUnmetException> {
+            agent.callLLM("Implement the feature.")
+        }
+        assertEquals(unsatisfiableFloor, failure.requestedFloor)
+        assertEquals(CapabilityRung.FOUR, failure.bestAvailableRung)
+        assertNull(client.lastConfig.get(), "an unmet floor must not fall through to any model")
+    }
+
+    @Test
+    fun `an Arc step declaring no floor still routes through its static configuration`() {
+        val client = RecordingUpstreamClient("arc-response")
+        val arc = ArcConfig(name = "arc", agents = listOf(ArcAgentConfig(role = "code")))
+
+        val agent = ArcAgentSpawner(
+            agentFactory = SparkAgentFactory(
+                defaultAiConfiguration = agentFallback,
+                upstreamLlmClient = client,
+            ),
+        ).spawn(arc, projectContext()).single()
+
+        assertEquals("arc-response", agent.callLLM("Implement the feature."))
+        assertEquals(agentFallback.model.name, client.lastConfig.get()?.model?.name)
+    }
+
+    private class RecordingUpstreamClient(
+        private val cannedResponse: String,
+    ) : UpstreamLlmClient {
+        val lastConfig = AtomicReference<AIConfiguration?>(null)
+
+        override suspend fun call(
+            request: ChatCompletionRequest,
+            configuration: AIConfiguration,
+        ): ChatCompletion {
+            lastConfig.set(configuration)
+            return ChatCompletion(
+                id = "rec",
+                created = 0L,
+                model = ModelId(configuration.model.name),
+                choices = listOf(
+                    ChatChoice(
+                        index = 0,
+                        message = ChatMessage(role = ChatRole.Assistant, content = cannedResponse),
+                    ),
+                ),
+            )
+        }
+    }
+}

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/llm/PerCallRungOverrideTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/llm/PerCallRungOverrideTest.kt
@@ -1,0 +1,147 @@
+package link.socket.ampere.llm
+
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import link.socket.ampere.agents.definition.SparkBasedAgent
+import link.socket.ampere.agents.domain.cognition.sparks.DefaultPhaseSparkLibrary
+import link.socket.ampere.agents.domain.cognition.sparks.PhaseSparkLibrary
+import link.socket.ampere.agents.domain.routing.CognitiveRelay
+import link.socket.ampere.agents.domain.routing.RelayConfig
+import link.socket.ampere.agents.domain.routing.RoutingContext
+import link.socket.ampere.agents.domain.routing.capability.CapabilityRequirement
+import link.socket.ampere.agents.domain.routing.capability.CapabilityRung
+import link.socket.ampere.domain.ai.configuration.AIConfiguration
+import link.socket.ampere.domain.ai.configuration.AIConfiguration_Default
+import link.socket.ampere.domain.ai.model.AIModel_OpenAI
+import link.socket.ampere.domain.ai.provider.AIProvider_OpenAI
+
+/**
+ * AMPR-232: the per-call rung override, driven through a real bundled agent.
+ *
+ * `AgentLLMService` has composed the two floors as `maxOf` since AMPR-229, but no
+ * production caller could reach the call-site half of it — `AgentReasoning` built
+ * the `RoutingContext` itself with no seam for requirements. These tests exercise
+ * that seam end to end and pin the semantics in both directions: a floor declared
+ * per call can only ever *raise* the agent's own.
+ */
+class PerCallRungOverrideTest {
+
+    private val sparkLibrary: PhaseSparkLibrary = runBlocking { DefaultPhaseSparkLibrary.load() }
+
+    private val agentFallback = AIConfiguration_Default(AIProvider_OpenAI, AIModel_OpenAI.GPT_4_1)
+
+    private class CapturingRelay : CognitiveRelay {
+        val capturedContext = AtomicReference<RoutingContext?>(null)
+        override val config: RelayConfig = RelayConfig()
+
+        override suspend fun resolve(
+            context: RoutingContext,
+            fallbackConfiguration: AIConfiguration,
+        ): AIConfiguration {
+            capturedContext.set(context)
+            return fallbackConfiguration
+        }
+
+        override suspend fun updateConfig(newConfig: RelayConfig) {}
+    }
+
+    private fun agentWith(
+        relay: CognitiveRelay,
+        agentFloor: CapabilityRung?,
+    ): SparkBasedAgent<*> = SparkBasedAgent.Code(
+        sparkRegistry = sparkLibrary,
+        agentId = "per-call-override",
+        aiConfiguration = agentFallback,
+        // The relay never gets as far as the transport; it hands back the
+        // fallback and the recorded context is what these tests assert on.
+        upstreamLlmClient = UnreachableUpstream,
+        cognitiveRelay = relay,
+        minimumRung = agentFloor,
+        observabilityScope = CoroutineScope(Dispatchers.Default),
+    )
+
+    private fun capturedMinRung(
+        agentFloor: CapabilityRung?,
+        requirements: CapabilityRequirement?,
+    ): RoutingContext? {
+        val relay = CapturingRelay()
+        val agent = agentWith(relay, agentFloor)
+        try {
+            agent.callLLM("do the thing", requirements = requirements)
+        } catch (_: Throwable) {
+            // The fake configuration blows up at the transport; by then the
+            // relay has already recorded the context we care about.
+        }
+        return relay.capturedContext.get()
+    }
+
+    @Test
+    fun `a call-site floor above the agent's resolves against the call-site floor`() {
+        val captured = capturedMinRung(
+            agentFloor = CapabilityRung.THREE,
+            requirements = CapabilityRequirement(minRung = CapabilityRung.FOUR),
+        )
+
+        assertEquals(CapabilityRung.FOUR, captured?.requirements?.minRung)
+    }
+
+    @Test
+    fun `a call-site floor below the agent's does not downgrade it`() {
+        val captured = capturedMinRung(
+            agentFloor = CapabilityRung.FOUR,
+            requirements = CapabilityRequirement(minRung = CapabilityRung.THREE),
+        )
+
+        assertEquals(CapabilityRung.FOUR, captured?.requirements?.minRung)
+    }
+
+    @Test
+    fun `a call-site floor applies to an agent declaring none`() {
+        val captured = capturedMinRung(
+            agentFloor = null,
+            requirements = CapabilityRequirement(minRung = CapabilityRung.FOUR),
+        )
+
+        assertEquals(CapabilityRung.FOUR, captured?.requirements?.minRung)
+    }
+
+    @Test
+    fun `a call supplying no requirements keeps the agent's own floor`() {
+        val captured = capturedMinRung(
+            agentFloor = CapabilityRung.THREE,
+            requirements = null,
+        )
+
+        assertEquals(CapabilityRung.THREE, captured?.requirements?.minRung)
+    }
+
+    @Test
+    fun `neither an agent floor nor a call-site floor leaves the call unconstrained`() {
+        val captured = capturedMinRung(agentFloor = null, requirements = null)
+
+        assertNull(captured?.requirements?.minRung)
+    }
+
+    @Test
+    fun `a per-call requirement carries its non-rung axes through to the relay`() {
+        val captured = capturedMinRung(
+            agentFloor = CapabilityRung.THREE,
+            requirements = CapabilityRequirement(minContextTokens = 128_000),
+        )
+
+        assertEquals(CapabilityRung.THREE, captured?.requirements?.minRung)
+        assertEquals(128_000, captured?.requirements?.minContextTokens)
+    }
+
+    private object UnreachableUpstream : UpstreamLlmClient {
+        override suspend fun call(
+            request: com.aallam.openai.api.chat.ChatCompletionRequest,
+            configuration: AIConfiguration,
+        ) = throw NotImplementedError("These tests never get as far as the transport")
+    }
+}


### PR DESCRIPTION
Closes #597

The Arc path was entirely dormant w.r.t. rungs — `ArcAgentConfig` carried no floor and `SparkAgentFactory.createAgent` built agents without one — and although `AgentLLMService` has composed call-site and agent floors as `maxOf` since AMPR-229, no production caller could reach the call-site half, because `AgentReasoning` built the `RoutingContext` itself with no seam for requirements. This adds `minimumRung` to both `ArcAgentConfig` (per-step) and `ArcConfig` (per-Arc), composed by `ArcConfig.minimumRungFor` and threaded by `ArcAgentSpawner` into the spawned agent's `AgentDefinition.minimumRung`, plus an optional `CapabilityRequirement` on `callLLM`/`callLLMForJson` so a call site can raise the floor for one call.

Two things worth reviewing: the ticket said "per-Arc *default*", but I made the Arc-wide value a floor that composes as `maxOf` rather than a default a step can override downward, so that "floors only ever raise" holds uniformly (reverting is a one-line change in `minimumRungFor`); and because a floor with no relay is a floor that gets silently ignored, an agent declaring one with no injected relay now gets a real `CognitiveRelayImpl` over the bundled catalog, while floorless agents keep the existing dormant behavior. Known gap: that fallback relay publishes no routing events since no `EventSerialBus` is available at the `SparkAgentFactory` seam — `RoutingFloorUnmetException` still propagates, only the `RouteFloorUnmet` event is missing.

19 new tests cover all three validation criteria end to end through real spawned agents rather than mocks, and I verified `jvmTest` (all modules), `ktlintFormat`, `:ampere-core:compileCommonMainKotlinMetadata`, and `:ampere-core:compileKotlinIosSimulatorArm64`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)