### PR TITLE
AMPR-242 #618: Settle cost records on cancelled LLM calls

### DIFF
--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/reasoning/AgentLLMService.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/reasoning/AgentLLMService.kt
@@ -1,9 +1,12 @@
 package link.socket.ampere.agents.domain.reasoning
 
 import co.touchlab.kermit.Logger
+import com.aallam.openai.api.chat.ChatCompletion
 import com.aallam.openai.api.chat.ChatCompletionRequest
 import com.aallam.openai.api.chat.ChatMessage
 import com.aallam.openai.api.chat.ChatRole
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.withContext
 import kotlinx.datetime.Clock
 import kotlinx.serialization.json.JsonArray
@@ -163,6 +166,20 @@ class AgentLLMService(
                     startedAt = startedAt,
                 )
                 response
+            } catch (cancellation: CancellationException) {
+                // A custom provider is a prompt-in/text-out test seam that reports no
+                // usage even on success, so there is no input floor to book here — only
+                // the mechanical fix applies: settle the row, then propagate unchanged.
+                emitCompletedTelemetry(
+                    routingContext = routingContext,
+                    providerId = providerId,
+                    modelId = modelId,
+                    usage = TokenUsage(),
+                    success = false,
+                    startedAt = startedAt,
+                    errorType = CANCELLED_ERROR_TYPE,
+                )
+                throw cancellation
             } catch (t: Throwable) {
                 emitCompletedTelemetry(
                     routingContext = routingContext,
@@ -259,10 +276,35 @@ class AgentLLMService(
         )
 
         val startedAt = Clock.System.now()
+        // Held outside the `try` so the cancellation handler can tell "cancelled before
+        // the provider answered" from "cancelled after it answered but before we settled"
+        // — the latter has real actuals and must not be downgraded to an estimate.
+        var upstreamCompletion: ChatCompletion? = null
         val completion = try {
             withContext(ioDispatcher) {
-                client.call(request, effectiveConfig)
+                client.call(request, effectiveConfig).also { upstreamCompletion = it }
             }
+        } catch (cancellation: CancellationException) {
+            // AMPR-242: cancellation must still settle a cost record. `NonCancellable` is
+            // what makes the write survive — without it every suspension point below
+            // throws immediately on the cancelled Job and no row is ever inserted.
+            withContext(NonCancellable) {
+                emitCompletedTelemetry(
+                    routingContext = routingContext,
+                    providerId = effectiveConfig.provider.id,
+                    modelId = model.name,
+                    usage = cancelledUsage(
+                        providerId = effectiveConfig.provider.id,
+                        modelId = model.name,
+                        messages = messages,
+                        completion = upstreamCompletion,
+                    ),
+                    success = false,
+                    startedAt = startedAt,
+                    errorType = CANCELLED_ERROR_TYPE,
+                )
+            }
+            throw cancellation
         } catch (t: Throwable) {
             emitCompletedTelemetry(
                 routingContext = routingContext,
@@ -381,6 +423,17 @@ class AgentLLMService(
         const val DEFAULT_TEMPERATURE = 0.3
         const val DEFAULT_MAX_TOKENS = 4000
 
+        /**
+         * `errorType` stamped on the [ProviderCallCompletedEvent] of a cancelled call.
+         *
+         * Fixed rather than derived from `Throwable::simpleName` because cancellation
+         * arrives as several concrete types (`JobCancellationException`,
+         * `TimeoutCancellationException`, a bare `CancellationException`) that all mean
+         * the same thing to a cost consumer. Marks rows whose usage is an estimated
+         * input floor rather than provider-reported actuals (AMPR-242).
+         */
+        const val CANCELLED_ERROR_TYPE = "Cancelled"
+
         const val DEFAULT_SYSTEM_MESSAGE =
             "You are an autonomous agent component. Respond clearly and concisely."
 
@@ -410,6 +463,15 @@ class AgentLLMService(
         }
     }
 
+    /**
+     * Emits the start row for a provider call.
+     *
+     * Runs under [NonCancellable] (AMPR-242). Every hop below this — [AgentEventApi.publish]
+     * → `EventRepository.saveEvent` → `withContext(ioDispatcher)` — is a suspension point,
+     * and `withContext` on an already-cancelled Job throws *without running its block*. A
+     * cancellation arriving here would otherwise drop the start row that
+     * `ArcTraceProjection.buildModelInvocations` correlates completions against.
+     */
     private suspend fun emitStartedTelemetry(
         routingContext: RoutingContext?,
         providerId: String,
@@ -417,21 +479,31 @@ class AgentLLMService(
         routingReason: String,
     ) {
         val publishingAgentId = eventApi?.agentId ?: return
-        eventApi.publish(
-            ProviderCallStartedEvent(
-                eventId = generateUUID("llm-start", publishingAgentId),
-                timestamp = Clock.System.now(),
-                eventSource = EventSource.Agent(publishingAgentId),
-                workflowId = routingContext?.workflowId,
-                agentId = routingContext?.agentId ?: publishingAgentId,
-                cognitivePhase = routingContext?.phase,
-                providerId = providerId,
-                modelId = modelId,
-                routingReason = routingReason,
-            ),
-        )
+        withContext(NonCancellable) {
+            eventApi.publish(
+                ProviderCallStartedEvent(
+                    eventId = generateUUID("llm-start", publishingAgentId),
+                    timestamp = Clock.System.now(),
+                    eventSource = EventSource.Agent(publishingAgentId),
+                    workflowId = routingContext?.workflowId,
+                    agentId = routingContext?.agentId ?: publishingAgentId,
+                    cognitivePhase = routingContext?.phase,
+                    providerId = providerId,
+                    modelId = modelId,
+                    routingReason = routingReason,
+                ),
+            )
+        }
     }
 
+    /**
+     * Emits the completion row for a provider call.
+     *
+     * Runs under [NonCancellable] for the same reason as [emitStartedTelemetry]: on the
+     * success path the provider has already returned real tokens, so a cancellation
+     * landing between the call returning and this write would lose a call that was
+     * genuinely spent.
+     */
     private suspend fun emitCompletedTelemetry(
         routingContext: RoutingContext?,
         providerId: String,
@@ -443,21 +515,55 @@ class AgentLLMService(
     ) {
         val publishingAgentId = eventApi?.agentId ?: return
         val completedAt = Clock.System.now()
-        eventApi.publish(
-            ProviderCallCompletedEvent(
-                eventId = generateUUID("llm-complete", publishingAgentId),
-                timestamp = completedAt,
-                eventSource = EventSource.Agent(publishingAgentId),
-                workflowId = routingContext?.workflowId,
-                agentId = routingContext?.agentId ?: publishingAgentId,
-                cognitivePhase = routingContext?.phase,
-                providerId = providerId,
-                modelId = modelId,
-                usage = usage,
-                latencyMs = (completedAt - startedAt).inWholeMilliseconds,
-                success = success,
-                errorType = errorType,
-            ),
+        withContext(NonCancellable) {
+            eventApi.publish(
+                ProviderCallCompletedEvent(
+                    eventId = generateUUID("llm-complete", publishingAgentId),
+                    timestamp = completedAt,
+                    eventSource = EventSource.Agent(publishingAgentId),
+                    workflowId = routingContext?.workflowId,
+                    agentId = routingContext?.agentId ?: publishingAgentId,
+                    cognitivePhase = routingContext?.phase,
+                    providerId = providerId,
+                    modelId = modelId,
+                    usage = usage,
+                    latencyMs = (completedAt - startedAt).inWholeMilliseconds,
+                    success = success,
+                    errorType = errorType,
+                ),
+            )
+        }
+    }
+
+    /**
+     * Settles a cancelled call to the best actuals available (AMPR-242).
+     *
+     * If [completion] is non-null the provider did answer — cancellation merely landed
+     * before the success-path write — so its reported counts are used verbatim. Otherwise
+     * the call is booked at its honest floor: the input tokens the prompt demonstrably put
+     * on the wire, with zero output.
+     *
+     * Output is `0` rather than `null` deliberately — [ProviderPricingCalculator] returns
+     * `null` for a null count, which would silently drop the cost back to nothing.
+     */
+    private suspend fun cancelledUsage(
+        providerId: String,
+        modelId: String,
+        messages: List<ChatMessage>,
+        completion: ChatCompletion?,
+    ): TokenUsage {
+        val usage = completion?.usage?.let(TokenUsageExtractor::fromOpenAiUsage)
+            ?: TokenUsage(
+                inputTokens = PromptTokenEstimator.estimateInputTokens(
+                    messages.map { it.content.orEmpty() },
+                ),
+                outputTokens = 0,
+            )
+
+        return enrichUsageWithEstimatedCost(
+            providerId = providerId,
+            modelId = modelId,
+            usage = usage,
         )
     }
 

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/reasoning/PromptTokenEstimator.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/reasoning/PromptTokenEstimator.kt
@@ -1,0 +1,41 @@
+package link.socket.ampere.agents.domain.reasoning
+
+/**
+ * Deterministic, provider-agnostic floor estimate of the prompt tokens a request sent.
+ *
+ * Used only on the cancellation path (AMPR-242). When an in-flight provider call is
+ * cancelled, no provider-reported usage ever arrives, but the prompt was demonstrably
+ * put on the wire — booking zero would make cancelling free, which is both exploitable
+ * and false in the trace. Ampere therefore books the *input* side of the call and zero
+ * output: an honest floor computable without a provider round-trip.
+ *
+ * This is an approximation, not a tokenizer. Ampere has no per-provider BPE vocabulary
+ * in common code, so the estimate uses the widely-used ~4-characters-per-token ratio
+ * plus a fixed per-message framing overhead. Events settled this way are distinguishable
+ * by their `errorType` of [AgentLLMService.CANCELLED_ERROR_TYPE], so consumers that need
+ * exactness can exclude them.
+ *
+ * Replacing this with streamed provider actuals requires an `UpstreamLlmClient`
+ * partial-usage surface and is tracked separately as a metering-policy decision.
+ */
+internal object PromptTokenEstimator {
+
+    /** Average characters per token across common BPE vocabularies. */
+    private const val CHARS_PER_TOKEN = 4
+
+    /** Per-message role/delimiter framing the provider adds around each message. */
+    private const val PER_MESSAGE_OVERHEAD_TOKENS = 4
+
+    /**
+     * Estimates the input tokens for [messageContents], one entry per chat message.
+     *
+     * Blank and empty entries still cost their framing overhead, matching how providers
+     * bill an empty message. Returns `0` only for an empty list.
+     */
+    fun estimateInputTokens(messageContents: List<String>): Int =
+        messageContents.sumOf { content ->
+            ceilDiv(content.length, CHARS_PER_TOKEN) + PER_MESSAGE_OVERHEAD_TOKENS
+        }
+
+    private fun ceilDiv(value: Int, divisor: Int): Int = (value + divisor - 1) / divisor
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/reasoning/PromptTokenEstimatorTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/domain/reasoning/PromptTokenEstimatorTest.kt
@@ -1,0 +1,53 @@
+package link.socket.ampere.agents.domain.reasoning
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PromptTokenEstimatorTest {
+
+    @Test
+    fun `empty message list estimates zero tokens`() {
+        assertEquals(0, PromptTokenEstimator.estimateInputTokens(emptyList()))
+    }
+
+    @Test
+    fun `an empty message still costs its framing overhead`() {
+        assertEquals(4, PromptTokenEstimator.estimateInputTokens(listOf("")))
+    }
+
+    @Test
+    fun `content is charged at four characters per token and rounded up`() {
+        // 8 chars -> 2 content tokens + 4 framing
+        assertEquals(6, PromptTokenEstimator.estimateInputTokens(listOf("12345678")))
+        // 9 chars -> ceil(9/4) = 3 content tokens + 4 framing
+        assertEquals(7, PromptTokenEstimator.estimateInputTokens(listOf("123456789")))
+    }
+
+    @Test
+    fun `each message is charged separately`() {
+        val single = PromptTokenEstimator.estimateInputTokens(listOf("abcdabcd"))
+        val split = PromptTokenEstimator.estimateInputTokens(listOf("abcd", "abcd"))
+
+        assertEquals(6, single)
+        assertEquals(10, split)
+    }
+
+    @Test
+    fun `estimate is monotonic in prompt length`() {
+        val short = PromptTokenEstimator.estimateInputTokens(listOf("a".repeat(100)))
+        val long = PromptTokenEstimator.estimateInputTokens(listOf("a".repeat(1_000)))
+
+        assertTrue(long > short)
+    }
+
+    @Test
+    fun `estimate is deterministic for the same input`() {
+        val messages = listOf("You are a helpful agent.", "Summarize the following text.")
+
+        assertEquals(
+            PromptTokenEstimator.estimateInputTokens(messages),
+            PromptTokenEstimator.estimateInputTokens(messages),
+        )
+    }
+}

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/llm/AgentLlmCancellationTelemetryTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/llm/AgentLlmCancellationTelemetryTest.kt
@@ -1,0 +1,260 @@
+package link.socket.ampere.llm
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import com.aallam.openai.api.chat.ChatChoice
+import com.aallam.openai.api.chat.ChatCompletion
+import com.aallam.openai.api.chat.ChatCompletionRequest
+import com.aallam.openai.api.chat.ChatMessage
+import com.aallam.openai.api.chat.ChatRole
+import com.aallam.openai.api.core.Usage
+import com.aallam.openai.api.model.ModelId
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import link.socket.ampere.agents.config.AgentConfiguration
+import link.socket.ampere.agents.config.CognitiveConfig
+import link.socket.ampere.agents.domain.cognition.sparks.CognitivePhase
+import link.socket.ampere.agents.domain.event.Event
+import link.socket.ampere.agents.domain.event.ProviderCallCompletedEvent
+import link.socket.ampere.agents.domain.event.ProviderCallStartedEvent
+import link.socket.ampere.agents.domain.reasoning.AgentLLMService
+import link.socket.ampere.agents.domain.routing.RoutingContext
+import link.socket.ampere.agents.events.EventRepository
+import link.socket.ampere.agents.events.api.AgentEventApi
+import link.socket.ampere.agents.events.bus.EventSerialBus
+import link.socket.ampere.data.DEFAULT_JSON
+import link.socket.ampere.db.Database
+import link.socket.ampere.domain.agent.bundled.WriteCodeAgent
+import link.socket.ampere.domain.ai.configuration.AIConfiguration
+import link.socket.ampere.domain.ai.configuration.AIConfiguration_Default
+import link.socket.ampere.domain.ai.model.AIModel_OpenAI
+import link.socket.ampere.domain.ai.provider.AIProvider_OpenAI
+import link.socket.ampere.domain.llm.LlmProvider
+
+/**
+ * AMPR-242: cancelling an in-flight LLM call must still settle a cost record.
+ *
+ * These assert against the persisted event store rather than the event bus, because the
+ * defect being guarded is precisely that no row was ever *written* — a bus-only assertion
+ * could pass on an emission that never reached SQLDelight.
+ */
+class AgentLlmCancellationTelemetryTest {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    private lateinit var driver: JdbcSqliteDriver
+    private lateinit var eventRepository: EventRepository
+    private lateinit var eventApi: AgentEventApi
+
+    @BeforeTest
+    fun setUp() {
+        driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        Database.Schema.create(driver)
+        val database = Database(driver)
+
+        eventRepository = EventRepository(DEFAULT_JSON, scope, database)
+        eventApi = AgentEventApi(
+            agentId = "cancellation-agent",
+            eventRepository = eventRepository,
+            eventSerialBus = EventSerialBus(scope),
+        )
+    }
+
+    @AfterTest
+    fun tearDown() {
+        driver.close()
+    }
+
+    @Test
+    fun `cancelling an in-flight upstream call still persists start and completion rows`() = runBlocking {
+        val client = HangingUpstreamLlmClient()
+        val llmService = AgentLLMService(
+            agentConfiguration = upstreamConfig(),
+            eventApi = eventApi,
+            upstreamLlmClient = client,
+        )
+
+        val job = scope.launch { llmService.call(prompt = PROMPT, systemMessage = SYSTEM_MESSAGE) }
+        client.entered.await()
+        job.cancelAndJoin()
+
+        val events = persistedEvents()
+        assertEquals(1, events.filterIsInstance<ProviderCallStartedEvent>().size)
+
+        val completed = events.filterIsInstance<ProviderCallCompletedEvent>().single()
+        assertFalse(completed.success)
+        assertEquals(AgentLLMService.CANCELLED_ERROR_TYPE, completed.errorType)
+    }
+
+    @Test
+    fun `a cancelled call books the input tokens it sent rather than zero`() = runBlocking {
+        val client = HangingUpstreamLlmClient()
+        val llmService = AgentLLMService(
+            agentConfiguration = upstreamConfig(),
+            eventApi = eventApi,
+            upstreamLlmClient = client,
+        )
+
+        val job = scope.launch { llmService.call(prompt = PROMPT, systemMessage = SYSTEM_MESSAGE) }
+        client.entered.await()
+        job.cancelAndJoin()
+
+        val completed = persistedEvents().filterIsInstance<ProviderCallCompletedEvent>().single()
+        val inputTokens = assertNotNull(completed.usage.inputTokens)
+
+        assertTrue(inputTokens > 0, "cancelled call booked $inputTokens input tokens")
+        assertEquals(0, completed.usage.outputTokens)
+        // Zero output is what makes the cost computable at all: the pricing calculator
+        // returns null the moment either count is null, which would re-zero the record.
+        assertTrue(assertNotNull(completed.usage.estimatedCost) > 0.0)
+    }
+
+    @Test
+    fun `cancellation after the provider answered books the reported actuals`() = runBlocking {
+        val callerJob = Job()
+        val client = SelfCancellingUpstreamLlmClient { callerJob }
+        val llmService = AgentLLMService(
+            agentConfiguration = upstreamConfig(),
+            eventApi = eventApi,
+            upstreamLlmClient = client,
+        )
+
+        val job = scope.launch(callerJob) { llmService.call(prompt = PROMPT, systemMessage = SYSTEM_MESSAGE) }
+        job.join()
+
+        val completed = persistedEvents().filterIsInstance<ProviderCallCompletedEvent>().single()
+        assertEquals(AgentLLMService.CANCELLED_ERROR_TYPE, completed.errorType)
+        assertEquals(REPORTED_PROMPT_TOKENS, completed.usage.inputTokens)
+        assertEquals(REPORTED_COMPLETION_TOKENS, completed.usage.outputTokens)
+    }
+
+    @Test
+    fun `cancelling a custom provider call persists a cancelled completion row`() = runBlocking {
+        val entered = CompletableDeferred<Unit>()
+        val provider: LlmProvider = {
+            entered.complete(Unit)
+            awaitCancellation()
+        }
+        val llmService = AgentLLMService(
+            agentConfiguration = upstreamConfig(customProvider = provider),
+            eventApi = eventApi,
+        )
+
+        val job = scope.launch {
+            llmService.call(
+                prompt = PROMPT,
+                systemMessage = SYSTEM_MESSAGE,
+                routingContext = RoutingContext(
+                    phase = CognitivePhase.EXECUTE,
+                    agentId = eventApi.agentId,
+                    agentRole = "Cancellation Test Agent",
+                    workflowId = "wf-cancel",
+                ),
+            )
+        }
+        entered.await()
+        job.cancelAndJoin()
+
+        val completed = persistedEvents().filterIsInstance<ProviderCallCompletedEvent>().single()
+        assertFalse(completed.success)
+        assertEquals(AgentLLMService.CANCELLED_ERROR_TYPE, completed.errorType)
+        assertEquals("wf-cancel", completed.workflowId)
+    }
+
+    @Test
+    fun `a completed call is unaffected by the cancellation handling`() = runBlocking {
+        val llmService = AgentLLMService(
+            agentConfiguration = upstreamConfig(),
+            eventApi = eventApi,
+            upstreamLlmClient = SelfCancellingUpstreamLlmClient(cancelTarget = null),
+        )
+
+        val response = llmService.call(prompt = PROMPT, systemMessage = SYSTEM_MESSAGE)
+
+        val completed = persistedEvents().filterIsInstance<ProviderCallCompletedEvent>().single()
+        assertEquals(RESPONSE, response)
+        assertTrue(completed.success)
+        assertEquals(null, completed.errorType)
+        assertEquals(REPORTED_PROMPT_TOKENS, completed.usage.inputTokens)
+        assertEquals(REPORTED_COMPLETION_TOKENS, completed.usage.outputTokens)
+    }
+
+    private suspend fun persistedEvents(): List<Event> =
+        eventRepository.getAllEvents().getOrThrow()
+
+    private fun upstreamConfig(customProvider: LlmProvider? = null): AgentConfiguration =
+        AgentConfiguration(
+            agentDefinition = WriteCodeAgent,
+            aiConfiguration = AIConfiguration_Default(
+                provider = AIProvider_OpenAI,
+                model = AIModel_OpenAI.GPT_4_1,
+            ),
+            cognitiveConfig = CognitiveConfig(),
+            llmProvider = customProvider,
+        )
+
+    /** Never answers, so cancellation always lands before any provider-reported usage exists. */
+    private class HangingUpstreamLlmClient : UpstreamLlmClient {
+        val entered = CompletableDeferred<Unit>()
+
+        override suspend fun call(
+            request: ChatCompletionRequest,
+            configuration: AIConfiguration,
+        ): ChatCompletion {
+            entered.complete(Unit)
+            awaitCancellation()
+        }
+    }
+
+    /**
+     * Answers with real usage and cancels [cancelTarget] on the way out, reproducing the
+     * window where the tokens were genuinely spent but cancellation beat the settle.
+     */
+    private class SelfCancellingUpstreamLlmClient(
+        private val cancelTarget: (() -> Job)?,
+    ) : UpstreamLlmClient {
+        override suspend fun call(
+            request: ChatCompletionRequest,
+            configuration: AIConfiguration,
+        ): ChatCompletion {
+            cancelTarget?.invoke()?.cancel()
+            return ChatCompletion(
+                id = "completion",
+                created = 0L,
+                model = ModelId(configuration.model.name),
+                choices = listOf(
+                    ChatChoice(
+                        index = 0,
+                        message = ChatMessage(role = ChatRole.Assistant, content = RESPONSE),
+                    ),
+                ),
+                usage = Usage(
+                    promptTokens = REPORTED_PROMPT_TOKENS,
+                    completionTokens = REPORTED_COMPLETION_TOKENS,
+                    totalTokens = REPORTED_PROMPT_TOKENS + REPORTED_COMPLETION_TOKENS,
+                ),
+            )
+        }
+    }
+
+    companion object {
+        private const val PROMPT = "Summarize the attached specification in three bullets."
+        private const val SYSTEM_MESSAGE = "You are a precise technical summarizer."
+        private const val RESPONSE = "Summarized."
+        private const val REPORTED_PROMPT_TOKENS = 1_234
+        private const val REPORTED_COMPLETION_TOKENS = 56
+    }
+}


### PR DESCRIPTION
Closes AMPR-242 / #618.

## The defect

Cancelling an in-flight LLM call deterministically destroyed its cost record.

`AgentLLMService` caught `CancellationException` in a bare `catch (t: Throwable)` and then tried to *suspend*: `emitCompletedTelemetry` → `AgentEventApi.publish` → `EventRepository.saveEvent` → `withContext(ioDispatcher)`. `withContext` on an already-cancelled Job throws **without executing its block**, so no row was inserted, `emitCompletedTelemetry` threw, and the trailing `throw t` was never reached. The `runCatching` inside `saveEvent` is not the mechanism — cancellation escapes before it is entered.

The same exposure applied to `emitStartedTelemetry` and to the success-path completion emit, so a cancelled call could also lose the *start* row that `ArcTraceProjection.buildModelInvocations` correlates completions against.

## The fix

- Both telemetry emissions now run under `withContext(NonCancellable)`, placed inside the emit helpers so every call site is covered uniformly.
- The upstream-client `catch` is split into a cancellation-aware pair. The `CancellationException` is rethrown unchanged, so structured concurrency still unwinds normally.
- Cancelled rows are stamped with a stable `AgentLLMService.CANCELLED_ERROR_TYPE` (`"Cancelled"`) rather than a `Throwable::simpleName`, which varies across `JobCancellationException` / `TimeoutCancellationException` / a bare `CancellationException` while meaning the same thing to a cost consumer.

## The policy

Per the ticket's proposal — **book the honest floor, never zero**:

- If the provider *did* answer and cancellation merely beat the settle, the reported actuals are used verbatim. The completion is captured outside the `try` so the handler can tell the two windows apart; this is what stops Defect B from downgrading a genuinely-spent call to an estimate.
- Otherwise the call books the input tokens the prompt demonstrably put on the wire, with **zero** output. Zero rather than `null` is load-bearing: `ProviderPricingCalculator` returns `null` the moment either count is `null`, which would silently re-zero the record.

`PromptTokenEstimator` is a deterministic ~4-chars-per-token floor plus per-message framing overhead. It is explicitly **not** a tokenizer — Ampere has no per-provider BPE vocabulary in common code. Streamed provider actuals would need an `UpstreamLlmClient` partial-usage surface and remain a separate metering-policy decision for Act 4. Rows settled this way are identifiable by their `errorType`, so consumers needing exactness can exclude them.

The custom-provider branch gets the mechanical fix only (settle + propagate). It reports no usage even on success, so there is no floor to book there and adding one would make a cancelled custom call book *more* than a successful one.

## Tests

The first cancellation tests in this area. They assert against the **persisted event store**, not the event bus — the defect being guarded is precisely that no row was ever written, so a bus-only assertion could pass on an emission that never reached SQLDelight.

`AgentLlmCancellationTelemetryTest` covers: cancel mid-flight persists both start and completion rows; the cancelled row books non-zero input tokens, zero output, and a computable cost; cancellation *after* the provider answered books the reported actuals; the custom-provider path persists a cancelled row; and an uncancelled call is unaffected. `PromptTokenEstimatorTest` pins the estimator's rounding, per-message overhead, monotonicity, and determinism.

## ⚠️ Not verified locally

Neither `./gradlew jvmTest` nor `:ampere-core:compileCommonMainKotlinMetadata` completed on my machine — the Gradle daemon was contended by another workspace and both runs were killed before producing output. **This branch has not been compiled or run.** Please treat CI as the first real signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)