### PR TITLE
AMPR-231 #596: Expose a registry injection seam on AgentFactory

### DIFF
--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/AgentFactory.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/AgentFactory.kt
@@ -17,7 +17,9 @@ import link.socket.ampere.agents.domain.routing.CognitiveRelay
 import link.socket.ampere.agents.domain.routing.CognitiveRelayImpl
 import link.socket.ampere.agents.domain.routing.RelayConfig
 import link.socket.ampere.agents.domain.routing.capability.CapabilityRung
+import link.socket.ampere.agents.domain.routing.capability.DefaultModelDescriptorSource
 import link.socket.ampere.agents.domain.routing.capability.InMemoryModelDescriptorRegistry
+import link.socket.ampere.agents.domain.routing.capability.ModelDescriptorSource
 import link.socket.ampere.agents.domain.state.AgentState
 import link.socket.ampere.agents.events.api.AgentEventApi
 import link.socket.ampere.agents.events.bus.EventSerialBus
@@ -73,6 +75,8 @@ enum class AgentType {
  * @param aiConfiguration Optional AI configuration for model selection
  * @param projectSpark Optional project spark (defaults to AmpereProjectSpark)
  * @param toolWriteCodeFileOverride Optional override for write_code_file tool
+ * @param modelDescriptorSource Optional catalog source for the default relay's
+ *   model registry (AMPR-231); ignored when [cognitiveRelay] is supplied
  */
 class AgentFactory(
     private val scope: CoroutineScope,
@@ -101,6 +105,14 @@ class AgentFactory(
      * downgrading.
      */
     private val codeAgentMinimumRung: CapabilityRung? = DEFAULT_CODE_AGENT_RUNG,
+    /**
+     * Catalog source for the default relay's [InMemoryModelDescriptorRegistry]
+     * (AMPR-231). Null falls back to [DefaultModelDescriptorSource] — the
+     * bundled cloud catalog, unchanged from prior behavior. Ignored when
+     * [cognitiveRelay] is supplied directly: an explicit relay owns its own
+     * registry, and the two are never merged.
+     */
+    private val modelDescriptorSource: ModelDescriptorSource? = null,
     /**
      * Outbound LLM transport handed to every agent this factory builds
      * (AMPR-236). `Ampere.fromEnvironment(upstreamLlmClient = ...)` supplies
@@ -164,9 +176,19 @@ class AgentFactory(
         cognitiveRelay ?: CognitiveRelayImpl(
             initialConfig = RelayConfig(rules = CapabilityRoutingDefaults.defaultCapabilityRules()),
             eventBus = eventSerialBus,
-            registry = InMemoryModelDescriptorRegistry(),
+            registry = InMemoryModelDescriptorRegistry(
+                // Loaded eagerly (mirrors phaseSparkLibrary below) so a supplied
+                // source governs routing immediately, not only after a future
+                // refresh() call.
+                seed = runBlockingCompat { effectiveModelDescriptorSource.load() }
+                    .getOrElse { InMemoryModelDescriptorRegistry.defaultModelDescriptors() },
+                source = effectiveModelDescriptorSource,
+            ),
         )
     }
+
+    private val effectiveModelDescriptorSource: ModelDescriptorSource
+        get() = modelDescriptorSource ?: DefaultModelDescriptorSource
 
     private val agentConfiguration: AgentConfiguration
         get() = AgentConfiguration(

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/api/AmpereConfig.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/api/AmpereConfig.kt
@@ -1,5 +1,6 @@
 package link.socket.ampere.api
 
+import link.socket.ampere.agents.domain.routing.capability.ModelDescriptorSource
 import link.socket.ampere.dsl.config.ProviderConfig
 import link.socket.ampere.dsl.events.Escalated
 
@@ -25,6 +26,9 @@ import link.socket.ampere.dsl.events.Escalated
  * @param workspace Workspace directory for file operations
  * @param databasePath Override default database location
  * @param onEscalation Callback invoked when an agent escalates to human
+ * @param modelDescriptorSource Catalog source for the default relay's model
+ *   registry (AMPR-231). Null keeps the bundled cloud catalog. Reaches the
+ *   embedding API without the caller touching `AgentFactory` directly.
  */
 @AmpereStableApi
 data class AmpereConfig(
@@ -33,6 +37,7 @@ data class AmpereConfig(
     val databasePath: String? = null,
     val onEscalation: ((Escalated) -> Unit)? = null,
     val pricingOverrides: PricingOverrides = PricingOverrides(),
+    val modelDescriptorSource: ModelDescriptorSource? = null,
 ) {
     class Builder {
         private var providerConfig: ProviderConfig? = null
@@ -40,6 +45,7 @@ data class AmpereConfig(
         private var databasePath: String? = null
         private var escalationHandler: ((Escalated) -> Unit)? = null
         private val pricingOverridesBuilder = PricingOverridesBuilder()
+        private var modelDescriptorSource: ModelDescriptorSource? = null
 
         /**
          * Set the AI provider configuration.
@@ -102,6 +108,18 @@ data class AmpereConfig(
             pricingOverridesBuilder.apply(configure)
         }
 
+        /**
+         * Catalog source for the default relay's model registry (AMPR-231).
+         * Omit to keep the bundled cloud catalog.
+         *
+         * ```
+         * modelDescriptorSource(MyCatalogSource)
+         * ```
+         */
+        fun modelDescriptorSource(source: ModelDescriptorSource) {
+            modelDescriptorSource = source
+        }
+
         fun build(): AmpereConfig {
             val provider = requireNotNull(providerConfig) {
                 "Provider is required. Use provider(AnthropicConfig()) or similar."
@@ -112,6 +130,7 @@ data class AmpereConfig(
                 databasePath = databasePath,
                 onEscalation = escalationHandler,
                 pricingOverrides = pricingOverridesBuilder.build(),
+                modelDescriptorSource = modelDescriptorSource,
             )
         }
     }

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/api/AmpereFromEnvironment.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/api/AmpereFromEnvironment.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import link.socket.ampere.agents.definition.AgentFactory
 import link.socket.ampere.agents.domain.knowledge.KnowledgeRepository
+import link.socket.ampere.agents.domain.routing.capability.ModelDescriptorSource
 import link.socket.ampere.agents.environment.EnvironmentService
 import link.socket.ampere.agents.events.messages.DefaultThreadViewService
 import link.socket.ampere.agents.events.tickets.DefaultTicketViewService
@@ -57,6 +58,10 @@ import link.socket.ampere.memory.MemoryStore
  * @param agentScope Coroutine scope the instance's [AmpereInstance.agentFactory]
  *   hands to the agents it builds. Defaults to a fresh `Dispatchers.Default`
  *   scope; pass the environment's own scope to share cancellation.
+ * @param modelDescriptorSource Catalog source for the default relay's model
+ *   registry (AMPR-231). Null keeps the bundled cloud catalog. Has no effect
+ *   if a caller constructs agents with their own [AgentFactory] supplying a
+ *   [link.socket.ampere.agents.domain.routing.CognitiveRelay] directly.
  */
 @AmpereStableApi
 fun Ampere.fromEnvironment(
@@ -66,6 +71,7 @@ fun Ampere.fromEnvironment(
     memoryStore: MemoryStore? = null,
     upstreamLlmClient: UpstreamLlmClient? = null,
     agentScope: CoroutineScope = CoroutineScope(Dispatchers.Default),
+    modelDescriptorSource: ModelDescriptorSource? = null,
 ): AmpereInstance {
     val sdkEventApi = environmentService.createEventApi("sdk-cli")
 
@@ -135,6 +141,7 @@ fun Ampere.fromEnvironment(
         eventApiFactory = { agentId -> environmentService.createEventApi(agentId) },
         eventSerialBus = environmentService.eventBus,
         upstreamLlmClient = upstreamLlmClient,
+        modelDescriptorSource = modelDescriptorSource,
     )
 
     return object : AmpereInstance {

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/routing/capability/AgentFactoryModelDescriptorSourceTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/routing/capability/AgentFactoryModelDescriptorSourceTest.kt
@@ -1,0 +1,96 @@
+package link.socket.ampere.agents.domain.routing.capability
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlinx.coroutines.test.runTest
+import link.socket.ampere.agents.domain.routing.CognitiveRelayImpl
+import link.socket.ampere.agents.domain.routing.RelayConfig
+import link.socket.ampere.agents.domain.routing.RoutingContext
+import link.socket.ampere.agents.domain.routing.RoutingResolution
+import link.socket.ampere.agents.domain.routing.RoutingRule
+import link.socket.ampere.domain.ai.configuration.AIConfiguration_Default
+import link.socket.ampere.domain.ai.model.AIModelFeatures.RelativeReasoning
+import link.socket.ampere.domain.ai.model.AIModelFeatures.SupportedInputs
+import link.socket.ampere.domain.ai.model.AIModel_Claude
+import link.socket.ampere.domain.ai.model.AIModel_Gemini
+import link.socket.ampere.domain.ai.provider.AIProvider_Anthropic
+import link.socket.ampere.domain.ai.provider.AIProvider_Google
+
+/**
+ * AMPR-231: exercises the exact registry construction [link.socket.ampere.agents.definition.AgentFactory]
+ * now performs — a [ModelDescriptorSource] loaded eagerly into an
+ * [InMemoryModelDescriptorRegistry] seed — so a consumer-supplied catalog governs
+ * routing immediately, without a relay or rule list of their own.
+ */
+class AgentFactoryModelDescriptorSourceTest {
+
+    private val fallbackConfig = AIConfiguration_Default(
+        provider = AIProvider_Anthropic,
+        model = AIModel_Claude.Sonnet_4,
+    )
+
+    private val customModelConfig = AIConfiguration_Default(
+        provider = AIProvider_Google,
+        model = AIModel_Gemini.Flash_2_5,
+    )
+
+    private val customDescriptor = ModelDescriptor(
+        modelName = AIModel_Gemini.Flash_2_5.name,
+        providerId = AIProvider_Google.id,
+        capabilities = emptySet(),
+        reasoning = RelativeReasoning.HIGH,
+        maxContextTokens = 200_000,
+        supportedInputs = SupportedInputs.TEXT,
+        cost = CostPolicy.Free,
+        rung = CapabilityRung.THREE,
+    )
+
+    private val customSource = ModelDescriptorSource { Result.success(listOf(customDescriptor)) }
+
+    @Test
+    fun `registry seeded from a supplied source holds only that source's catalog`() = runTest {
+        // Mirrors AgentFactory.effectiveCognitiveRelay: seed loaded eagerly from the
+        // source, not left to a future refresh().
+        val registry = InMemoryModelDescriptorRegistry(
+            seed = customSource.load().getOrThrow(),
+            source = customSource,
+        )
+
+        assertEquals(listOf(customDescriptor), registry.all())
+    }
+
+    @Test
+    fun `CODE agent floor routes to the sole model from a single-descriptor custom registry`() = runTest {
+        // AgentFactory.DEFAULT_CODE_AGENT_RUNG is CapabilityRung.THREE; a consumer
+        // handing in one descriptor at that rung must see the CODE path route to it
+        // without supplying a relay or rule list themselves.
+        val registry = InMemoryModelDescriptorRegistry(
+            seed = customSource.load().getOrThrow(),
+            source = customSource,
+        )
+
+        val relay = CognitiveRelayImpl(
+            initialConfig = RelayConfig(
+                rules = listOf(RoutingRule.ByCapability(customModelConfig)),
+            ),
+            registry = registry,
+        )
+
+        val result = relay.resolveWithMetadata(
+            context = RoutingContext(requirements = CapabilityRequirement(minRung = CapabilityRung.THREE)),
+            fallbackConfiguration = fallbackConfig,
+        )
+
+        assertIs<RoutingResolution.Success>(result)
+        assertEquals(AIModel_Gemini.Flash_2_5, result.configuration.model)
+    }
+
+    @Test
+    fun `default source composition is unaffected when no source is supplied`() = runTest {
+        val defaultCatalog = DefaultModelDescriptorSource.load().getOrThrow()
+        val noArgRegistry = InMemoryModelDescriptorRegistry()
+
+        assertEquals(defaultCatalog.toSet(), noArgRegistry.all().toSet())
+    }
+}


### PR DESCRIPTION
Closes #596

I added a `modelDescriptorSource: ModelDescriptorSource? = null` parameter to `AgentFactory`, threaded through `Ampere.fromEnvironment` and mirrored on `AmpereConfig.Builder`, so a consumer can hand in a model catalog without overriding the entire `CognitiveRelay` or its rule list. The default relay's registry is seeded eagerly from the supplied source (falling back to the bundled catalog on load failure) so it governs routing immediately; an explicit `cognitiveRelay` still wins unchanged. Added `AgentFactoryModelDescriptorSourceTest` covering the registry seeding, floor-based routing to a single custom descriptor, and default-catalog parity when no source is supplied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)