### PR TITLE
AMPR-241 #617: Cooperative Arc cancellation + Cancelled terminal state

### DIFF
--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/AmpereCommand.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/AmpereCommand.kt
@@ -47,6 +47,7 @@ import link.socket.ampere.cli.watch.presentation.WatchViewState
 import link.socket.ampere.renderer.HelpOverlayRenderer
 import link.socket.ampere.domain.arc.AmpereRuntime
 import link.socket.ampere.domain.arc.ArcConfig
+import link.socket.ampere.domain.arc.ArcOutcome
 import link.socket.ampere.domain.arc.ArcRegistry
 import link.socket.ampere.repl.TerminalFactory
 
@@ -641,34 +642,48 @@ class AmpereCommand(
                 val runtime = AmpereRuntime.create(
                     arcConfig = arcConfig,
                     projectDirPath = projectDirPath,
+                    agentScope = agentScope,
                 )
 
                 jazzPane.setPhase(CognitiveProgressPane.Phase.INITIALIZING, "Charging: Analyzing project...")
                 updateStatus(StatusBar.SystemStatus.THINKING)
 
-                val chargeResult = runtime.executeChargeOnly(goal)
-                jazzPane.setPhase(
-                    CognitiveProgressPane.Phase.PERCEIVE,
-                    "Project: ${chargeResult.projectContext.projectId}, ${chargeResult.agents.size} agents"
-                )
-
+                // A single `execute()` runs Charge internally; calling `executeChargeOnly` first
+                // would scan the project and spawn a whole second set of agents per goal.
                 jazzPane.setPhase(CognitiveProgressPane.Phase.PLAN, "Flow: Executing agent loop...")
                 updateStatus(StatusBar.SystemStatus.WORKING)
 
-                val result = runtime.execute(goal)
+                when (val outcome = runtime.execute(goal)) {
+                    is ArcOutcome.Completed -> {
+                        val charge = outcome.chargeResult
+                        jazzPane.setPhase(
+                            CognitiveProgressPane.Phase.PERCEIVE,
+                            "Project: ${charge.projectContext.projectId}, ${charge.agents.size} agents"
+                        )
+                        jazzPane.setPhase(
+                            CognitiveProgressPane.Phase.LEARN,
+                            "Pulse: ${outcome.pulseResult.evaluationReport.goalsCompleted}/${outcome.pulseResult.evaluationReport.goalsTotal} goals"
+                        )
 
-                jazzPane.setPhase(
-                    CognitiveProgressPane.Phase.LEARN,
-                    "Pulse: ${result.pulseResult.evaluationReport.goalsCompleted}/${result.pulseResult.evaluationReport.goalsTotal} goals"
-                )
-
-                if (result.success) {
-                    jazzPane.setPhase(CognitiveProgressPane.Phase.COMPLETED)
-                    updateStatus(StatusBar.SystemStatus.COMPLETED)
-                } else {
-                    jazzPane.setFailed("Arc completed with failures")
-                    updateStatus(StatusBar.SystemStatus.ATTENTION_NEEDED)
+                        if (outcome.success) {
+                            jazzPane.setPhase(CognitiveProgressPane.Phase.COMPLETED)
+                            updateStatus(StatusBar.SystemStatus.COMPLETED)
+                        } else {
+                            jazzPane.setFailed("Arc completed with failures")
+                            updateStatus(StatusBar.SystemStatus.ATTENTION_NEEDED)
+                        }
+                    }
+                    is ArcOutcome.Cancelled -> {
+                        jazzPane.setFailed("Arc cancelled at tick ${outcome.flowResult?.finalTick ?: 0}")
+                        updateStatus(StatusBar.SystemStatus.ATTENTION_NEEDED)
+                    }
+                    is ArcOutcome.Failed -> {
+                        jazzPane.setFailed("Arc execution failed: ${outcome.cause.message}")
+                        updateStatus(StatusBar.SystemStatus.ATTENTION_NEEDED)
+                    }
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 jazzPane.setFailed("Arc execution failed: ${e.message}")
                 updateStatus(StatusBar.SystemStatus.ATTENTION_NEEDED)
@@ -721,7 +736,7 @@ class AmpereCommand(
                 goal != null -> {
                     val effectiveGoal = goal!!
                     if (useArcPhases) {
-                        executeArcPhasesHeadless(effectiveGoal, selectedArc)
+                        executeArcPhasesHeadless(effectiveGoal, selectedArc, agentScope)
                         isOneShot = true
                     } else {
                         val goalHandler = GoalHandler(
@@ -793,24 +808,39 @@ class AmpereCommand(
         }
     }
 
-    private suspend fun executeArcPhasesHeadless(goal: String, arcConfig: ArcConfig) {
+    private suspend fun executeArcPhasesHeadless(
+        goal: String,
+        arcConfig: ArcConfig,
+        agentScope: CoroutineScope,
+    ) {
         val projectDirPath = File(System.getProperty("user.dir")).absolutePath
         val runtime = AmpereRuntime.create(
             arcConfig = arcConfig,
             projectDirPath = projectDirPath,
+            agentScope = agentScope,
         )
-        val chargeResult = runtime.executeChargeOnly(goal)
-        println(
-            "Charge complete. Project: ${chargeResult.projectContext.projectId}, " +
-                "${chargeResult.agents.size} agents"
-        )
-        val result = runtime.execute(goal)
-        println(
-            "Pulse: ${result.pulseResult.evaluationReport.goalsCompleted}/" +
-                "${result.pulseResult.evaluationReport.goalsTotal} goals"
-        )
-        if (!result.success) {
-            System.err.println("Arc completed with failures")
+
+        // `execute()` runs Charge itself; a preceding `executeChargeOnly` would double the
+        // project scan and spawn a second full set of agents for the same goal.
+        when (val outcome = runtime.execute(goal)) {
+            is ArcOutcome.Completed -> {
+                val charge = outcome.chargeResult
+                println(
+                    "Charge complete. Project: ${charge.projectContext.projectId}, " +
+                        "${charge.agents.size} agents"
+                )
+                println(
+                    "Pulse: ${outcome.pulseResult.evaluationReport.goalsCompleted}/" +
+                        "${outcome.pulseResult.evaluationReport.goalsTotal} goals"
+                )
+                if (!outcome.success) {
+                    System.err.println("Arc completed with failures")
+                }
+            }
+            is ArcOutcome.Cancelled ->
+                System.err.println("Arc cancelled at tick ${outcome.flowResult?.finalTick ?: 0}")
+            is ArcOutcome.Failed ->
+                System.err.println("Arc execution failed: ${outcome.cause.message}")
         }
     }
 

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/SparkAgentFactory.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/SparkAgentFactory.kt
@@ -1,7 +1,6 @@
 package link.socket.ampere.agents.definition
 
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import link.socket.ampere.agents.definition.code.CodeState
 import link.socket.ampere.agents.domain.RunId
 import link.socket.ampere.agents.domain.cognition.CognitiveAffinity
@@ -36,7 +35,10 @@ import link.socket.ampere.llm.UpstreamLlmClient
  * 2. Pre-sparks it with common Spark configurations
  * 3. Returns the agent ready for tasks
  *
- * @param scope CoroutineScope for agent async operations
+ * @param scope Caller-owned CoroutineScope for agent async operations. Required on purpose: a
+ *   default like `CoroutineScope(Dispatchers.Default)` would hand every created agent a detached
+ *   scope with no parent Job, no owner, and no cancellation path — a `GlobalScope` in all but
+ *   name. Pass the scope whose lifetime the agents should share.
  * @param eventApiFactory Creates per-agent event APIs for publishing events
  * @param memoryServiceFactory Creates per-agent memory services
  * @param defaultAiConfiguration Default AI configuration for agents
@@ -50,7 +52,7 @@ import link.socket.ampere.llm.UpstreamLlmClient
  *   `RoutingContext.workflowId` and therefore reach `ProviderCallStartedEvent`/`ProviderCallCompletedEvent`.
  */
 class SparkAgentFactory(
-    private val scope: CoroutineScope = CoroutineScope(Dispatchers.Default),
+    private val scope: CoroutineScope,
     private val eventApiFactory: ((AgentId) -> AgentEventApi)? = null,
     private val memoryServiceFactory: ((AgentId) -> AgentMemoryService)? = null,
     private val defaultAiConfiguration: AIConfiguration? = null,

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/execution/AutonomousWorkLoop.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/execution/AutonomousWorkLoop.kt
@@ -4,6 +4,7 @@ import kotlin.math.pow
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -77,56 +78,62 @@ class AutonomousWorkLoop<S : AgentState>(
             _isRunning.value = true
             var consecutiveNoWork = 0
 
-            while (_isRunning.value) {
-                try {
-                    if (shouldThrottleForRateLimit()) {
-                        delay(config.backoffInterval)
-                        continue
-                    }
+            try {
+                while (_isRunning.value) {
+                    try {
+                        if (shouldThrottleForRateLimit()) {
+                            delay(config.backoffInterval)
+                            continue
+                        }
 
-                    val issues = workflow.queryAvailableIssues()
-                    if (issues.isEmpty()) {
-                        consecutiveNoWork++
-                        delay(calculateBackoff(consecutiveNoWork))
-                        continue
-                    }
-                    consecutiveNoWork = 0
+                        val issues = workflow.queryAvailableIssues()
+                        if (issues.isEmpty()) {
+                            consecutiveNoWork++
+                            delay(calculateBackoff(consecutiveNoWork))
+                            continue
+                        }
+                        consecutiveNoWork = 0
 
-                    val issue = issues.first()
-                    val claimed = workflow.claimIssue(issue.number)
-                    if (claimed.isFailure) {
-                        delay(config.pollingInterval)
-                        continue
-                    }
+                        val issue = issues.first()
+                        val claimed = workflow.claimIssue(issue.number)
+                        if (claimed.isFailure) {
+                            delay(config.pollingInterval)
+                            continue
+                        }
 
-                    eventApi?.publishTaskCreated(
-                        taskId = "issue-${issue.number}",
-                        urgency = Urgency.MEDIUM,
-                        description = "Working on issue #${issue.number}: ${issue.title}",
-                        assignedTo = agent.id,
-                    )
-
-                    val result = workflow.workOnIssue(issue, agent)
-                    issuesProcessedThisHour++
-
-                    if (result.isSuccess) {
-                        eventApi?.publishCodeSubmitted(
-                            urgency = Urgency.LOW,
-                            filePath = "issue-${issue.number}",
-                            changeDescription = "Completed issue #${issue.number}: ${result.getOrNull()}",
-                            reviewRequired = true,
-                            assignedTo = null,
+                        eventApi?.publishTaskCreated(
+                            taskId = "issue-${issue.number}",
+                            urgency = Urgency.MEDIUM,
+                            description = "Working on issue #${issue.number}: ${issue.title}",
+                            assignedTo = agent.id,
                         )
+
+                        val result = workflow.workOnIssue(issue, agent)
+                        issuesProcessedThisHour++
+
+                        if (result.isSuccess) {
+                            eventApi?.publishCodeSubmitted(
+                                urgency = Urgency.LOW,
+                                filePath = "issue-${issue.number}",
+                                changeDescription = "Completed issue #${issue.number}: ${result.getOrNull()}",
+                                reviewRequired = true,
+                                assignedTo = null,
+                            )
+                        }
+
+                        delay(config.pollingInterval)
+                    } catch (e: CancellationException) {
+                        // Never back off and retry on cancellation — that would keep a stopped
+                        // loop alive. Let it unwind to the `finally` below.
+                        throw e
+                    } catch (e: Exception) {
+                        println("Error in autonomous work loop: ${e.message}")
+                        delay(config.backoffInterval)
                     }
-
-                    delay(config.pollingInterval)
-                } catch (e: Exception) {
-                    println("Error in autonomous work loop: ${e.message}")
-                    delay(config.backoffInterval)
                 }
+            } finally {
+                _isRunning.value = false
             }
-
-            _isRunning.value = false
         }
     }
 

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/arc/AmpereRuntime.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/arc/AmpereRuntime.kt
@@ -1,5 +1,17 @@
 package link.socket.ampere.domain.arc
 
+import kotlin.concurrent.Volatile
+import kotlin.coroutines.coroutineContext
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableJob
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.withContext
 import link.socket.ampere.agents.definition.AgentId
 import link.socket.ampere.agents.domain.routing.CognitiveRelay
 import link.socket.ampere.agents.events.api.AgentEventApi
@@ -13,18 +25,6 @@ import okio.Path
 import okio.Path.Companion.toPath
 
 /**
- * Result of a complete Arc lifecycle execution.
- */
-data class ArcExecutionResult(
-    val runId: ArcRunId,
-    val chargeResult: ChargeResult,
-    val flowResult: FlowResult,
-    val pulseResult: PulseResult,
-) {
-    val success: Boolean get() = pulseResult.success
-}
-
-/**
  * Runtime for executing Arc workflows through the Charge → Flow → Pulse lifecycle.
  *
  * The runtime orchestrates the three phases:
@@ -32,18 +32,34 @@ data class ArcExecutionResult(
  * - **Flow**: Agent execution loop (perceive → remember → plan → execute)
  * - **Pulse**: Evaluation, learning capture, and delivery
  *
+ * ### Lifetime and cancellation
+ *
+ * [agentScope] is caller-owned: the caller decides when spawned agents die. Each [execute] call
+ * runs inside a per-run child scope of [agentScope], and that child is cancelled and joined
+ * before [execute] returns — so no agent coroutine outlives the Arc run that spawned it, and
+ * cancelling [agentScope] cancels any run in flight.
+ *
+ * There are two ways to end a run early:
+ * - [stop] is cooperative and graceful. Flow finishes the tick it is on, terminates with
+ *   [TerminationReason.MANUAL_STOP], and Pulse still runs — so the outcome is
+ *   [ArcOutcome.Completed].
+ * - [cancel] is a real coroutine cancellation. Flow stops at its next cancellation point,
+ *   Pulse is skipped, and the outcome is [ArcOutcome.Cancelled].
+ *
  * Example usage:
  * ```kotlin
  * val runtime = AmpereRuntime(
  *     arcConfig = ArcRegistry.get("startup-saas")!!,
  *     projectDir = Path("/path/to/project"),
+ *     agentScope = myScope,
  * )
- * val result = runtime.execute("Implement user authentication")
+ * val outcome = runtime.execute("Implement user authentication")
  * ```
  */
 class AmpereRuntime(
     private val arcConfig: ArcConfig,
     private val projectDir: Path,
+    private val agentScope: CoroutineScope,
     private val fileSystem: FileSystem = systemFileSystem,
     private val maxFlowTicks: Int = 100,
     private val cognitiveRelay: CognitiveRelay? = null,
@@ -61,91 +77,158 @@ class AmpereRuntime(
 ) {
     private var chargeResult: ChargeResult? = null
     private var flowResult: FlowResult? = null
+
+    // `stop()` and `cancel()` are called from whatever thread owns the UI or the shutdown hook,
+    // never from the Arc's own coroutine — so everything they touch, and everything they are
+    // observed through, has to be volatile to be visible across that boundary.
+    @Volatile
     private var isRunning = false
+
+    @Volatile
+    private var stopRequested = false
+
+    /** Set for the duration of [execute] so [cancel] has something to cancel. */
+    @Volatile
+    private var runJob: CompletableJob? = null
+
+    /** Set once Flow starts so [stop] can reach it and a cancelled run can still be summarised. */
+    @Volatile
+    internal var flowPhase: FlowPhase? = null
+        private set
 
     /**
      * Execute the full Arc lifecycle for a given goal.
+     *
+     * Never throws for an Arc-level failure or cancellation — both are returned as
+     * [ArcOutcome.Failed] and [ArcOutcome.Cancelled]. Cancellation of the *caller's* coroutine
+     * is still propagated as a [CancellationException], as structured concurrency requires.
      *
      * @param userGoal The goal to accomplish
      * @param runId Ambient identity for this Arc execution (AMPR-240). Threaded down into every
      *   spawned agent so their `RoutingContext.workflowId` — and therefore
      *   `ProviderCallStartedEvent`/`ProviderCallCompletedEvent` — carries this run's id. Defaults to a
-     *   freshly generated id so existing callers keep working unchanged.
-     * @return ArcExecutionResult containing results from all three phases
+     *   freshly generated id so existing callers keep working unchanged. It is echoed back on
+     *   every [ArcOutcome], including the cancelled and failed ones.
+     * @return The terminal [ArcOutcome] of the run
      * @throws IllegalStateException if already running
      * @throws IllegalArgumentException if goal is blank
      */
-    suspend fun execute(userGoal: String, runId: ArcRunId = generateUUID("arc-run")): ArcExecutionResult {
+    suspend fun execute(userGoal: String, runId: ArcRunId = generateUUID("arc-run")): ArcOutcome {
         require(!isRunning) { "Runtime is already executing" }
         require(userGoal.isNotBlank()) { "User goal cannot be blank" }
 
         isRunning = true
+        stopRequested = false
+        chargeResult = null
+        flowResult = null
+        flowPhase = null
+
+        // A per-run child of the caller-owned scope: cancellable on its own (so `cancel()` does
+        // not touch the caller), and cancelled + joined in the `finally` below so the run leaves
+        // nothing alive behind it. SupervisorJob so one agent's failure cannot tear down the
+        // caller's scope.
+        val job = SupervisorJob(agentScope.coroutineContext[Job])
+        val runScope = CoroutineScope(agentScope.coroutineContext + job)
+        runJob = job
 
         try {
-            // Phase 1: Charge - Initialize project context and spawn agents
-            val charge = executeCharge(userGoal, runId)
-            chargeResult = charge
-
-            // Phase 2: Flow - Execute agent loop
-            val flow = executeFlow(charge)
-            flowResult = flow
-
-            // Phase 3: Pulse - Evaluate and capture learnings
-            val pulse = executePulse(charge, flow)
-
-            return ArcExecutionResult(
+            return runScope.async { runArc(userGoal, runId, runScope) }.await()
+        } catch (e: CancellationException) {
+            // If the *caller* was cancelled this is not ours to swallow — rethrow it.
+            coroutineContext.ensureActive()
+            return ArcOutcome.Cancelled(
                 runId = runId,
-                chargeResult = charge,
-                flowResult = flow,
-                pulseResult = pulse,
+                chargeResult = chargeResult,
+                flowResult = flowResult ?: flowPhase?.snapshot(),
             )
         } finally {
+            withContext(NonCancellable) {
+                job.cancelAndJoin()
+            }
+            runJob = null
             isRunning = false
         }
+    }
+
+    private suspend fun runArc(
+        userGoal: String,
+        runId: ArcRunId,
+        runScope: CoroutineScope,
+    ): ArcOutcome = try {
+        // Phase 1: Charge - Initialize project context and spawn agents
+        val charge = executeCharge(userGoal, runId, runScope)
+        chargeResult = charge
+
+        // Phase 2: Flow - Execute agent loop
+        val flow = executeFlow(charge)
+        flowResult = flow
+
+        // Phase 3: Pulse - Evaluate and capture learnings
+        val pulse = executePulse(charge, flow)
+
+        ArcOutcome.Completed(
+            runId = runId,
+            chargeResult = charge,
+            flowResult = flow,
+            pulseResult = pulse,
+        )
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Throwable) {
+        ArcOutcome.Failed(
+            runId = runId,
+            cause = e,
+            chargeResult = chargeResult,
+            flowResult = flowResult ?: flowPhase?.snapshot(),
+        )
     }
 
     /**
      * Execute only the Charge phase.
      * Useful for testing or when you need to inspect the project context before proceeding.
+     *
+     * The agents in the returned [ChargeResult] are bound to [agentScope] rather than to a
+     * per-run scope, because there is no run here to bound them to — the caller owns them.
      */
     suspend fun executeChargeOnly(userGoal: String, runId: ArcRunId = generateUUID("arc-run")): ChargeResult {
         require(userGoal.isNotBlank()) { "User goal cannot be blank" }
 
-        val chargePhase = ChargePhase(
-            arcConfig = arcConfig,
-            projectDir = projectDir,
-            fileSystem = fileSystem,
-            cognitiveRelay = cognitiveRelay,
-            executor = executor,
-            upstreamLlmClient = upstreamLlmClient,
-            runId = runId,
-            eventApiFactory = eventApiFactory,
-        )
-        return chargePhase.execute(userGoal)
+        return newChargePhase(agentScope, runId).execute(userGoal)
     }
 
-    private suspend fun executeCharge(userGoal: String, runId: ArcRunId): ChargeResult {
-        val chargePhase = ChargePhase(
-            arcConfig = arcConfig,
-            projectDir = projectDir,
-            fileSystem = fileSystem,
-            cognitiveRelay = cognitiveRelay,
-            executor = executor,
-            upstreamLlmClient = upstreamLlmClient,
-            runId = runId,
-            eventApiFactory = eventApiFactory,
-        )
-        return chargePhase.execute(userGoal)
-    }
+    private suspend fun executeCharge(
+        userGoal: String,
+        runId: ArcRunId,
+        runScope: CoroutineScope,
+    ): ChargeResult = newChargePhase(runScope, runId).execute(userGoal)
+
+    private fun newChargePhase(agentScope: CoroutineScope, runId: ArcRunId): ChargePhase = ChargePhase(
+        arcConfig = arcConfig,
+        projectDir = projectDir,
+        agentScope = agentScope,
+        fileSystem = fileSystem,
+        cognitiveRelay = cognitiveRelay,
+        executor = executor,
+        upstreamLlmClient = upstreamLlmClient,
+        runId = runId,
+        eventApiFactory = eventApiFactory,
+    )
 
     private suspend fun executeFlow(chargeResult: ChargeResult): FlowResult {
-        val flowPhase = FlowPhase(
+        val phase = FlowPhase(
             arcConfig = arcConfig,
             agents = chargeResult.agents,
             goalTree = chargeResult.goalTree,
             maxTicks = maxFlowTicks,
         )
-        return flowPhase.execute()
+        flowPhase = phase
+
+        // A `stop()` that landed during Charge takes effect at this phase boundary.
+        if (stopRequested) {
+            phase.stop()
+        }
+
+        return phase.execute()
     }
 
     private suspend fun executePulse(chargeResult: ChargeResult, flowResult: FlowResult): PulseResult {
@@ -159,11 +242,26 @@ class AmpereRuntime(
     }
 
     /**
-     * Stop a running execution.
-     * This will stop at the next safe point (between phases or between ticks).
+     * Request a graceful stop of a running execution.
+     *
+     * Takes effect at the next safe point — between phases, or between Flow ticks. Flow
+     * terminates with [TerminationReason.MANUAL_STOP] and Pulse still runs, so the run ends as
+     * [ArcOutcome.Completed]. Use [cancel] to abandon the run instead.
      */
     fun stop() {
-        isRunning = false
+        stopRequested = true
+        flowPhase?.stop()
+    }
+
+    /**
+     * Cancel a running execution.
+     *
+     * Cancels the run's coroutine scope, so the Flow tick loop stops at its next cancellation
+     * point and every agent coroutine spawned by the run is torn down. [execute] returns
+     * [ArcOutcome.Cancelled] carrying whatever partial phase results exist.
+     */
+    fun cancel() {
+        runJob?.cancel(CancellationException("Arc execution cancelled"))
     }
 
     /**
@@ -182,17 +280,20 @@ class AmpereRuntime(
          *
          * @param arcConfig The Arc configuration to use
          * @param projectDirPath The project directory as a string path
+         * @param agentScope Caller-owned scope that spawned agents are bound to
          * @param maxFlowTicks Maximum ticks for the flow phase
          * @return AmpereRuntime configured with the specified Arc
          */
         fun create(
             arcConfig: ArcConfig,
             projectDirPath: String,
+            agentScope: CoroutineScope,
             maxFlowTicks: Int = 100,
         ): AmpereRuntime {
             return AmpereRuntime(
                 arcConfig = arcConfig,
                 projectDir = projectDirPath.toPath(),
+                agentScope = agentScope,
                 maxFlowTicks = maxFlowTicks,
             )
         }
@@ -212,18 +313,21 @@ class AmpereRuntime(
          *
          * @param teamRoles List of role names from team config
          * @param projectDir Project directory path
+         * @param agentScope Caller-owned scope that spawned agents are bound to
          * @param fileSystem File system to use
          * @return AmpereRuntime configured with equivalent Arc config
          */
         fun fromTeamConfig(
             teamRoles: List<String>,
             projectDir: Path,
+            agentScope: CoroutineScope,
             fileSystem: FileSystem = systemFileSystem,
         ): AmpereRuntime {
             val arcConfig = teamConfigToArcConfig(teamRoles)
             return AmpereRuntime(
                 arcConfig = arcConfig,
                 projectDir = projectDir,
+                agentScope = agentScope,
                 fileSystem = fileSystem,
             )
         }

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/arc/ArcOutcome.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/arc/ArcOutcome.kt
@@ -1,0 +1,62 @@
+package link.socket.ampere.domain.arc
+
+import link.socket.ampere.trace.ArcRunId
+
+/**
+ * Terminal state of a single Arc lifecycle run.
+ *
+ * An Arc ends in exactly one of three ways, and every one of them is a value rather than a
+ * thrown exception:
+ * - [Completed] — all three phases ran to the end. Inspect [Completed.success] for whether the
+ *   Pulse evaluation considered the goal met; a `Completed` Arc can still be an unsuccessful one.
+ * - [Failed] — a phase threw. The failure is carried in [Failed.cause] alongside whatever
+ *   partial phase results were produced before it.
+ * - [Cancelled] — the run was cancelled cooperatively (via `AmpereRuntime.cancel()` or by
+ *   cancelling the caller-owned scope). Partial phase results are carried the same way.
+ *
+ * [chargeResult] and [flowResult] are non-null on [Completed] and best-effort on the other two,
+ * so a caller can always report how far the Arc got.
+ */
+sealed interface ArcOutcome {
+
+    /**
+     * Identity of the run this outcome terminates (AMPR-240).
+     *
+     * Present on every variant, not just the successful one: a run that failed or was cancelled
+     * still emitted telemetry under this id, and correlating that partial trace is exactly when
+     * the id is most useful.
+     */
+    val runId: ArcRunId
+
+    /** The Charge phase result, or `null` if the Arc did not get that far. */
+    val chargeResult: ChargeResult?
+
+    /** The Flow phase result, or `null` if the Arc did not get that far. */
+    val flowResult: FlowResult?
+
+    /** All three phases ran to completion. */
+    data class Completed(
+        override val runId: ArcRunId,
+        override val chargeResult: ChargeResult,
+        override val flowResult: FlowResult,
+        val pulseResult: PulseResult,
+    ) : ArcOutcome {
+        /** Whether the Pulse evaluation judged the goal met. */
+        val success: Boolean get() = pulseResult.success
+    }
+
+    /** A phase threw a non-cancellation [Throwable]. */
+    data class Failed(
+        override val runId: ArcRunId,
+        val cause: Throwable,
+        override val chargeResult: ChargeResult? = null,
+        override val flowResult: FlowResult? = null,
+    ) : ArcOutcome
+
+    /** The run was cancelled before it could finish. */
+    data class Cancelled(
+        override val runId: ArcRunId,
+        override val chargeResult: ChargeResult? = null,
+        override val flowResult: FlowResult? = null,
+    ) : ArcOutcome
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/arc/ChargePhase.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/arc/ChargePhase.kt
@@ -1,5 +1,6 @@
 package link.socket.ampere.domain.arc
 
+import kotlinx.coroutines.CoroutineScope
 import link.socket.ampere.agents.definition.Agent
 import link.socket.ampere.agents.definition.AgentId
 import link.socket.ampere.agents.definition.SparkAgentFactory
@@ -70,9 +71,15 @@ data class GoalNode(
     val children: List<GoalNode> = emptyList(),
 )
 
+/**
+ * @param agentScope Caller-owned scope that every agent spawned here is bound to. Required, and
+ *   deliberately not defaulted: agents spawned onto an implicit scope have no owner and no
+ *   cancellation path, which is the orphaned-coroutine hole this parameter exists to close.
+ */
 class ChargePhase(
     private val arcConfig: ArcConfig,
     private val projectDir: Path,
+    private val agentScope: CoroutineScope,
     private val fileSystem: FileSystem = systemFileSystem,
     private val cognitiveRelay: CognitiveRelay? = null,
     private val executor: Executor? = null,
@@ -97,6 +104,7 @@ class ChargePhase(
 
         val agents = ArcAgentSpawner(
             agentFactory = SparkAgentFactory(
+                scope = agentScope,
                 cognitiveRelay = cognitiveRelay,
                 executor = executor,
                 upstreamLlmClient = upstreamLlmClient,
@@ -309,7 +317,7 @@ internal class GoalTreeBuilder {
 }
 
 internal class ArcAgentSpawner(
-    private val agentFactory: SparkAgentFactory = SparkAgentFactory(),
+    private val agentFactory: SparkAgentFactory,
     private val sparkRegistry: SparkRegistry = DefaultSparkCatalog.registry,
 ) {
     fun spawn(arcConfig: ArcConfig, projectContext: ProjectContext): List<SparkBasedAgent<CodeState>> {

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/arc/FlowPhase.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/arc/FlowPhase.kt
@@ -1,5 +1,9 @@
 package link.socket.ampere.domain.arc
 
+import kotlin.concurrent.Volatile
+import kotlin.coroutines.coroutineContext
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import link.socket.ampere.agents.definition.Agent
@@ -17,9 +21,19 @@ data class FlowResult(
 )
 
 enum class TerminationReason {
+    /** Every goal in the tree was completed. */
     GOAL_COMPLETE,
+
+    /** The tick budget ran out before the goal tree was complete. */
     MAX_TICKS_REACHED,
+
+    /** A caller asked for a graceful stop via [FlowPhase.stop] / `AmpereRuntime.stop()`. */
     MANUAL_STOP,
+
+    /** The Flow coroutine was cancelled; the tick loop bailed at its next cancellation point. */
+    CANCELLED,
+
+    /** A tick threw. The exception is rethrown; this reason only labels the partial result. */
     ERROR,
 }
 
@@ -49,13 +63,21 @@ class FlowPhase(
     private val goalTree: GoalTree,
     private val maxTicks: Int = 100,
 ) {
+    // Volatile because [stop] is called from another thread while the tick loop is running, and
+    // [getCurrentTick]/[snapshot] are read from another thread while it is still ticking.
+    @Volatile
     private var currentTick = 0
+
     private val sharedContext = SharedContext(
         goalTree = goalTree,
         currentGoal = goalTree.root,
     )
     private val barrierMutex = Mutex()
+
+    @Volatile
     private var isComplete = false
+
+    @Volatile
     private var terminationReason: TerminationReason? = null
 
     suspend fun execute(): FlowResult {
@@ -66,27 +88,48 @@ class FlowPhase(
             "FlowPhase currently only supports SEQUENTIAL orchestration"
         }
 
-        while (!isComplete && currentTick < maxTicks) {
-            executeTick()
-            currentTick++
+        try {
+            while (!isComplete && currentTick < maxTicks) {
+                // The tick loop is the Arc's cancellation point: a tick can be long and an
+                // inner suspend call may never hit one, so check explicitly every tick.
+                coroutineContext.ensureActive()
 
-            if (sharedContext.isGoalTreeComplete()) {
-                isComplete = true
-                terminationReason = TerminationReason.GOAL_COMPLETE
+                executeTick()
+                currentTick++
+
+                if (sharedContext.isGoalTreeComplete()) {
+                    isComplete = true
+                    terminationReason = TerminationReason.GOAL_COMPLETE
+                }
             }
+        } catch (e: CancellationException) {
+            terminationReason = TerminationReason.CANCELLED
+            throw e
+        } catch (e: Throwable) {
+            terminationReason = TerminationReason.ERROR
+            throw e
         }
 
         if (!isComplete && currentTick >= maxTicks) {
             terminationReason = TerminationReason.MAX_TICKS_REACHED
         }
 
-        return FlowResult(
-            completedGoals = sharedContext.completedGoals.toList(),
-            finalTick = currentTick,
-            agentOutcomes = sharedContext.agentOutcomes.mapValues { it.value.toList() },
-            terminationReason = terminationReason ?: TerminationReason.MANUAL_STOP,
-        )
+        return snapshot()
     }
+
+    /**
+     * The Flow's progress so far, as a [FlowResult].
+     *
+     * [execute] returns this on the happy path, and callers that hold the [FlowPhase] can call
+     * it after a cancellation or failure to recover the partial run — that is the whole reason
+     * `AmpereRuntime` holds the instance rather than dropping it.
+     */
+    fun snapshot(): FlowResult = FlowResult(
+        completedGoals = sharedContext.completedGoals.toList(),
+        finalTick = currentTick,
+        agentOutcomes = sharedContext.agentOutcomes.mapValues { it.value.toList() },
+        terminationReason = terminationReason ?: TerminationReason.MANUAL_STOP,
+    )
 
     private suspend fun executeTick() {
         val agentOrder = determineAgentOrder()
@@ -196,6 +239,10 @@ class FlowPhase(
 
     fun isComplete(): Boolean = isComplete
 
+    /**
+     * Request a graceful stop. The tick loop exits after the tick in flight, and the run
+     * terminates with [TerminationReason.MANUAL_STOP].
+     */
     fun stop() {
         isComplete = true
         terminationReason = TerminationReason.MANUAL_STOP

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/domain/arc/AmpereRuntimeTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/domain/arc/AmpereRuntimeTest.kt
@@ -2,16 +2,35 @@ package link.socket.ampere.domain.arc
 
 import kotlin.io.path.createTempDirectory
 import kotlin.io.path.writeText
+import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.job
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import link.socket.ampere.agents.definition.SparkBasedAgent
 import okio.Path.Companion.toPath
 
 class AmpereRuntimeTest {
+
+    /** For tests that construct a runtime but never execute it. */
+    private val idleScope = CoroutineScope(SupervisorJob())
+
+    @AfterTest
+    fun cancelIdleScope() {
+        idleScope.cancel()
+    }
 
     @Test
     fun `runtime executes full arc lifecycle`() = runTest {
@@ -54,10 +73,11 @@ class AmpereRuntimeTest {
         val runtime = AmpereRuntime(
             arcConfig = arcConfig,
             projectDir = tempDir.toString().toPath(),
+            agentScope = backgroundScope,
             maxFlowTicks = 5,
         )
 
-        val result = runtime.execute("Implement user login")
+        val result = assertIs<ArcOutcome.Completed>(runtime.execute("Implement user login"))
 
         // Verify Charge phase results
         assertNotNull(result.chargeResult)
@@ -114,6 +134,7 @@ class AmpereRuntimeTest {
         val runtime = AmpereRuntime(
             arcConfig = arcConfig,
             projectDir = tempDir.toString().toPath(),
+            agentScope = backgroundScope,
         )
 
         val chargeResult = runtime.executeChargeOnly("Build API endpoint")
@@ -131,6 +152,7 @@ class AmpereRuntimeTest {
         val runtime = AmpereRuntime.fromTeamConfig(
             teamRoles = teamRoles,
             projectDir = tempDir.toString().toPath(),
+            agentScope = idleScope,
         )
 
         val arcConfig = runtime.getArcConfig()
@@ -192,6 +214,7 @@ class AmpereRuntimeTest {
         val runtime = AmpereRuntime(
             arcConfig = arcConfig,
             projectDir = tempDir.toString().toPath(),
+            agentScope = backgroundScope,
             maxFlowTicks = 1,
         )
 
@@ -218,6 +241,7 @@ class AmpereRuntimeTest {
         val runtime = AmpereRuntime(
             arcConfig = arcConfig,
             projectDir = tempDir.toString().toPath(),
+            agentScope = idleScope,
         )
 
         val retrieved = runtime.getArcConfig()
@@ -236,6 +260,7 @@ class AmpereRuntimeTest {
         val runtime = AmpereRuntime(
             arcConfig = ArcRegistry.getDefault(),
             projectDir = tempDir.toString().toPath(),
+            agentScope = backgroundScope,
         )
 
         val exception = runCatching { runtime.execute("") }.exceptionOrNull()
@@ -270,10 +295,11 @@ class AmpereRuntimeTest {
         val runtime = AmpereRuntime(
             arcConfig = devopsArc,
             projectDir = tempDir.toString().toPath(),
+            agentScope = backgroundScope,
             maxFlowTicks = 1,
         )
 
-        val result = runtime.execute("Deploy to staging")
+        val result = assertIs<ArcOutcome.Completed>(runtime.execute("Deploy to staging"))
 
         assertEquals(3, result.chargeResult.agents.size)
         assertTrue(
@@ -281,5 +307,143 @@ class AmpereRuntimeTest {
                 it.cognitiveState.contains("Role:Operations")
             },
         )
+    }
+
+    /**
+     * Real dispatchers on purpose: the cancel has to race a Flow loop that is genuinely running
+     * on another thread, which a single-threaded test dispatcher cannot express.
+     */
+    @Test
+    fun `cancelling mid flow yields a Cancelled outcome and leaves no live coroutines`() =
+        runBlocking {
+            val tempDir = arcProjectDir("runtime-cancel")
+
+            val arcConfig = ArcConfig(
+                name = "cancel-arc",
+                agents = listOf(ArcAgentConfig(role = "code")),
+                orchestration = OrchestrationConfig(
+                    type = OrchestrationType.SEQUENTIAL,
+                    order = listOf("code"),
+                ),
+            )
+
+            val callerScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+            try {
+                val runtime = AmpereRuntime(
+                    arcConfig = arcConfig,
+                    projectDir = tempDir.toString().toPath(),
+                    agentScope = callerScope,
+                    // Large enough that Flow cannot finish before the cancel lands.
+                    maxFlowTicks = Int.MAX_VALUE,
+                )
+
+                val run = callerScope.async { runtime.execute("Implement a very long running goal") }
+
+                // Cancel only once Flow is demonstrably underway, so this is a mid-Flow cancel
+                // rather than a cancel that happened to beat the Charge phase.
+                withTimeout(60_000) {
+                    while ((runtime.flowPhase?.getCurrentTick() ?: 0) < 1) {
+                        delay(5)
+                    }
+                }
+
+                runtime.cancel()
+
+                val outcome = withTimeout(60_000) { assertIs<ArcOutcome.Cancelled>(run.await()) }
+
+                assertNotNull(outcome.chargeResult, "Charge finished, so it should be reported")
+                assertEquals(
+                    TerminationReason.CANCELLED,
+                    outcome.flowResult?.terminationReason,
+                    "A cancelled Flow must report CANCELLED, not a fallback reason",
+                )
+                assertFalse(runtime.isRunning())
+
+                // The per-run scope is cancelled and joined before execute() returns, so the
+                // caller-owned scope is back to holding nothing but the finished `run` itself.
+                assertEquals(
+                    emptyList(),
+                    callerScope.coroutineContext.job.children.filter { it != run }.toList(),
+                    "The Arc run must leave no live coroutines in the caller-owned scope",
+                )
+            } finally {
+                callerScope.cancel()
+            }
+        }
+
+    @Test
+    fun `stop between ticks yields a completed outcome with MANUAL_STOP`() = runBlocking {
+        val tempDir = arcProjectDir("runtime-stop")
+
+        val arcConfig = ArcConfig(
+            name = "stop-arc",
+            agents = listOf(ArcAgentConfig(role = "code")),
+            orchestration = OrchestrationConfig(
+                type = OrchestrationType.SEQUENTIAL,
+                order = listOf("code"),
+            ),
+        )
+
+        val callerScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+        try {
+            val runtime = AmpereRuntime(
+                arcConfig = arcConfig,
+                projectDir = tempDir.toString().toPath(),
+                agentScope = callerScope,
+                maxFlowTicks = Int.MAX_VALUE,
+            )
+
+            val run = callerScope.async { runtime.execute("Implement a very long running goal") }
+
+            withTimeout(60_000) {
+                while ((runtime.flowPhase?.getCurrentTick() ?: 0) < 1) {
+                    delay(5)
+                }
+            }
+
+            runtime.stop()
+
+            // Unlike cancel(), a graceful stop still runs Pulse, so the Arc completes.
+            val outcome = withTimeout(60_000) { assertIs<ArcOutcome.Completed>(run.await()) }
+
+            assertEquals(TerminationReason.MANUAL_STOP, outcome.flowResult.terminationReason)
+        } finally {
+            callerScope.cancel()
+        }
+    }
+
+    @Test
+    fun `runtime is reusable after a run finishes`() = runTest {
+        val runtime = AmpereRuntime(
+            arcConfig = ArcRegistry.getDefault(),
+            projectDir = arcProjectDir("runtime-reentrant").toString().toPath(),
+            agentScope = backgroundScope,
+            maxFlowTicks = 1,
+        )
+
+        // The `isRunning` guard must reset in the finally, so a second call is accepted.
+        assertIs<ArcOutcome.Completed>(runtime.execute("First goal"))
+        assertIs<ArcOutcome.Completed>(runtime.execute("Second goal"))
+    }
+
+    /** A temp dir with the AGENTS.md/README.md that ChargePhase requires to produce a context. */
+    private fun arcProjectDir(prefix: String): java.nio.file.Path {
+        val tempDir = createTempDirectory(prefix)
+        tempDir.resolve("README.md").writeText("# CancelProject\n\nA long running test project.")
+        tempDir.resolve("AGENTS.md").writeText(
+            """
+            # AGENTS
+
+            ## Dependencies
+            - Kotlin
+
+            ## Conventions
+            - Use suspend functions
+
+            ## Architecture
+            - Clean architecture
+            """.trimIndent(),
+        )
+        return tempDir
     }
 }

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/domain/arc/ArcRungPropagationTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/domain/arc/ArcRungPropagationTest.kt
@@ -9,11 +9,15 @@ import com.aallam.openai.api.model.ModelId
 import com.charleskorn.kaml.Yaml
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.serialization.encodeToString
 import link.socket.ampere.agents.definition.SparkAgentFactory
 import link.socket.ampere.agents.domain.routing.RoutingFloorUnmetException
@@ -37,6 +41,14 @@ import okio.Path.Companion.toPath
  * that makes a declared floor mean something rather than being silently ignored.
  */
 class ArcRungPropagationTest {
+
+    /** Owns the agents these tests spawn; cancelled once each test is done with them. */
+    private val agentScope = CoroutineScope(SupervisorJob())
+
+    @AfterTest
+    fun cancelAgentScope() {
+        agentScope.cancel()
+    }
 
     // The agent's static fallback. If the relay ever resolved to this on a
     // floored step, the floor would have been ignored — which is the bug.
@@ -150,7 +162,7 @@ class ArcRungPropagationTest {
             ),
         )
 
-        val agents = ArcAgentSpawner().spawn(arc, projectContext())
+        val agents = ArcAgentSpawner(SparkAgentFactory(scope = agentScope)).spawn(arc, projectContext())
 
         assertEquals(
             CapabilityRung.THREE,
@@ -171,7 +183,7 @@ class ArcRungPropagationTest {
             minimumRung = CapabilityRung.THREE,
         )
 
-        val agents = ArcAgentSpawner().spawn(arc, projectContext())
+        val agents = ArcAgentSpawner(SparkAgentFactory(scope = agentScope)).spawn(arc, projectContext())
 
         assertEquals(CapabilityRung.THREE, agents[0].agentConfiguration.agentDefinition.minimumRung)
     }
@@ -186,7 +198,7 @@ class ArcRungPropagationTest {
             ),
         )
 
-        val agents = ArcAgentSpawner().spawn(arc, projectContext())
+        val agents = ArcAgentSpawner(SparkAgentFactory(scope = agentScope)).spawn(arc, projectContext())
 
         assertNotNull(
             agents[0].agentConfiguration.cognitiveRelay,
@@ -212,6 +224,7 @@ class ArcRungPropagationTest {
 
         val agent = ArcAgentSpawner(
             agentFactory = SparkAgentFactory(
+                scope = agentScope,
                 defaultAiConfiguration = agentFallback,
                 upstreamLlmClient = client,
             ),
@@ -239,6 +252,7 @@ class ArcRungPropagationTest {
 
         val agent = ArcAgentSpawner(
             agentFactory = SparkAgentFactory(
+                scope = agentScope,
                 defaultAiConfiguration = agentFallback,
                 upstreamLlmClient = client,
             ),
@@ -259,6 +273,7 @@ class ArcRungPropagationTest {
 
         val agent = ArcAgentSpawner(
             agentFactory = SparkAgentFactory(
+                scope = agentScope,
                 defaultAiConfiguration = agentFallback,
                 upstreamLlmClient = client,
             ),

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/domain/arc/ChargePhaseTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/domain/arc/ChargePhaseTest.kt
@@ -5,7 +5,11 @@ import kotlin.io.path.writeText
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.runTest
+import link.socket.ampere.agents.definition.SparkAgentFactory
 import okio.FileSystem
 import okio.Path.Companion.toPath
 
@@ -79,7 +83,12 @@ class ChargePhaseTest {
             ),
         )
 
-        val agents = ArcAgentSpawner().spawn(arcConfig, context)
+        val spawnScope = CoroutineScope(SupervisorJob())
+        val agents = try {
+            ArcAgentSpawner(SparkAgentFactory(scope = spawnScope)).spawn(arcConfig, context)
+        } finally {
+            spawnScope.cancel()
+        }
 
         assertEquals(2, agents.size)
 
@@ -124,7 +133,11 @@ class ChargePhaseTest {
             ),
         )
 
-        val result = ChargePhase(arcConfig, tempDir.toString().toPath()).execute("Implement auth and add tests")
+        val result = ChargePhase(
+            arcConfig = arcConfig,
+            projectDir = tempDir.toString().toPath(),
+            agentScope = backgroundScope,
+        ).execute("Implement auth and add tests")
 
         assertEquals("ChargeProject", result.projectContext.projectId)
         assertTrue(result.projectContext.techStack.isNotEmpty())

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/domain/arc/FlowPhaseTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/domain/arc/FlowPhaseTest.kt
@@ -3,7 +3,15 @@ package link.socket.ampere.domain.arc
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import link.socket.ampere.agents.definition.SparkAgentFactory
+import okio.Path.Companion.toPath
 
 class FlowPhaseTest {
 
@@ -90,6 +98,57 @@ class FlowPhaseTest {
         assertEquals(false, flow.isComplete())
         flow.stop()
         assertTrue(flow.isComplete())
+        assertEquals(TerminationReason.MANUAL_STOP, flow.snapshot().terminationReason)
+    }
+
+    @Test
+    fun `flow phase tick loop bails out when its coroutine is cancelled`() = runTest {
+        val arcConfig = ArcConfig(
+            name = "test-arc",
+            agents = listOf(ArcAgentConfig(role = "code")),
+            orchestration = OrchestrationConfig(type = OrchestrationType.SEQUENTIAL),
+        )
+
+        val goalTree = GoalTree(root = GoalNode(id = "goal-1", description = "Test goal"))
+
+        val agentScope = CoroutineScope(SupervisorJob())
+        val agents = try {
+            ArcAgentSpawner(SparkAgentFactory(scope = agentScope)).spawn(
+                arcConfig,
+                ProjectContext(
+                    projectId = "demo",
+                    description = "Demo",
+                    repositoryRoot = "/tmp".toPath(),
+                    architecture = "Layered",
+                    conventions = "Kotlin",
+                    techStack = listOf("Kotlin"),
+                    sources = emptyList(),
+                ),
+            )
+        } finally {
+            agentScope.cancel()
+        }
+
+        val flow = FlowPhase(
+            arcConfig = arcConfig,
+            agents = agents,
+            goalTree = goalTree,
+            maxTicks = 100,
+        )
+
+        // Cancel from inside the coroutine that runs the loop: the very first `ensureActive()`
+        // must throw rather than grinding through all 100 ticks.
+        val outerJob = Job()
+        val thrown = runCatching {
+            withContext(outerJob) {
+                outerJob.cancel()
+                flow.execute()
+            }
+        }.exceptionOrNull()
+
+        assertTrue(thrown is CancellationException, "Cancellation must propagate, not be swallowed")
+        assertEquals(0, flow.getCurrentTick())
+        assertEquals(TerminationReason.CANCELLED, flow.snapshot().terminationReason)
     }
 
     @Test

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/trace/ArcRunIdentityIntegrationTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/trace/ArcRunIdentityIntegrationTest.kt
@@ -104,6 +104,7 @@ class ArcRunIdentityIntegrationTest {
         val runtime = AmpereRuntime(
             arcConfig = arcConfig,
             projectDir = tempDir.toString().toPath(),
+            agentScope = backgroundScope,
             maxFlowTicks = 1,
             upstreamLlmClient = FakeUpstreamLlmClient,
             eventApiFactory = { agentId -> eventApiFactory.create(agentId) },

--- a/ampere-eval/src/commonMain/kotlin/link/socket/ampere/eval/bench/Bench.kt
+++ b/ampere-eval/src/commonMain/kotlin/link/socket/ampere/eval/bench/Bench.kt
@@ -1,5 +1,8 @@
 package link.socket.ampere.eval.bench
 
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
 import kotlinx.datetime.Clock
 import link.socket.ampere.agents.domain.event.BenchEvent
 import link.socket.ampere.agents.domain.event.EventSource
@@ -9,6 +12,7 @@ import link.socket.ampere.agents.events.utils.generateUUID
 import link.socket.ampere.agents.execution.executor.NoOpExecutor
 import link.socket.ampere.domain.arc.AmpereRuntime
 import link.socket.ampere.domain.arc.ArcConfig
+import link.socket.ampere.domain.arc.ArcOutcome
 import link.socket.ampere.domain.arc.ArcRegistry
 import link.socket.ampere.eval.meter.Reading
 import link.socket.ampere.eval.relay.MissPolicy
@@ -121,22 +125,15 @@ class Bench(
 
         val playbackRelay = PlaybackRelay(trace = goldenTrace, missPolicy = MissPolicy.Error)
 
-        val runResult = runCatching {
-            AmpereRuntime(
-                arcConfig = arcConfig,
-                projectDir = projectDir,
-                cognitiveRelay = playbackRelay,
-                executor = NoOpExecutor(),
-                maxFlowTicks = maxFlowTicks,
-            ).execute(probe.seed.userGoal)
-        }
+        val outcome = runArc(arcConfig, probe, playbackRelay)
 
-        return runResult.fold(
-            onSuccess = { grade(probe, goldenTrace) },
-            onFailure = { error ->
-                failingResult(probe, goldenTrace, "Arc run diverged from goldenTrace: ${error.message}")
-            },
-        )
+        return when (outcome) {
+            is ArcOutcome.Completed -> grade(probe, goldenTrace)
+            is ArcOutcome.Cancelled ->
+                failingResult(probe, goldenTrace, "Arc run was cancelled before it finished.")
+            is ArcOutcome.Failed ->
+                failingResult(probe, goldenTrace, "Arc run diverged from goldenTrace: ${outcome.cause.message}")
+        }
     }
 
     private suspend fun runLive(runId: String, probe: Probe, arcConfig: ArcConfig): ProbeResult {
@@ -155,33 +152,61 @@ class Bench(
 
         val handle = recorder.start(runId = runId, arcId = probe.arcId)
 
-        val runResult = runCatching {
-            AmpereRuntime(
-                arcConfig = arcConfig,
-                projectDir = projectDir,
-                cognitiveRelay = relay,
-                executor = NoOpExecutor(),
-                maxFlowTicks = maxFlowTicks,
-            ).execute(probe.seed.userGoal)
+        // The recording handle must be closed even if the bench coroutine is cancelled, so stop
+        // it in a `finally` rather than only on the happy path.
+        var traceResult: Result<Trace>? = null
+        val outcome = try {
+            runArc(arcConfig, probe, relay)
+        } finally {
+            traceResult = withContext(NonCancellable) { handle.stop() }
         }
-
-        val traceResult = handle.stop()
+        val trace = checkNotNull(traceResult) { "TraceRecorder handle was not stopped." }
 
         return when {
-            runResult.isFailure ->
+            outcome is ArcOutcome.Cancelled ->
                 failingResult(
                     probe,
-                    traceResult.getOrNull() ?: emptyTrace(runId, probe),
-                    "Live run failed: ${runResult.exceptionOrNull()?.message}",
+                    trace.getOrNull() ?: emptyTrace(runId, probe),
+                    "Live run was cancelled before it finished.",
                 )
-            traceResult.isFailure ->
+            outcome is ArcOutcome.Failed ->
+                failingResult(
+                    probe,
+                    trace.getOrNull() ?: emptyTrace(runId, probe),
+                    "Live run failed: ${outcome.cause.message}",
+                )
+            trace.isFailure ->
                 failingResult(
                     probe,
                     emptyTrace(runId, probe),
-                    "Failed to persist recorded trace: ${traceResult.exceptionOrNull()?.message}",
+                    "Failed to persist recorded trace: ${trace.exceptionOrNull()?.message}",
                 )
-            else -> grade(probe, traceResult.getOrThrow())
+            else -> grade(probe, trace.getOrThrow())
         }
+    }
+
+    /**
+     * Runs one probe's Arc to a terminal [ArcOutcome].
+     *
+     * `coroutineScope` makes the run a genuine child of the bench coroutine: agents are bound to
+     * it, and cancelling the bench cancels the Arc instead of leaving detached agents behind.
+     * Cancellation is not caught here — [AmpereRuntime.execute] already returns
+     * [ArcOutcome.Cancelled] for its own cancellation and rethrows the caller's, and swallowing
+     * the latter is exactly what the old `runCatching` did wrong.
+     */
+    private suspend fun runArc(
+        arcConfig: ArcConfig,
+        probe: Probe,
+        relay: CognitiveRelay,
+    ): ArcOutcome = coroutineScope {
+        AmpereRuntime(
+            arcConfig = arcConfig,
+            projectDir = projectDir,
+            agentScope = this,
+            cognitiveRelay = relay,
+            executor = NoOpExecutor(),
+            maxFlowTicks = maxFlowTicks,
+        ).execute(probe.seed.userGoal)
     }
 
     private suspend fun grade(probe: Probe, trace: Trace): ProbeResult {


### PR DESCRIPTION
Closes #617 ([AMPR-241](https://linear.app/miley/issue/AMPR-241/cooperative-arc-cancellation-cancelled-as-a-first-class-terminal-state))

Nothing in the Arc execution path was cancellable: `AmpereRuntime.stop()` flipped a flag `execute()` read once and never re-checked, the `FlowPhase` instance was constructed as a local and dropped so its `stop()` had no caller, the tick loop had no cancellation point, and `ChargePhase` spawned agents without a scope so `SparkAgentFactory` fell back to a detached `CoroutineScope(Dispatchers.Default)` with no parent Job and no cancellation path. This PR introduces a sealed `ArcOutcome` (`Completed`/`Failed`/`Cancelled`) replacing `ArcExecutionResult`, adds `TerminationReason.CANCELLED` and wires up the never-assigned `ERROR`, and makes `AmpereRuntime` hold the `FlowPhase` and run each Arc in a per-run child of a **required** caller-owned scope that is cancelled and joined before `execute()` returns — with `stop()` (graceful → `MANUAL_STOP`) now distinct from `cancel()` (hard → `CANCELLED`), and `ensureActive()` in the tick loop. That scope is threaded through `ChargePhase` into `SparkAgentFactory` and the factory's default `scope` argument is removed so the hole cannot silently re-open, the four `catch (Exception)`/`runCatching` sites in `AmpereCommand`, `Bench`, and `AutonomousWorkLoop` no longer swallow `CancellationException`, cross-thread runtime state is `@Volatile`, and the CLI's double-Charge (two project scans and two full agent sets per user goal) is gone.

Tests cancel mid-Flow and assert a `Cancelled` outcome, `CANCELLED` termination reason, and zero live coroutines left in the caller-owned scope; both new cancellation tests were verified to fail when `ensureActive()` is removed.

The second commit rebases onto current `main` and updates `ArcRungPropagationTest`, which AMPR-232 (#621) landed after this branch was cut — it constructs `ArcAgentSpawner`/`SparkAgentFactory` at six sites without the now-required `agentFactory` and `scope` arguments, which is what broke the first CI run. That is precisely the "expect callers to need updating" breakage the ticket predicted from removing the default argument.

Note: the four remaining default-scope sites in `SparkBasedAgent.kt` (the `Code`/`Product`/… companion factories) are off the Arc path and were left alone; closing those is a reasonable follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)