### PR TITLE
AMPR-235 #600: Declarative YAML rung config surface (T6)

### DIFF
--- a/ampere-core/src/jvmMain/kotlin/link/socket/ampere/agents/domain/routing/capability/YamlModelDescriptorSource.kt
+++ b/ampere-core/src/jvmMain/kotlin/link/socket/ampere/agents/domain/routing/capability/YamlModelDescriptorSource.kt
@@ -1,0 +1,95 @@
+package link.socket.ampere.agents.domain.routing.capability
+
+import com.charleskorn.kaml.Yaml
+import com.charleskorn.kaml.YamlConfiguration
+import java.io.File
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * A [ModelDescriptorSource] backed by a YAML file of model→rung (and optional
+ * cost/capability) overrides — the one concrete source that makes runtime
+ * catalog refresh usable without writing Kotlin (AMPR-235).
+ *
+ * Overrides *layer over* [base] rather than replacing it, mirroring the
+ * `.ampere/… → registry → default` precedence [link.socket.ampere.domain.arc.ArcConfigLoader]
+ * uses for Arcs: a model named in [file] gets its listed fields replaced; every
+ * other field on that descriptor, and every model [file] doesn't mention, keeps
+ * exactly what [base] returned. This lets a consumer re-rung one model without
+ * restating the catalog.
+ *
+ * Per the [ModelDescriptorSource] contract, a malformed file surfaces as
+ * [Result.failure] and never touches the registry's live catalog; an absent or
+ * empty file reproduces [base] exactly, which is current behavior unchanged.
+ *
+ * @param file The overrides YAML file, e.g. `.ampere/model-rungs.yaml`.
+ * @param base The catalog overrides are layered onto. Defaults to the bundled
+ *   cloud + on-device catalog.
+ */
+class YamlModelDescriptorSource(
+    private val file: File,
+    private val base: () -> List<ModelDescriptor> = InMemoryModelDescriptorRegistry::defaultModelDescriptors,
+) : ModelDescriptorSource {
+
+    override suspend fun load(): Result<List<ModelDescriptor>> = runCatching {
+        val baseCatalog = base()
+
+        if (!file.exists()) return@runCatching baseCatalog
+
+        val content = file.readText()
+        if (content.isBlank()) return@runCatching baseCatalog
+
+        val overrides = yaml.decodeFromString(YamlModelOverridesFile.serializer(), content).modelOverrides
+        if (overrides.isEmpty()) return@runCatching baseCatalog
+
+        val baseModelNames = baseCatalog.mapTo(mutableSetOf()) { it.modelName }
+        val unknown = overrides.keys - baseModelNames
+        require(unknown.isEmpty()) {
+            "model-overrides names model(s) not in the base catalog: $unknown"
+        }
+
+        baseCatalog.map { descriptor ->
+            overrides[descriptor.modelName]?.applyTo(descriptor) ?: descriptor
+        }
+    }
+
+    companion object {
+        private val yaml = Yaml(configuration = YamlConfiguration(strictMode = false))
+    }
+}
+
+@Serializable
+internal data class YamlModelOverridesFile(
+    @SerialName("model-overrides")
+    val modelOverrides: Map<String, YamlModelOverride> = emptyMap(),
+)
+
+/**
+ * One model's overrides. Every field is optional: a config author re-rungs a
+ * model by naming only `rung`, and every other field on that model's base
+ * [ModelDescriptor] survives untouched.
+ */
+@Serializable
+internal data class YamlModelOverride(
+    val rung: String? = null,
+    @SerialName("cost-per-watt")
+    val costPerWatt: Double? = null,
+    val capabilities: List<ProviderCapability>? = null,
+) {
+    fun applyTo(descriptor: ModelDescriptor): ModelDescriptor = descriptor.copy(
+        rung = rung?.let(::parseRung) ?: descriptor.rung,
+        costPerWatt = costPerWatt ?: descriptor.costPerWatt,
+        capabilities = capabilities?.toSet() ?: descriptor.capabilities,
+    )
+
+    private fun parseRung(name: String): CapabilityRung = when (name.trim().uppercase()) {
+        "ZERO" -> CapabilityRung.ZERO
+        "ONE" -> CapabilityRung.ONE
+        "TWO" -> CapabilityRung.TWO
+        "THREE" -> CapabilityRung.THREE
+        "FOUR" -> CapabilityRung.FOUR
+        else -> throw IllegalArgumentException(
+            "Unknown rung '$name'. Supported: ZERO, ONE, TWO, THREE, FOUR",
+        )
+    }
+}

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/domain/routing/capability/YamlModelDescriptorSourceTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/agents/domain/routing/capability/YamlModelDescriptorSourceTest.kt
@@ -1,0 +1,215 @@
+package link.socket.ampere.agents.domain.routing.capability
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import link.socket.ampere.domain.ai.model.AIModelFeatures.RelativeReasoning
+import link.socket.ampere.domain.ai.model.AIModelFeatures.SupportedInputs
+import link.socket.ampere.domain.ai.provider.AIProvider_Anthropic
+
+/**
+ * The YAML-backed [ModelDescriptorSource] (AMPR-235): overrides layer over a
+ * base catalog rather than replacing it, following the same "user file
+ * overrides base" precedence as `ArcConfigLoader`.
+ */
+class YamlModelDescriptorSourceTest {
+
+    private fun descriptor(
+        name: String,
+        rung: CapabilityRung? = CapabilityRung.ONE,
+    ): ModelDescriptor = ModelDescriptor(
+        modelName = name,
+        providerId = AIProvider_Anthropic.id,
+        capabilities = emptySet(),
+        reasoning = RelativeReasoning.NORMAL,
+        maxContextTokens = 200_000,
+        supportedInputs = SupportedInputs.TEXT,
+        rung = rung,
+    )
+
+    private fun tempFile(content: String? = null): File {
+        val file = File.createTempFile("model-rungs", ".yaml")
+        file.deleteOnExit()
+        if (content == null) {
+            file.delete()
+        } else {
+            file.writeText(content)
+        }
+        return file
+    }
+
+    // ── Absent/empty file reproduces base exactly ─────────────────────────────
+
+    @Test
+    fun `an absent file reproduces the base catalog unchanged`() = runTest {
+        val base = listOf(descriptor("model-a", CapabilityRung.TWO))
+        val source = YamlModelDescriptorSource(file = tempFile(content = null), base = { base })
+
+        val result = source.load()
+
+        assertTrue(result.isSuccess)
+        assertEquals(base, result.getOrThrow())
+    }
+
+    @Test
+    fun `an empty file reproduces the base catalog unchanged`() = runTest {
+        val base = listOf(descriptor("model-a", CapabilityRung.TWO))
+        val source = YamlModelDescriptorSource(file = tempFile(""), base = { base })
+
+        val result = source.load()
+
+        assertTrue(result.isSuccess)
+        assertEquals(base, result.getOrThrow())
+    }
+
+    @Test
+    fun `a file with no model-overrides entries reproduces the base catalog unchanged`() = runTest {
+        val base = listOf(descriptor("model-a", CapabilityRung.TWO))
+        val source = YamlModelDescriptorSource(file = tempFile("model-overrides: {}"), base = { base })
+
+        val result = source.load()
+
+        assertTrue(result.isSuccess)
+        assertEquals(base, result.getOrThrow())
+    }
+
+    // ── Overrides layer over base ──────────────────────────────────────────────
+
+    @Test
+    fun `a rung override re-rungs one model without touching the rest`() = runTest {
+        val base = listOf(
+            descriptor("model-a", CapabilityRung.ONE),
+            descriptor("model-b", CapabilityRung.TWO),
+        )
+        val yaml = """
+            model-overrides:
+              model-a:
+                rung: FOUR
+        """.trimIndent()
+        val source = YamlModelDescriptorSource(file = tempFile(yaml), base = { base })
+
+        val catalog = source.load().getOrThrow()
+
+        assertEquals(CapabilityRung.FOUR, catalog.first { it.modelName == "model-a" }.rung)
+        assertEquals(CapabilityRung.TWO, catalog.first { it.modelName == "model-b" }.rung)
+    }
+
+    @Test
+    fun `cost-per-watt and capabilities overrides apply alongside rung`() = runTest {
+        val base = listOf(descriptor("model-a", CapabilityRung.ONE))
+        val yaml = """
+            model-overrides:
+              model-a:
+                rung: TWO
+                cost-per-watt: 0.05
+                capabilities: [TOOL_CALLING]
+        """.trimIndent()
+        val source = YamlModelDescriptorSource(file = tempFile(yaml), base = { base })
+
+        val overridden = source.load().getOrThrow().single()
+
+        assertEquals(CapabilityRung.TWO, overridden.rung)
+        assertEquals(0.05, overridden.costPerWatt)
+        assertEquals(setOf(ProviderCapability.TOOL_CALLING), overridden.capabilities)
+    }
+
+    @Test
+    fun `an override omitting a field leaves that field at its base value`() = runTest {
+        val base = listOf(
+            ModelDescriptor(
+                modelName = "model-a",
+                providerId = AIProvider_Anthropic.id,
+                capabilities = setOf(ProviderCapability.WORLD_KNOWLEDGE),
+                reasoning = RelativeReasoning.NORMAL,
+                maxContextTokens = 200_000,
+                supportedInputs = SupportedInputs.TEXT,
+                costPerWatt = 0.02,
+                rung = CapabilityRung.ONE,
+            ),
+        )
+        val yaml = """
+            model-overrides:
+              model-a:
+                rung: THREE
+        """.trimIndent()
+        val source = YamlModelDescriptorSource(file = tempFile(yaml), base = { base })
+
+        val overridden = source.load().getOrThrow().single()
+
+        assertEquals(CapabilityRung.THREE, overridden.rung)
+        assertEquals(0.02, overridden.costPerWatt)
+        assertEquals(setOf(ProviderCapability.WORLD_KNOWLEDGE), overridden.capabilities)
+    }
+
+    // ── Malformed input fails without touching the registry (via Result) ──────
+
+    @Test
+    fun `an unknown rung name surfaces a failure`() = runTest {
+        val base = listOf(descriptor("model-a"))
+        val yaml = """
+            model-overrides:
+              model-a:
+                rung: NINE
+        """.trimIndent()
+        val source = YamlModelDescriptorSource(file = tempFile(yaml), base = { base })
+
+        val result = source.load()
+
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun `an override naming a model outside the base catalog surfaces a failure`() = runTest {
+        val base = listOf(descriptor("model-a"))
+        val yaml = """
+            model-overrides:
+              nonexistent-model:
+                rung: TWO
+        """.trimIndent()
+        val source = YamlModelDescriptorSource(file = tempFile(yaml), base = { base })
+
+        val result = source.load()
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull()?.message?.contains("nonexistent-model") == true)
+    }
+
+    @Test
+    fun `malformed yaml surfaces a failure rather than throwing`() = runTest {
+        val base = listOf(descriptor("model-a"))
+        val source = YamlModelDescriptorSource(
+            file = tempFile("model-overrides: [this, is, not, a, map]"),
+            base = { base },
+        )
+
+        val result = source.load()
+
+        assertTrue(result.isFailure)
+    }
+
+    // ── Integration with the registry ──────────────────────────────────────────
+
+    @Test
+    fun `refresh through a registry picks up a re-rung with no recompile`() = runTest {
+        val base = listOf(descriptor("model-a", CapabilityRung.ONE))
+        val file = tempFile(
+            """
+            model-overrides:
+              model-a:
+                rung: FOUR
+            """.trimIndent(),
+        )
+        val registry = InMemoryModelDescriptorRegistry(
+            seed = base,
+            source = YamlModelDescriptorSource(file = file, base = { base }),
+        )
+
+        assertEquals(CapabilityRung.ONE, registry.descriptorFor("model-a")?.rung)
+
+        assertTrue(registry.refresh().isSuccess)
+
+        assertEquals(CapabilityRung.FOUR, registry.descriptorFor("model-a")?.rung)
+    }
+}

--- a/ampere.example.yaml
+++ b/ampere.example.yaml
@@ -130,3 +130,24 @@ team:
 # Set a default goal for the team. Can also be passed via CLI:
 #   ampere --goal "Build a user authentication system"
 goal: "Build a user authentication system"
+
+# Model Rung Overrides (optional)
+# --------------------------------
+# Re-rate a model's capability tier (or cost/capabilities) without waiting on a
+# framework release or recompiling. Loaded via YamlModelDescriptorSource and
+# layered *over* the bundled catalog (defaultModelDescriptors()) — a model
+# named here has only its listed fields replaced; every other field on that
+# model, and every model not named here, keeps its shipped value. Routing
+# picks up the change the next time the registry's refresh() is called
+# (caller-driven; there is no file-watching or hot reload).
+#
+# model-overrides:
+#   claude-haiku-4-5:
+#     rung: TWO                # ZERO, ONE, TWO, THREE, or FOUR
+#   gemini-2.5-flash:
+#     rung: THREE
+#     cost-per-watt: 0.009      # optional: USD per normalized Watt (1 Watt = 1000 tokens)
+#     capabilities: [TOOL_CALLING, LONG_CONTEXT]   # optional: replaces the model's capability set
+#
+# A model name not present in the bundled catalog fails the load (Result.failure)
+# rather than being silently ignored — the prior catalog is left untouched.


### PR DESCRIPTION
## Summary
- Adds `YamlModelDescriptorSource`, a `ModelDescriptorSource` backed by a YAML `model-overrides` file that layers rung/cost/capability overrides over the bundled catalog (`defaultModelDescriptors()`) rather than replacing it, following the same override-over-base precedence `ArcConfigLoader` uses.
- A malformed file or an override naming a model outside the base catalog surfaces as `Result.failure`, leaving the prior catalog intact; an absent or empty file reproduces the base catalog unchanged.
- Documents the `model-overrides` schema in `ampere.example.yaml`.
- Adds `YamlModelDescriptorSourceTest` covering absent/empty files, partial overrides, malformed YAML, unknown model names, and end-to-end `refresh()` through `InMemoryModelDescriptorRegistry`.

Closes #600

## Test plan
- [ ] `./gradlew :ampere-core:jvmTest --tests "*.YamlModelDescriptorSourceTest"` (not run locally — pending CI)
- [ ] `./gradlew :ampere-core:compileCommonMainKotlinMetadata` (not run locally — pending CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)