### PR TITLE
AMPR-243 #619: Arc execution bridge — Swift async start/await/cancel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,3 +72,20 @@ jobs:
       - name: Run iOS simulator tests
         timeout-minutes: 25
         run: ./gradlew :ampere-core:iosSimulatorArm64Test
+
+      # The Kotlin↔Swift Arc bridge (AMPR-243). iosSimulatorArm64Test proves the Kotlin half
+      # runs on Native; only xcodebuild proves the Objective-C export is usable from Swift.
+      - name: Run Swift bridge tests
+        timeout-minutes: 30
+        run: |
+          UDID=$(xcrun simctl list devices available -j \
+            | jq -r '[.devices[][] | select(.name | startswith("iPhone"))][0].udid')
+          test -n "$UDID" || { echo "No iPhone simulator available"; exit 1; }
+          xcodebuild test \
+            -project ampere-ios/ampere-ios.xcodeproj \
+            -scheme ampere-ios \
+            -destination "id=$UDID" \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY="" \
+            DEVELOPMENT_TEAM=""

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/bus/EventSerialBus.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/bus/EventSerialBus.kt
@@ -15,8 +15,20 @@ import link.socket.ampere.agents.events.utils.ConsoleEventLogger
 import link.socket.ampere.agents.events.utils.EventLogger
 import link.socket.ampere.util.runBlockingCompat
 
-typealias HandlerMap = MutableMap<EventType, List<EventHandler<Event, Subscription>>>
-typealias SubscriptionMap = MutableMap<EventType, Subscription>
+/**
+ * One handler listening on one [EventType], addressable by the [subscription] the bus
+ * handed back to whoever registered it.
+ *
+ * Registrations are what make per-subscriber teardown possible. Two subscribers to the
+ * same event type hold two registrations; releasing one leaves the other listening.
+ */
+internal class HandlerRegistration(
+    val subscription: Subscription,
+    val handler: EventHandler<Event, Subscription>,
+)
+
+internal typealias HandlerMap = MutableMap<EventType, List<HandlerRegistration>>
+internal typealias SubscriptionMap = MutableMap<EventType, Subscription>
 
 /**
  * EventSerialBus (ESB) is a thread-safe, Kotlin Multiplatform-compatible event bus.
@@ -27,15 +39,22 @@ typealias SubscriptionMap = MutableMap<EventType, Subscription>
  * - Thread-safe and Kotlin Multiplatform compatible
  * - Handlers are invoked asynchronously using the provided [CoroutineScope]
  * - Persistence is handled by higher-level APIs; EventBus only dispatches events to subscribers
+ *
+ * ### Choosing a subscribe/unsubscribe overload
+ *
+ * [subscribe] and [unsubscribe] are non-suspending, which they buy by taking the bus mutex
+ * under [runBlockingCompat]. That blocks the calling thread, throws outright on JS/WasmJS,
+ * and must never be called from a UI thread. Any caller that can suspend should prefer
+ * [subscribeSuspending] / [unsubscribeSuspending], which take the same mutex without blocking.
  */
 class EventSerialBus(
     private val scope: CoroutineScope,
     private val logger: EventLogger = ConsoleEventLogger(),
 ) {
-    /** Map event from EventClassType -> (subscriptionId, eventHandler) */
+    /** Map from EventClassType -> the handler registrations listening on it, in registration order */
     private val handlerMap: HandlerMap = mutableMapOf()
 
-    /** Map from subscriptionId -> EventClassType (to efficiently locate the handler on unsubscribe) */
+    /** Map from EventClassType -> a representative Subscription, kept for unsubscribe-by-type logging */
     private val subscriptionMap: SubscriptionMap = mutableMapOf()
 
     private val mutex = Mutex()
@@ -52,33 +71,29 @@ class EventSerialBus(
             addAll(event.parentEventTypes)
         }
 
-        // Snapshot handlers under lock to maintain ordering and thread-safety.
-        val handlerPairs: List<Pair<EventType, List<EventHandler<Event, Subscription>>>> = mutex.withLock {
-            dispatchTypes.mapNotNull { type ->
-                val handlers = handlerMap[type]
-                if (handlers.isNullOrEmpty()) null else type to handlers
-            }
+        // Snapshot registrations under lock to maintain ordering and thread-safety.
+        val registrations: List<HandlerRegistration> = mutex.withLock {
+            dispatchTypes.flatMap { type -> handlerMap[type].orEmpty() }
         }
 
-        if (handlerPairs.isEmpty()) {
+        if (registrations.isEmpty()) {
             return
         }
 
         logger.logPublish(event)
 
-        for ((type, handlers) in handlerPairs) {
-            for (handler in handlers) {
-                scope.launch {
-                    try {
-                        val subscription = subscriptionMap[type]
-                        handler(event, subscription)
-                    } catch (throwable: Throwable) {
-                        // Swallow exceptions from handlers to avoid impacting other subscribers, but still log them.
-                        logger.logError(
-                            message = "Subscriber handler failure for ${event.eventType}(id=${event.eventId})",
-                            throwable = throwable,
-                        )
-                    }
+        for (registration in registrations) {
+            scope.launch {
+                try {
+                    // Each handler sees its own Subscription, not whichever subscriber happened
+                    // to register for this event type first.
+                    registration.handler(event, registration.subscription)
+                } catch (throwable: Throwable) {
+                    // Swallow exceptions from handlers to avoid impacting other subscribers, but still log them.
+                    logger.logError(
+                        message = "Subscriber handler failure for ${event.eventType}(id=${event.eventId})",
+                        throwable = throwable,
+                    )
                 }
             }
         }
@@ -98,45 +113,53 @@ class EventSerialBus(
     /**
      * Subscribe to events of [eventType]. Returns an [EventSubscription] that can be used to
      * [unsubscribe]. The [handler] runs asynchronously for each matching event.
+     *
+     * Blocks the calling thread while it takes the bus mutex. Prefer [subscribeSuspending] from
+     * anywhere that can suspend.
      */
-    @Suppress("UNCHECKED_CAST")
     fun subscribe(
         agentId: AgentId,
         eventType: EventType,
         handler: EventHandler<Event, Subscription>,
     ): Subscription {
-        val subscription = EventSubscription.ByEventClassType(
-            agentIdOverride = agentId,
-            eventTypes = setOf(eventType),
-        )
+        val registration = newRegistration(agentId, eventType, handler)
 
-        val eventHandler: EventHandler<Event, Subscription> = EventHandler { event, subscription ->
-            handler(event, subscription)
-        }
+        runBlockingLock { register(eventType, registration) }
 
-        // Register handler under lock
-        runBlockingLock {
-            val existing = handlerMap[eventType]
+        logger.logSubscription(eventType, registration.subscription)
 
-            val updated = if (existing == null) {
-                listOf(eventHandler)
-            } else {
-                existing + eventHandler
-            }
-
-            handlerMap[eventType] = updated
-            subscriptionMap.getOrPut(eventType) { subscription }
-        }
-
-        // Log subscription
-        logger.logSubscription(eventType, subscription)
-
-        return subscription
+        return registration.subscription
     }
 
+    /**
+     * Suspending twin of [subscribe]: same registration semantics, no [runBlockingCompat].
+     *
+     * This is the overload to build Flows on — a `callbackFlow` or `flow` builder can call it
+     * directly, and unlike [subscribe] it works on every target and never blocks a UI thread.
+     */
+    suspend fun subscribeSuspending(
+        agentId: AgentId,
+        eventType: EventType,
+        handler: EventHandler<Event, Subscription>,
+    ): Subscription {
+        val registration = newRegistration(agentId, eventType, handler)
+
+        mutex.withLock { register(eventType, registration) }
+
+        logger.logSubscription(eventType, registration.subscription)
+
+        return registration.subscription
+    }
+
+    /**
+     * Remove **every** handler registered for [eventType], regardless of who registered it.
+     *
+     * This is a blunt instrument kept for compatibility: one subscriber calling it tears down
+     * every other subscriber on that type. Prefer [unsubscribe] with the [Subscription] returned
+     * by [subscribe] — that removes only your own handler.
+     */
     fun unsubscribe(eventType: EventType) {
         runBlockingLock {
-            // TODO: Potentially cancel subscription before removing
             val subscription = subscriptionMap[eventType] ?: return@runBlockingLock
 
             subscriptionMap.remove(eventType)
@@ -145,6 +168,78 @@ class EventSerialBus(
             // Log unsubscription
             logger.logUnsubscription(eventType, subscription)
         }
+    }
+
+    /**
+     * Remove only the handler registered under [subscription], leaving every other subscriber
+     * on the same event type intact.
+     *
+     * Idempotent: unsubscribing an already-released subscription is a no-op.
+     *
+     * Matching is by object identity, so pass back the exact instance [subscribe] returned. A
+     * serialization round-trip produces an equal-but-distinct [Subscription] that this will not
+     * match — deliberately, because two subscribers with the same `agentId` and event type
+     * produce equal `subscriptionId`s and only identity can tell them apart.
+     *
+     * Blocks the calling thread while it takes the bus mutex; prefer [unsubscribeSuspending].
+     */
+    fun unsubscribe(subscription: Subscription) {
+        val releasedTypes = runBlockingLock { release(subscription) }
+
+        releasedTypes.forEach { eventType -> logger.logUnsubscription(eventType, subscription) }
+    }
+
+    /** Suspending twin of [unsubscribe]: same removal semantics, no [runBlockingCompat]. */
+    suspend fun unsubscribeSuspending(subscription: Subscription) {
+        val releasedTypes = mutex.withLock { release(subscription) }
+
+        releasedTypes.forEach { eventType -> logger.logUnsubscription(eventType, subscription) }
+    }
+
+    private fun newRegistration(
+        agentId: AgentId,
+        eventType: EventType,
+        handler: EventHandler<Event, Subscription>,
+    ): HandlerRegistration = HandlerRegistration(
+        subscription = EventSubscription.ByEventClassType(
+            agentIdOverride = agentId,
+            eventTypes = setOf(eventType),
+        ),
+        handler = handler,
+    )
+
+    /** Must be called while holding [mutex]. */
+    private fun register(eventType: EventType, registration: HandlerRegistration) {
+        handlerMap[eventType] = handlerMap[eventType].orEmpty() + registration
+        subscriptionMap.getOrPut(eventType) { registration.subscription }
+    }
+
+    /**
+     * Must be called while holding [mutex]. Returns the event types [subscription] was
+     * actually removed from, so the caller can log outside the lock.
+     */
+    private fun release(subscription: Subscription): List<EventType> {
+        val releasedTypes = mutableListOf<EventType>()
+
+        for ((eventType, registrations) in handlerMap.entries.toList()) {
+            val remaining = registrations.filterNot { it.subscription === subscription }
+            if (remaining.size == registrations.size) continue
+
+            releasedTypes += eventType
+
+            if (remaining.isEmpty()) {
+                handlerMap.remove(eventType)
+                subscriptionMap.remove(eventType)
+            } else {
+                handlerMap[eventType] = remaining
+                // The representative subscription is the one we just dropped; promote a survivor.
+                if (subscriptionMap[eventType] === subscription) {
+                    subscriptionMap[eventType] = remaining.first().subscription
+                }
+            }
+        }
+
+        return releasedTypes
     }
 
     /** Helper to reuse the same locking pattern in non-suspending API without exposing Mutex */

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/relay/EmissionStream.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/relay/EmissionStream.kt
@@ -1,0 +1,99 @@
+package link.socket.ampere.agents.events.relay
+
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.updateAndGet
+import kotlinx.coroutines.withContext
+import link.socket.ampere.agents.domain.RunId
+import link.socket.ampere.agents.domain.emission.Emission
+import link.socket.ampere.agents.domain.event.EmissionEvent
+import link.socket.ampere.agents.events.api.EventHandler
+import link.socket.ampere.agents.events.bus.EventSerialBus
+import link.socket.ampere.agents.events.utils.generateUUID
+
+/**
+ * How many Emissions a single [emissions] collector buffers before the oldest one is dropped.
+ *
+ * Sized for a progress surface that renders a handful of Emissions per second and can stall for
+ * a second or two — a Live Activity being redrawn, a Swift `AsyncStream` consumer waiting on the
+ * main actor. Anything past that is a consumer that has fallen too far behind to be showing
+ * "progress" at all, so the stream keeps the newest state and reports the loss.
+ */
+const val DEFAULT_EMISSION_BUFFER_CAPACITY: Int = 64
+
+/**
+ * A live stream of the Emissions produced by one Arc run.
+ *
+ * The [EventSerialBus] is callback-only: it hands a handler to every subscriber and never
+ * suspends the publisher. This adapts that into a cold [Flow] with a real backpressure policy.
+ *
+ * Three properties make it safe to hand to a second consumer, which the one pre-existing
+ * bus→Flow adapter ([EventRelayServiceImpl.subscribeToLiveEvents]) is not:
+ *
+ * 1. **Per-collector teardown.** Each collector registers its own subscription and releases it
+ *    with [EventSerialBus.unsubscribe], so cancelling one collector cannot silence another —
+ *    including the emission reply routers the Arc itself depends on.
+ * 2. **Explicit overflow.** A slow collector overflows into [BufferOverflow.DROP_OLDEST] rather
+ *    than the silent drop of a default-capacity `trySend`. The newest state survives, which is
+ *    what a progress surface wants.
+ * 3. **Loss is reported, not swallowed.** Every dropped Emission calls [onDropped] with the
+ *    running total for this collector, so a consumer can say "12 updates skipped" instead of
+ *    quietly rendering a stale timeline. Keep [onDropped] cheap — it runs on the producing
+ *    coroutine, inside the channel's own bookkeeping.
+ *
+ * Ordering is the bus's: handlers are dispatched as independent coroutines, so two Emissions
+ * published concurrently can arrive in either order. Emissions published *before* collection
+ * starts are not replayed — the bus has no history. Collect before starting the run, or use
+ * [link.socket.ampere.domain.arc.bridge.ArcSession.start], which subscribes before it launches.
+ *
+ * @param runId Keep only Emissions whose `provenance.runId` matches. Null streams every
+ *   Emission on the bus, whatever run produced it.
+ * @param capacity Buffered Emissions per collector; see [DEFAULT_EMISSION_BUFFER_CAPACITY].
+ * @param onDropped Called with the running number of Emissions this collector has lost.
+ */
+fun EventSerialBus.emissions(
+    runId: RunId? = null,
+    capacity: Int = DEFAULT_EMISSION_BUFFER_CAPACITY,
+    onDropped: (droppedTotal: Long) -> Unit = {},
+): Flow<Emission> = flow {
+    // StateFlow rather than a plain var: the counter is written from whichever bus coroutine
+    // overflowed the buffer and read from the collector, and `update` is the one atomic
+    // read-modify-write available in commonMain without a new dependency.
+    val droppedTotal = MutableStateFlow(0L)
+
+    val channel = Channel<Emission>(
+        capacity = capacity,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+        onUndeliveredElement = { onDropped(droppedTotal.updateAndGet { it + 1 }) },
+    )
+
+    val subscription = subscribeSuspending(
+        agentId = "emission-stream-${generateUUID()}",
+        eventType = EmissionEvent.Produced.EVENT_TYPE,
+        handler = EventHandler { event, _ ->
+            // Produced is polymorphic: BaseProduced and HumanInteractionEvent.InputRequested
+            // both land here. Anything else on this type is not ours to read.
+            val emission = (event as? EmissionEvent.Produced)?.emission
+            if (emission != null && (runId == null || emission.provenance.runId == runId)) {
+                channel.trySend(emission)
+            }
+        },
+    )
+
+    try {
+        for (emission in channel) {
+            emit(emission)
+        }
+    } finally {
+        // Cancellation is the normal exit here, and releasing the subscription needs the bus
+        // mutex — which a cancelled coroutine cannot take.
+        withContext(NonCancellable) {
+            unsubscribeSuspending(subscription)
+        }
+        channel.close()
+    }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/relay/EventRelayServiceImpl.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/relay/EventRelayServiceImpl.kt
@@ -33,7 +33,7 @@ class EventRelayServiceImpl(
 
         // Create subscriptions for each event type
         val subscriptions = eventTypes.map { eventType ->
-            eventSerialBus.subscribe(
+            eventSerialBus.subscribeSuspending(
                 agentId = "event-stream-${generateUUID()}",
                 eventType = eventType,
                 handler = EventHandler { event: Event, _: Subscription? ->
@@ -47,9 +47,11 @@ class EventRelayServiceImpl(
 
         // Keep the flow alive until canceled
         awaitClose {
-            // Unsubscribe from all event types when the flow is canceled
-            eventTypes.forEach { eventType ->
-                eventSerialBus.unsubscribe(eventType)
+            // Release only this collector's handlers. Unsubscribing by event type would remove
+            // every other subscriber's handlers too — with no filters that is every type in
+            // EventRegistry, including the emission reply routers the Arc depends on.
+            subscriptions.forEach { subscription ->
+                eventSerialBus.unsubscribe(subscription)
             }
         }
     }

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/api/service/EventService.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/api/service/EventService.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.datetime.Instant
 import link.socket.ampere.agents.domain.event.CognitiveEvent
 import link.socket.ampere.agents.domain.event.CognitivePhaseEvent
+import link.socket.ampere.agents.domain.event.EmissionEvent
 import link.socket.ampere.agents.domain.event.Event
 import link.socket.ampere.agents.domain.event.FileSystemEvent
 import link.socket.ampere.agents.domain.event.GitEvent
@@ -156,6 +157,22 @@ fun EventService.routingEvents(
 fun EventService.completionEvents(
     filters: EventRelayFilters = EventRelayFilters(),
 ): Flow<ProviderCallCompletedEvent> = observe(filters).filterIsInstance<ProviderCallCompletedEvent>()
+
+/**
+ * Stream every Emission produced anywhere in the system, as the bus event that carries it.
+ *
+ * Polymorphic: `EmissionEvent.Produced` covers both `BaseProduced` and
+ * [HumanInteractionEvent.InputRequested], so a subscriber sees generic Emissions and human-input
+ * requests through one stream. Read `event.emission.provenance.runId` to attribute one to an Arc.
+ *
+ * For a single Arc run, prefer [link.socket.ampere.domain.arc.bridge.ArcRunHandle.observe] or
+ * [link.socket.ampere.agents.events.relay.emissions] — both filter by run and carry an explicit
+ * overflow policy, which this general-purpose stream inherits from the relay.
+ */
+@link.socket.ampere.api.AmpereStableApi
+fun EventService.emissionEvents(
+    filters: EventRelayFilters = EventRelayFilters(),
+): Flow<EmissionEvent.Produced> = observe(filters).filterIsInstance<EmissionEvent.Produced>()
 
 @link.socket.ampere.api.AmpereStableApi
 fun EventService.escalationFiredEvents(

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/arc/AmpereRuntime.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/arc/AmpereRuntime.kt
@@ -87,6 +87,13 @@ class AmpereRuntime(
     @Volatile
     private var stopRequested = false
 
+    /**
+     * Sticky record of a [cancel] call, so one that lands in the window between a run being
+     * marked running and its job existing is not lost. Checked once the job is in hand.
+     */
+    @Volatile
+    private var cancelRequested = false
+
     /** Set for the duration of [execute] so [cancel] has something to cancel. */
     @Volatile
     private var runJob: CompletableJob? = null
@@ -117,11 +124,15 @@ class AmpereRuntime(
         require(!isRunning) { "Runtime is already executing" }
         require(userGoal.isNotBlank()) { "User goal cannot be blank" }
 
-        isRunning = true
         stopRequested = false
+        cancelRequested = false
         chargeResult = null
         flowResult = null
         flowPhase = null
+
+        // Published last, and read by callers as the signal that this run's state is reset —
+        // so a `cancel()` that observes `isRunning` cannot have its flag wiped by the lines above.
+        isRunning = true
 
         // A per-run child of the caller-owned scope: cancellable on its own (so `cancel()` does
         // not touch the caller), and cancelled + joined in the `finally` below so the run leaves
@@ -130,6 +141,11 @@ class AmpereRuntime(
         val job = SupervisorJob(agentScope.coroutineContext[Job])
         val runScope = CoroutineScope(agentScope.coroutineContext + job)
         runJob = job
+
+        // A `cancel()` that raced this setup had no job to act on. It left its flag behind.
+        if (cancelRequested) {
+            job.cancel(CancellationException(CANCELLATION_MESSAGE))
+        }
 
         try {
             return runScope.async { runArc(userGoal, runId, runScope) }.await()
@@ -259,9 +275,14 @@ class AmpereRuntime(
      * Cancels the run's coroutine scope, so the Flow tick loop stops at its next cancellation
      * point and every agent coroutine spawned by the run is torn down. [execute] returns
      * [ArcOutcome.Cancelled] carrying whatever partial phase results exist.
+     *
+     * Sticky within a run: a call that arrives after [isRunning] goes true but before the run's
+     * job exists is applied by [execute] as soon as it has one. A call made while no run is in
+     * flight is discarded — the next [execute] starts clean.
      */
     fun cancel() {
-        runJob?.cancel(CancellationException("Arc execution cancelled"))
+        cancelRequested = true
+        runJob?.cancel(CancellationException(CANCELLATION_MESSAGE))
     }
 
     /**
@@ -275,6 +296,8 @@ class AmpereRuntime(
     fun getArcConfig(): ArcConfig = arcConfig
 
     companion object {
+        internal const val CANCELLATION_MESSAGE = "Arc execution cancelled"
+
         /**
          * Create a runtime from an Arc configuration and a project directory path string.
          *

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/arc/bridge/ArcCancellable.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/arc/bridge/ArcCancellable.kt
@@ -1,0 +1,27 @@
+package link.socket.ampere.domain.arc.bridge
+
+import kotlinx.coroutines.flow.MutableStateFlow
+
+/**
+ * A handle that stops one observation. The bridge's answer to a `Job`, which does not survive
+ * the Objective-C export in a form Swift can hold.
+ *
+ * [cancel] is idempotent and safe from any thread. It never throws, so a Swift
+ * `AsyncStream.onTermination` closure can call it unconditionally.
+ */
+class ArcCancellable internal constructor(
+    private val onCancel: () -> Unit,
+) {
+    private val cancelled = MutableStateFlow(false)
+
+    /** True once [cancel] has run. Observation has stopped; nothing further will be delivered. */
+    val isCancelled: Boolean
+        get() = cancelled.value
+
+    /** Stop the observation. Calls after the first are no-ops. */
+    fun cancel() {
+        if (cancelled.compareAndSet(expect = false, update = true)) {
+            onCancel()
+        }
+    }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/arc/bridge/ArcRunHandle.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/arc/bridge/ArcRunHandle.kt
@@ -1,0 +1,147 @@
+package link.socket.ampere.domain.arc.bridge
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.yield
+import link.socket.ampere.agents.domain.emission.Emission
+import link.socket.ampere.domain.arc.AmpereRuntime
+import link.socket.ampere.domain.arc.ArcOutcome
+import link.socket.ampere.trace.ArcRunId
+import link.socket.ampere.trace.ArcRunTrace
+import link.socket.ampere.trace.ArcTraceProjection
+
+/**
+ * A running Arc, as seen from outside the coroutine world.
+ *
+ * Created by [ArcSession.start]. The handle observes; it does not orchestrate — the run's
+ * lifetime belongs to the [AmpereRuntime] and the scope the session was built with.
+ *
+ * Every method is safe to call from any thread, in any order, more than once.
+ *
+ * ### Swift
+ *
+ * The Kotlin/Native Objective-C export turns each `suspend` function into a completion-handler
+ * method, which Swift re-imports as `async`. The call site reads the way a SKIE-generated one
+ * would, which is the point — adopting SKIE later should be a build-file change, not a Swift
+ * rewrite.
+ *
+ * ```swift
+ * let handle = session.start(userGoal: goal)
+ * Task { for await e in handle.emissions { await reporter.update(e) } }  // ProgressReportingIntent
+ * let outcome = try await handle.await()                                 // LongRunningIntent
+ * let cancelled = try await handle.cancel()                              // stop button
+ * ```
+ */
+class ArcRunHandle internal constructor(
+    /** Ambient identity of this run. Every event, trace row, and Emission it produces carries it. */
+    val runId: ArcRunId,
+    private val runtime: AmpereRuntime,
+    private val scope: CoroutineScope,
+    private val outcome: Deferred<ArcOutcome>,
+    private val emissions: Flow<Emission>,
+    private val traceProjection: ArcTraceProjection?,
+) {
+    /**
+     * Suspend until the run reaches a terminal [ArcOutcome].
+     *
+     * Returns rather than throws for Arc-level failure and cancellation — those are
+     * [ArcOutcome.Failed] and [ArcOutcome.Cancelled]. Cancelling the *caller* still throws, as
+     * structured concurrency requires; in Swift that surfaces as the enclosing `Task` being
+     * cancelled.
+     *
+     * Idempotent: every call after the first returns the same outcome immediately.
+     */
+    suspend fun await(): ArcOutcome = outcome.await()
+
+    /**
+     * Deliver this run's Emissions to [onEmission] until the run reaches a terminal outcome or
+     * the returned [ArcCancellable] is cancelled.
+     *
+     * Emissions produced before the first observer attaches are replayed from the session's
+     * buffer, so a Swift `Task { for await ... }` that starts a beat after [ArcSession.start]
+     * does not miss the opening of the run. A consumer that falls further behind than the
+     * session's buffer loses the oldest Emissions, reported through the session's
+     * `onEmissionsDropped` callback rather than dropped in silence.
+     */
+    fun observe(onEmission: (Emission) -> Unit): ArcCancellable =
+        observe(onEmission = onEmission, onFinished = {})
+
+    /**
+     * [observe], plus a terminal callback.
+     *
+     * [onFinished] runs exactly once — after the run ends, or after the returned
+     * [ArcCancellable] is cancelled. It is what lets a Swift `AsyncStream` call `finish()`
+     * instead of hanging a `for await` loop forever on a run that is already over.
+     *
+     * Emissions still in flight on the bus when the run terminates may not arrive: bus dispatch
+     * is asynchronous and the terminal outcome does not wait on it. The outcome is the
+     * authoritative end of the run; the Emission stream is progress, not a ledger.
+     */
+    fun observe(onEmission: (Emission) -> Unit, onFinished: () -> Unit): ArcCancellable {
+        val job = scope.launch {
+            try {
+                coroutineScope {
+                    val collector = launch { emissions.collect { onEmission(it) } }
+                    outcome.join()
+                    collector.cancel()
+                }
+            } finally {
+                onFinished()
+            }
+        }
+
+        return ArcCancellable { job.cancel() }
+    }
+
+    /**
+     * Halt the run cooperatively and suspend until it has settled.
+     *
+     * The ordering is what makes the ledger correct, and it is why this suspends rather than
+     * returning immediately:
+     *
+     * 1. [AmpereRuntime.cancel] cancels the run's job; `FlowPhase`'s tick loop observes it at
+     *    its next `ensureActive()` and terminates with `TerminationReason.CANCELLED`.
+     * 2. An in-flight LLM call unwinds through its `CancellationException` handler, which
+     *    settles a cost record under `NonCancellable` before rethrowing.
+     * 3. `execute` joins every agent coroutine before it returns, so those settlement writes are
+     *    durable by the time this function does.
+     *
+     * Returns the run's terminal outcome — [ArcOutcome.Cancelled] in the ordinary case. A run
+     * that had already completed or failed before the cancel landed returns *that* outcome
+     * instead: this reports what happened, it does not relabel it.
+     *
+     * Idempotent, and safe to call before the run has been dispatched.
+     */
+    suspend fun cancel(): ArcOutcome {
+        // The runtime only holds a cancellable job once `execute` is under way. Cancelling
+        // before that has nothing to act on, so wait for the run to be marked running —
+        // bounded by the run finishing on its own, which makes this terminate either way.
+        while (outcome.isActive && !runtime.isRunning()) {
+            yield()
+        }
+
+        runtime.cancel()
+
+        return outcome.await()
+    }
+
+    /**
+     * Fold this run's persisted rows into a trace: phases, model invocations, memory writes,
+     * tool calls, and the Watt cost actually incurred.
+     *
+     * Call it after [await] or [cancel]. Both guarantee that every agent coroutine — including
+     * the `NonCancellable` blocks that settle cost records for cancelled LLM calls — has
+     * completed, so the fold sees actuals rather than a half-written ledger.
+     *
+     * Null when the session was built without an [ArcTraceProjection], or when the run wrote no
+     * rows at all (a runtime configured without an event API persists no telemetry).
+     */
+    suspend fun trace(): ArcRunTrace? = traceProjection?.project(runId)?.getOrNull()
+
+    /** True while the run is still in flight. */
+    val isActive: Boolean
+        get() = outcome.isActive
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/arc/bridge/ArcSession.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/domain/arc/bridge/ArcSession.kt
@@ -1,0 +1,217 @@
+package link.socket.ampere.domain.arc.bridge
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+import link.socket.ampere.agents.domain.emission.Emission
+import link.socket.ampere.agents.events.bus.EventSerialBus
+import link.socket.ampere.agents.events.relay.DEFAULT_EMISSION_BUFFER_CAPACITY
+import link.socket.ampere.agents.events.relay.emissions
+import link.socket.ampere.agents.events.utils.generateUUID
+import link.socket.ampere.domain.arc.AmpereRuntime
+import link.socket.ampere.domain.arc.ArcConfig
+import link.socket.ampere.domain.arc.ArcOutcome
+import link.socket.ampere.trace.ArcRunId
+import link.socket.ampere.trace.ArcTraceProjection
+import okio.Path.Companion.toPath
+
+/**
+ * How many Emissions a run holds for observers that attach after it started.
+ *
+ * Sized to cover the gap between a Swift `session.start(...)` and the `Task { for await ... }`
+ * on the next line — a scheduling hop, not a real delay — with room for the opening burst of a
+ * Charge phase.
+ */
+const val DEFAULT_EMISSION_REPLAY: Int = 32
+
+/**
+ * Starts Arcs and hands back a handle to each one.
+ *
+ * The session owns the scope; the handle observes. That split is what keeps the bridge honest:
+ * nothing here re-implements the Arc lifecycle, it only makes [AmpereRuntime] reachable from a
+ * caller that cannot hold a `CoroutineScope` — which is every Swift call site, and the reason
+ * App Intents are blocked without it.
+ *
+ * One run at a time per [runtime]: [start] rejects a goal while a run is in flight, matching
+ * [AmpereRuntime.execute]'s own contract.
+ *
+ * ### Swift
+ *
+ * Swift builds a session through [Companion.create], never this constructor — see the note
+ * there on why a `CoroutineScope` cannot cross the boundary.
+ *
+ * ```swift
+ * let session = ArcSession.companion.create(
+ *     arcConfig: ArcRegistry.shared.getDefault(),
+ *     projectDirPath: projectPath,
+ *     maxFlowTicks: 100
+ * )
+ * defer { session.close() }
+ * let handle = session.start(userGoal: "Add a health check endpoint")
+ * ```
+ *
+ * @param scope Caller-owned. Its lifetime bounds every run this session starts.
+ * @param runtime The Arc runtime to drive.
+ * @param eventSerialBus The bus the run's Emissions are published on.
+ * @param traceProjection Optional; supplying it is what makes [ArcRunHandle.trace] return a
+ *   folded ledger instead of null.
+ * @param emissionReplay Emissions held for late observers. See [DEFAULT_EMISSION_REPLAY].
+ * @param emissionCapacity Emissions buffered for a slow observer before the oldest is dropped.
+ * @param onEmissionsDropped Called with the running number of Emissions lost to a slow
+ *   observer. Loss is reported, never silent — a progress surface that has skipped updates
+ *   should be able to say so.
+ */
+class ArcSession(
+    private val scope: CoroutineScope,
+    private val runtime: AmpereRuntime,
+    private val eventSerialBus: EventSerialBus,
+    private val traceProjection: ArcTraceProjection? = null,
+    private val emissionReplay: Int = DEFAULT_EMISSION_REPLAY,
+    private val emissionCapacity: Int = DEFAULT_EMISSION_BUFFER_CAPACITY,
+    private val onEmissionsDropped: (droppedTotal: Long) -> Unit = {},
+) {
+    /**
+     * Secondary constructor for the Objective-C export, which does not carry Kotlin default
+     * arguments across the boundary. The three parameters a Kotlin caller always has.
+     */
+    constructor(
+        scope: CoroutineScope,
+        runtime: AmpereRuntime,
+        eventSerialBus: EventSerialBus,
+    ) : this(
+        scope = scope,
+        runtime = runtime,
+        eventSerialBus = eventSerialBus,
+        traceProjection = null,
+    )
+
+    /** Set only by [Companion.create]; the scope this session must clean up after itself. */
+    private var ownedScope: CoroutineScope? = null
+
+    /**
+     * The bus this session's Emissions travel on.
+     *
+     * The only way to reach it for a session built by [Companion.create], which makes its own —
+     * a host that wants to watch anything beyond Emissions needs this handle.
+     */
+    val bus: EventSerialBus
+        get() = eventSerialBus
+
+    /** Start an Arc for [userGoal] under a freshly generated run identity. */
+    fun start(userGoal: String): ArcRunHandle = start(userGoal, generateUUID("arc-run"))
+
+    /**
+     * Start an Arc for [userGoal] under [runId].
+     *
+     * Returns as soon as the run is dispatched — the Arc itself runs on the session's scope.
+     * The Emission subscription is registered *before* this returns, so an observer attached on
+     * the returned handle cannot miss the run's opening.
+     *
+     * @throws IllegalArgumentException if [userGoal] is blank
+     * @throws IllegalStateException if [runtime] is already executing
+     */
+    fun start(userGoal: String, runId: ArcRunId): ArcRunHandle {
+        require(userGoal.isNotBlank()) { "User goal cannot be blank" }
+        check(!runtime.isRunning()) { "Runtime is already executing" }
+
+        val emissions = MutableSharedFlow<Emission>(replay = emissionReplay)
+
+        // UNDISPATCHED so the bus subscription is registered on the calling thread, before this
+        // function returns. Dispatching it would open a window in which the first tick's
+        // Emissions are published to nobody.
+        val pump = scope.launch(start = CoroutineStart.UNDISPATCHED) {
+            eventSerialBus
+                .emissions(
+                    runId = runId,
+                    capacity = emissionCapacity,
+                    onDropped = onEmissionsDropped,
+                )
+                .collect { emissions.emit(it) }
+        }
+
+        val outcome = scope.async {
+            try {
+                runtime.execute(userGoal, runId)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                // `execute` maps Arc-level failures itself; this catches the ones it cannot,
+                // so an unexpected throw cannot tear down the caller's session scope.
+                ArcOutcome.Failed(runId = runId, cause = e)
+            }
+        }
+
+        // Release the bus subscription the moment the run is terminal. Without this the handler
+        // outlives the run and the bus grows one dead subscriber per Arc.
+        scope.launch {
+            outcome.join()
+            pump.cancel()
+        }
+
+        return ArcRunHandle(
+            runId = runId,
+            runtime = runtime,
+            scope = scope,
+            outcome = outcome,
+            emissions = emissions,
+            traceProjection = traceProjection,
+        )
+    }
+
+    /**
+     * Release the scope this session made for itself in [Companion.create], cancelling any run
+     * still in flight.
+     *
+     * A no-op for a session built on a caller-supplied scope — that lifetime is not ours to end.
+     */
+    fun close() {
+        ownedScope?.cancel()
+        ownedScope = null
+    }
+
+    companion object {
+        /**
+         * Build a session that owns its scope and its bus.
+         *
+         * This exists because of one hard fact about the export: `kotlinx.coroutines` is a plain
+         * dependency of `ampere-core`, not an `export()`ed one, so none of its constructors
+         * cross the Objective-C boundary. `CoroutineScope` reaches Swift only as an opaque
+         * protocol with no way to make one. Every parameter here is something Swift *can*
+         * build — an [ArcConfig], a path string, an Int — and the coroutine machinery stays on
+         * the Kotlin side of the line.
+         *
+         * The caller owns the returned session and must [close] it.
+         *
+         * @param arcConfig Which Arc to run. `ArcRegistry.getDefault()` is the usual answer.
+         * @param projectDirPath Directory the Arc reads its project context from.
+         * @param maxFlowTicks Tick ceiling for the Flow phase.
+         */
+        fun create(
+            arcConfig: ArcConfig,
+            projectDirPath: String,
+            maxFlowTicks: Int,
+        ): ArcSession {
+            val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+            val session = ArcSession(
+                scope = scope,
+                runtime = AmpereRuntime(
+                    arcConfig = arcConfig,
+                    projectDir = projectDirPath.toPath(),
+                    agentScope = scope,
+                    maxFlowTicks = maxFlowTicks,
+                ),
+                eventSerialBus = EventSerialBus(scope = scope),
+            )
+            session.ownedScope = scope
+
+            return session
+        }
+    }
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/events/bus/EventSerialBusSubscriptionTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/events/bus/EventSerialBusSubscriptionTest.kt
@@ -1,0 +1,169 @@
+package link.socket.ampere.agents.events.bus
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import link.socket.ampere.agents.domain.Urgency
+import link.socket.ampere.agents.domain.event.Event
+import link.socket.ampere.agents.domain.event.EventSource
+import link.socket.ampere.agents.events.api.EventHandler
+import link.socket.ampere.agents.events.subscription.EventSubscription
+
+/**
+ * Per-subscription teardown on the bus (AMPR-243).
+ *
+ * Before this, `unsubscribe` took an event type and removed *every* handler registered for it,
+ * so one consumer letting go silenced all the others. That made the bus unsafe to hand a second
+ * Flow consumer — which the Swift Arc bridge is, and the first one that cancels routinely.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class EventSerialBusSubscriptionTest {
+
+    private fun taskEvent(eventId: String): Event.TaskCreated = Event.TaskCreated(
+        eventId = eventId,
+        urgency = Urgency.MEDIUM,
+        timestamp = Clock.System.now(),
+        eventSource = EventSource.Agent("agent-A"),
+        taskId = "task-1",
+        description = "Do the thing",
+        assignedTo = "agent-B",
+    )
+
+    @Test
+    fun `releasing one subscription leaves every other subscriber on that type listening`() = runTest {
+        val bus = EventSerialBus(scope = backgroundScope)
+        val keeper = mutableListOf<String>()
+        val leaver = mutableListOf<String>()
+
+        bus.subscribeSuspending(
+            agentId = "keeper",
+            eventType = Event.TaskCreated.EVENT_TYPE,
+            handler = EventHandler { event, _ -> keeper += event.eventId },
+        )
+        val leaverSubscription = bus.subscribeSuspending(
+            agentId = "leaver",
+            eventType = Event.TaskCreated.EVENT_TYPE,
+            handler = EventHandler { event, _ -> leaver += event.eventId },
+        )
+
+        bus.publish(taskEvent("evt-1"))
+        runCurrent()
+
+        bus.unsubscribeSuspending(leaverSubscription)
+
+        bus.publish(taskEvent("evt-2"))
+        runCurrent()
+
+        assertEquals(listOf("evt-1", "evt-2"), keeper, "The surviving subscriber must keep receiving")
+        assertEquals(listOf("evt-1"), leaver, "The released subscriber must stop receiving")
+    }
+
+    @Test
+    fun `releasing the same subscription twice is a no-op`() = runTest {
+        val bus = EventSerialBus(scope = backgroundScope)
+        val received = mutableListOf<String>()
+
+        val first = bus.subscribeSuspending(
+            agentId = "first",
+            eventType = Event.TaskCreated.EVENT_TYPE,
+            handler = EventHandler { _, _ -> received += "first" },
+        )
+        bus.subscribeSuspending(
+            agentId = "second",
+            eventType = Event.TaskCreated.EVENT_TYPE,
+            handler = EventHandler { _, _ -> received += "second" },
+        )
+
+        bus.unsubscribeSuspending(first)
+        bus.unsubscribeSuspending(first)
+
+        bus.publish(taskEvent("evt-1"))
+        runCurrent()
+
+        assertEquals(listOf("second"), received)
+    }
+
+    @Test
+    fun `two subscribers sharing an agent id are still told apart`() = runTest {
+        // Both subscriptions carry the same subscriptionId — `eventTypes + "/" + agentId` — so
+        // only object identity can distinguish them. Matching by value would release both.
+        val bus = EventSerialBus(scope = backgroundScope)
+        val received = mutableListOf<String>()
+
+        val first = bus.subscribeSuspending(
+            agentId = "same-agent",
+            eventType = Event.TaskCreated.EVENT_TYPE,
+            handler = EventHandler { _, _ -> received += "first" },
+        )
+        val second = bus.subscribeSuspending(
+            agentId = "same-agent",
+            eventType = Event.TaskCreated.EVENT_TYPE,
+            handler = EventHandler { _, _ -> received += "second" },
+        )
+
+        assertEquals(first.subscriptionId, second.subscriptionId, "Precondition: the ids collide")
+
+        bus.unsubscribeSuspending(first)
+
+        bus.publish(taskEvent("evt-1"))
+        runCurrent()
+
+        assertEquals(listOf("second"), received)
+    }
+
+    @Test
+    fun `unsubscribing by event type still removes every handler`() = runTest {
+        // The blunt overload is kept for compatibility; this pins its semantics so a future
+        // change cannot quietly narrow it.
+        val bus = EventSerialBus(scope = backgroundScope)
+        val received = mutableListOf<String>()
+
+        bus.subscribeSuspending(
+            agentId = "first",
+            eventType = Event.TaskCreated.EVENT_TYPE,
+            handler = EventHandler { _, _ -> received += "first" },
+        )
+        bus.subscribeSuspending(
+            agentId = "second",
+            eventType = Event.TaskCreated.EVENT_TYPE,
+            handler = EventHandler { _, _ -> received += "second" },
+        )
+
+        bus.unsubscribe(Event.TaskCreated.EVENT_TYPE)
+
+        bus.publish(taskEvent("evt-1"))
+        runCurrent()
+
+        assertEquals(emptyList(), received)
+    }
+
+    @Test
+    fun `each handler is given its own subscription rather than the first registered one`() = runTest {
+        val bus = EventSerialBus(scope = backgroundScope)
+        val seenAgentIds = mutableListOf<String>()
+
+        bus.subscribeSuspending(
+            agentId = "first",
+            eventType = Event.TaskCreated.EVENT_TYPE,
+            handler = EventHandler { _, subscription ->
+                seenAgentIds += (subscription as EventSubscription).agentId
+            },
+        )
+        bus.subscribeSuspending(
+            agentId = "second",
+            eventType = Event.TaskCreated.EVENT_TYPE,
+            handler = EventHandler { _, subscription ->
+                seenAgentIds += (subscription as EventSubscription).agentId
+            },
+        )
+
+        bus.publish(taskEvent("evt-1"))
+        runCurrent()
+
+        assertTrue("first" in seenAgentIds && "second" in seenAgentIds, "Saw $seenAgentIds")
+    }
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/events/relay/EmissionStreamTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/agents/events/relay/EmissionStreamTest.kt
@@ -1,0 +1,185 @@
+package link.socket.ampere.agents.events.relay
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import link.socket.ampere.agents.domain.Urgency
+import link.socket.ampere.agents.domain.emission.Emission
+import link.socket.ampere.agents.domain.emission.EmissionKind
+import link.socket.ampere.agents.domain.emission.EmissionPayload
+import link.socket.ampere.agents.domain.emission.EmissionProvenance
+import link.socket.ampere.agents.domain.emission.ProseFormat
+import link.socket.ampere.agents.domain.event.EmissionEvent
+import link.socket.ampere.agents.domain.event.EventSource
+import link.socket.ampere.agents.domain.event.HumanInteractionEvent
+import link.socket.ampere.agents.events.bus.EventSerialBus
+
+/**
+ * The bus→Flow adapter the Arc bridge streams progress through (AMPR-243).
+ *
+ * What is under test is the three properties that make it safe for a second consumer:
+ * per-run filtering, per-collector teardown, and an overflow policy that reports its losses.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class EmissionStreamTest {
+
+    private fun emission(runId: String?, text: String): Emission = Emission(
+        id = "emission-$text",
+        kind = EmissionKind.Prose,
+        payload = EmissionPayload.Prose(text = text, format = ProseFormat.PLAIN),
+        provenance = EmissionProvenance(runId = runId, inputDigest = "digest-$text"),
+        producedAt = Clock.System.now(),
+    )
+
+    private fun produced(runId: String?, text: String): EmissionEvent.BaseProduced =
+        EmissionEvent.BaseProduced(
+            eventId = "evt-$text",
+            timestamp = Clock.System.now(),
+            eventSource = EventSource.Agent("agent-A"),
+            urgency = Urgency.MEDIUM,
+            emission = emission(runId, text),
+        )
+
+    private fun proseOf(emission: Emission): String =
+        (emission.payload as EmissionPayload.Prose).text
+
+    @Test
+    fun `emissions carry only the requested run`() = runTest {
+        val bus = EventSerialBus(scope = backgroundScope)
+        val mine = mutableListOf<String>()
+
+        val collector = backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            bus.emissions(runId = "run-mine").collect { mine += proseOf(it) }
+        }
+
+        bus.publish(produced("run-mine", "first"))
+        bus.publish(produced("run-theirs", "second"))
+        bus.publish(produced(null, "third"))
+        bus.publish(produced("run-mine", "fourth"))
+        runCurrent()
+
+        assertEquals(listOf("first", "fourth"), mine)
+        collector.cancel()
+    }
+
+    @Test
+    fun `a null run id streams every emission on the bus`() = runTest {
+        val bus = EventSerialBus(scope = backgroundScope)
+        val all = mutableListOf<String>()
+
+        val collector = backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            bus.emissions(runId = null).collect { all += proseOf(it) }
+        }
+
+        bus.publish(produced("run-a", "first"))
+        bus.publish(produced("run-b", "second"))
+        runCurrent()
+
+        assertEquals(listOf("first", "second"), all)
+        collector.cancel()
+    }
+
+    @Test
+    fun `cancelling one collector leaves the other collecting`() = runTest {
+        // The regression that made the pre-existing relay unsafe to share: its teardown
+        // unsubscribed by event type and took every other subscriber down with it.
+        val bus = EventSerialBus(scope = backgroundScope)
+        val leaving = mutableListOf<String>()
+        val staying = mutableListOf<String>()
+
+        val leavingCollector = backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            bus.emissions(runId = "run-1").collect { leaving += proseOf(it) }
+        }
+        val stayingCollector = backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            bus.emissions(runId = "run-1").collect { staying += proseOf(it) }
+        }
+
+        bus.publish(produced("run-1", "before"))
+        runCurrent()
+
+        leavingCollector.cancel()
+        runCurrent()
+
+        bus.publish(produced("run-1", "after"))
+        runCurrent()
+
+        assertEquals(listOf("before"), leaving)
+        assertEquals(listOf("before", "after"), staying)
+        stayingCollector.cancel()
+    }
+
+    @Test
+    fun `a stalled collector drops the oldest emissions and is told how many`() = runTest {
+        val bus = EventSerialBus(scope = backgroundScope)
+        val collected = mutableListOf<String>()
+        val droppedTotals = mutableListOf<Long>()
+
+        val collector = backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            bus.emissions(
+                runId = "run-1",
+                capacity = 2,
+                onDropped = { droppedTotals += it },
+            ).collect {
+                collected += proseOf(it)
+                // Stall past every publish below; virtual time only moves when we let it.
+                delay(10_000)
+            }
+        }
+
+        listOf("one", "two", "three", "four", "five", "six").forEach { text ->
+            bus.publish(produced("run-1", text))
+        }
+        // runCurrent, not advanceUntilIdle: the collector must stay parked in its delay while
+        // the bus dispatches, which is the whole point of the scenario.
+        runCurrent()
+
+        assertEquals(
+            listOf(1L, 2L, 3L),
+            droppedTotals,
+            "Six emissions into a two-slot buffer behind a stalled collector loses three",
+        )
+
+        // Let the collector drain and confirm DROP_OLDEST kept the newest state.
+        advanceTimeBy(60_000)
+        runCurrent()
+        assertEquals(listOf("one", "five", "six"), collected)
+
+        collector.cancel()
+    }
+
+    @Test
+    fun `human input requests arrive on the emission stream`() = runTest {
+        // InputRequested declares EmissionEvent.Produced as a parent type, so the bus dispatches
+        // it to Produced subscribers. A progress surface should see it without special-casing.
+        val bus = EventSerialBus(scope = backgroundScope)
+        val seen = mutableListOf<String>()
+
+        val collector = backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            bus.emissions(runId = "run-1").collect { seen += proseOf(it) }
+        }
+
+        bus.publish(
+            HumanInteractionEvent.InputRequested(
+                eventId = "evt-ask",
+                timestamp = Clock.System.now(),
+                eventSource = EventSource.Agent("agent-A"),
+                urgency = Urgency.HIGH,
+                emission = emission("run-1", "needs-a-human"),
+                requestId = "req-1",
+                agentId = "agent-A",
+            ),
+        )
+        runCurrent()
+
+        assertTrue("needs-a-human" in seen, "Saw $seen")
+        collector.cancel()
+    }
+}

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/domain/arc/bridge/ArcSessionTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/domain/arc/bridge/ArcSessionTest.kt
@@ -1,0 +1,415 @@
+package link.socket.ampere.domain.arc.bridge
+
+import kotlin.io.path.createTempDirectory
+import kotlin.io.path.writeText
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.job
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.datetime.Clock
+import link.socket.ampere.agents.domain.Urgency
+import link.socket.ampere.agents.domain.emission.Emission
+import link.socket.ampere.agents.domain.emission.EmissionKind
+import link.socket.ampere.agents.domain.emission.EmissionPayload
+import link.socket.ampere.agents.domain.emission.EmissionProvenance
+import link.socket.ampere.agents.domain.emission.ProseFormat
+import link.socket.ampere.agents.domain.event.EmissionEvent
+import link.socket.ampere.agents.domain.event.EventSource
+import link.socket.ampere.agents.events.bus.EventSerialBus
+import link.socket.ampere.domain.arc.AmpereRuntime
+import link.socket.ampere.domain.arc.ArcAgentConfig
+import link.socket.ampere.domain.arc.ArcConfig
+import link.socket.ampere.domain.arc.ArcOutcome
+import link.socket.ampere.domain.arc.OrchestrationConfig
+import link.socket.ampere.domain.arc.OrchestrationType
+import link.socket.ampere.domain.arc.TerminationReason
+import okio.Path.Companion.toPath
+
+/**
+ * The Swift-facing Arc execution bridge (AMPR-243).
+ *
+ * Real dispatchers throughout: the whole point of the bridge is that `start` / `observe` /
+ * `cancel` are called from *outside* the run's coroutine, on another thread, which a
+ * single-threaded test dispatcher cannot express. These are the same assertions the Swift
+ * harness makes across the Objective-C boundary — proved here first, where a failure is legible.
+ */
+class ArcSessionTest {
+
+    private val timeoutMillis = 60_000L
+
+    // ---- fixtures ----------------------------------------------------------------------
+
+    /** A temp dir with the AGENTS.md/README.md that ChargePhase requires to produce a context. */
+    private fun arcProjectDir(prefix: String): java.nio.file.Path {
+        val tempDir = createTempDirectory(prefix)
+        tempDir.resolve("README.md").writeText("# BridgeProject\n\nA test project for the Arc bridge.")
+        tempDir.resolve("AGENTS.md").writeText(
+            """
+            # AGENTS
+
+            ## Dependencies
+            - Kotlin
+
+            ## Conventions
+            - Use suspend functions
+
+            ## Architecture
+            - Clean architecture
+            """.trimIndent(),
+        )
+        return tempDir
+    }
+
+    private fun arcConfig(name: String) = ArcConfig(
+        name = name,
+        agents = listOf(ArcAgentConfig(role = "code")),
+        orchestration = OrchestrationConfig(
+            type = OrchestrationType.SEQUENTIAL,
+            order = listOf("code"),
+        ),
+    )
+
+    private fun progressEvent(runId: String, text: String): EmissionEvent.BaseProduced =
+        EmissionEvent.BaseProduced(
+            eventId = "evt-$text",
+            timestamp = Clock.System.now(),
+            eventSource = EventSource.Agent("code"),
+            urgency = Urgency.MEDIUM,
+            emission = Emission(
+                id = "emission-$text",
+                kind = EmissionKind.Prose,
+                payload = EmissionPayload.Prose(text = text, format = ProseFormat.PLAIN),
+                provenance = EmissionProvenance(runId = runId, inputDigest = "digest-$text"),
+                producedAt = Clock.System.now(),
+            ),
+        )
+
+    private fun proseOf(emission: Emission): String =
+        (emission.payload as EmissionPayload.Prose).text
+
+    /** Suspend until Flow has taken at least one tick, so a cancel here is genuinely mid-flight. */
+    private suspend fun awaitFlowUnderway(runtime: AmpereRuntime) {
+        withTimeout(timeoutMillis) {
+            while ((runtime.flowPhase?.getCurrentTick() ?: 0) < 1) {
+                delay(5)
+            }
+        }
+    }
+
+    /** The session's own coroutines are cancelled asynchronously; give them a moment to detach. */
+    private suspend fun awaitNoLiveCoroutines(scope: CoroutineScope, except: Set<Any> = emptySet()) {
+        withTimeout(timeoutMillis) {
+            while (scope.coroutineContext.job.children.any { it !in except }) {
+                delay(5)
+            }
+        }
+    }
+
+    // ---- tests -------------------------------------------------------------------------
+
+    @Test
+    fun `observe delivers progress emissions and cancel halts the run cooperatively`() = runBlocking<Unit> {
+        val projectDir = arcProjectDir("bridge-cancel")
+        val callerScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+        try {
+            val bus = EventSerialBus(scope = callerScope)
+            val runtime = AmpereRuntime(
+                arcConfig = arcConfig("bridge-cancel-arc"),
+                projectDir = projectDir.toString().toPath(),
+                agentScope = callerScope,
+                // Large enough that Flow cannot finish before the cancel lands.
+                maxFlowTicks = Int.MAX_VALUE,
+            )
+            val session = ArcSession(scope = callerScope, runtime = runtime, eventSerialBus = bus)
+
+            val handle = session.start("Implement a very long running goal")
+
+            val seen = Channel<Emission>(Channel.UNLIMITED)
+            val finished = CompletableDeferred<Unit>()
+            handle.observe(
+                onEmission = { seen.trySend(it) },
+                onFinished = { finished.complete(Unit) },
+            )
+
+            awaitFlowUnderway(runtime)
+
+            repeat(3) { index -> bus.publish(progressEvent(handle.runId, "progress-$index")) }
+
+            // A set, not a list: the bus launches each handler as its own coroutine, so events
+            // published back-to-back can be delivered in either order. The bridge inherits that
+            // and does not pretend otherwise.
+            val delivered = withTimeout(timeoutMillis) { List(3) { proseOf(seen.receive()) }.toSet() }
+            assertEquals(setOf("progress-0", "progress-1", "progress-2"), delivered)
+
+            val outcome = withTimeout(timeoutMillis) { assertIs<ArcOutcome.Cancelled>(handle.cancel()) }
+
+            assertEquals(handle.runId, outcome.runId)
+            assertNotNull(outcome.chargeResult, "Charge finished, so it should be reported")
+            assertEquals(
+                TerminationReason.CANCELLED,
+                outcome.flowResult?.terminationReason,
+                "A cancelled Flow must report CANCELLED, not a fallback reason",
+            )
+            assertFalse(runtime.isRunning())
+            assertFalse(handle.isActive)
+
+            // The observation completes on its own when the run ends: a Swift AsyncStream needs
+            // this to call finish() instead of hanging its `for await` loop forever.
+            withTimeout(timeoutMillis) { finished.await() }
+
+            // Nothing the session started outlives the run — no pump, no watcher, no observer.
+            awaitNoLiveCoroutines(callerScope)
+        } finally {
+            callerScope.cancel()
+        }
+    }
+
+    @Test
+    fun `cancel is idempotent and keeps returning the same outcome`() = runBlocking<Unit> {
+        val projectDir = arcProjectDir("bridge-idempotent")
+        val callerScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+        try {
+            val bus = EventSerialBus(scope = callerScope)
+            val runtime = AmpereRuntime(
+                arcConfig = arcConfig("bridge-idempotent-arc"),
+                projectDir = projectDir.toString().toPath(),
+                agentScope = callerScope,
+                maxFlowTicks = Int.MAX_VALUE,
+            )
+            val session = ArcSession(scope = callerScope, runtime = runtime, eventSerialBus = bus)
+
+            val handle = session.start("Implement a very long running goal")
+            awaitFlowUnderway(runtime)
+
+            val first = withTimeout(timeoutMillis) { handle.cancel() }
+            val second = withTimeout(timeoutMillis) { handle.cancel() }
+            val awaited = withTimeout(timeoutMillis) { handle.await() }
+
+            assertIs<ArcOutcome.Cancelled>(first)
+            assertSame(first, second, "A second cancel must report the first one's outcome")
+            assertSame(first, awaited, "await must agree with cancel")
+        } finally {
+            callerScope.cancel()
+        }
+    }
+
+    @Test
+    fun `cancelling before the run is dispatched still halts it`() = runBlocking<Unit> {
+        // The stop button can be pressed in the same breath as the start button. The runtime
+        // holds no cancellable job until execute() is under way, so this races that window
+        // deliberately — it must not run the Arc to completion.
+        val projectDir = arcProjectDir("bridge-early-cancel")
+        val callerScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+        try {
+            val bus = EventSerialBus(scope = callerScope)
+            val runtime = AmpereRuntime(
+                arcConfig = arcConfig("bridge-early-cancel-arc"),
+                projectDir = projectDir.toString().toPath(),
+                agentScope = callerScope,
+                maxFlowTicks = Int.MAX_VALUE,
+            )
+            val session = ArcSession(scope = callerScope, runtime = runtime, eventSerialBus = bus)
+
+            val handle = session.start("Implement a very long running goal")
+            val outcome = withTimeout(timeoutMillis) { handle.cancel() }
+
+            assertIs<ArcOutcome.Cancelled>(outcome)
+            assertFalse(runtime.isRunning())
+        } finally {
+            callerScope.cancel()
+        }
+    }
+
+    @Test
+    fun `a run that completes reports Completed and finishes its observers`() = runBlocking<Unit> {
+        val projectDir = arcProjectDir("bridge-complete")
+        val callerScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+        try {
+            val bus = EventSerialBus(scope = callerScope)
+            val runtime = AmpereRuntime(
+                arcConfig = arcConfig("bridge-complete-arc"),
+                projectDir = projectDir.toString().toPath(),
+                agentScope = callerScope,
+                maxFlowTicks = 1,
+            )
+            val session = ArcSession(scope = callerScope, runtime = runtime, eventSerialBus = bus)
+
+            val handle = session.start("Add a health check endpoint")
+
+            val finished = CompletableDeferred<Unit>()
+            handle.observe(onEmission = { }, onFinished = { finished.complete(Unit) })
+
+            val outcome = withTimeout(timeoutMillis) { assertIs<ArcOutcome.Completed>(handle.await()) }
+            assertEquals(handle.runId, outcome.runId)
+
+            withTimeout(timeoutMillis) { finished.await() }
+            awaitNoLiveCoroutines(callerScope)
+
+            // No projection was supplied, so there is no ledger to fold — and the bridge says so
+            // rather than inventing one.
+            assertNull(handle.trace())
+        } finally {
+            callerScope.cancel()
+        }
+    }
+
+    @Test
+    fun `an observer cancelled by the consumer stops receiving without disturbing the others`() =
+        runBlocking<Unit> {
+            val projectDir = arcProjectDir("bridge-observer")
+            val callerScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+            try {
+                val bus = EventSerialBus(scope = callerScope)
+                val runtime = AmpereRuntime(
+                    arcConfig = arcConfig("bridge-observer-arc"),
+                    projectDir = projectDir.toString().toPath(),
+                    agentScope = callerScope,
+                    maxFlowTicks = Int.MAX_VALUE,
+                )
+                val session = ArcSession(scope = callerScope, runtime = runtime, eventSerialBus = bus)
+
+                val handle = session.start("Implement a very long running goal")
+                awaitFlowUnderway(runtime)
+
+                val leaving = Channel<Emission>(Channel.UNLIMITED)
+                val staying = Channel<Emission>(Channel.UNLIMITED)
+                val leavingToken = handle.observe { leaving.trySend(it) }
+                handle.observe { staying.trySend(it) }
+
+                bus.publish(progressEvent(handle.runId, "before"))
+                assertEquals("before", withTimeout(timeoutMillis) { proseOf(leaving.receive()) })
+                assertEquals("before", withTimeout(timeoutMillis) { proseOf(staying.receive()) })
+
+                leavingToken.cancel()
+                assertTrue(leavingToken.isCancelled)
+
+                bus.publish(progressEvent(handle.runId, "after"))
+                assertEquals("after", withTimeout(timeoutMillis) { proseOf(staying.receive()) })
+                assertNull(leaving.tryReceive().getOrNull(), "A cancelled observer must go quiet")
+
+                withTimeout(timeoutMillis) { handle.cancel() }
+            } finally {
+                callerScope.cancel()
+            }
+        }
+
+    @Test
+    fun `a late observer is caught up from the replay buffer`() = runBlocking<Unit> {
+        // Swift attaches its progress stream in a `Task { }` on the line after `start`, which is
+        // a scheduling hop later. The opening of the run must not fall through that gap.
+        val projectDir = arcProjectDir("bridge-replay")
+        val callerScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+        try {
+            val bus = EventSerialBus(scope = callerScope)
+            val runtime = AmpereRuntime(
+                arcConfig = arcConfig("bridge-replay-arc"),
+                projectDir = projectDir.toString().toPath(),
+                agentScope = callerScope,
+                maxFlowTicks = Int.MAX_VALUE,
+            )
+            val session = ArcSession(scope = callerScope, runtime = runtime, eventSerialBus = bus)
+
+            val handle = session.start("Implement a very long running goal")
+
+            bus.publish(progressEvent(handle.runId, "opening"))
+
+            val late = Channel<Emission>(Channel.UNLIMITED)
+            handle.observe { late.trySend(it) }
+
+            assertEquals("opening", withTimeout(timeoutMillis) { proseOf(late.receive()) })
+
+            withTimeout(timeoutMillis) { handle.cancel() }
+        } finally {
+            callerScope.cancel()
+        }
+    }
+
+    @Test
+    fun `create builds a session that owns its own scope and bus`() = runBlocking<Unit> {
+        // The Swift-facing entry point: nothing in its signature is a coroutine type, because
+        // kotlinx.coroutines does not cross the Objective-C boundary. Exercised here so a change
+        // that reintroduces a CoroutineScope parameter fails on the JVM first.
+        val projectDir = arcProjectDir("bridge-owned-scope")
+        val session = ArcSession.create(
+            arcConfig = arcConfig("bridge-owned-arc"),
+            projectDirPath = projectDir.toString(),
+            maxFlowTicks = 1,
+        )
+
+        try {
+            val handle = session.start("Add a health check endpoint")
+
+            val finished = CompletableDeferred<Unit>()
+            handle.observe(onEmission = { }, onFinished = { finished.complete(Unit) })
+
+            val outcome = withTimeout(timeoutMillis) { assertIs<ArcOutcome.Completed>(handle.await()) }
+            assertEquals(handle.runId, outcome.runId)
+            withTimeout(timeoutMillis) { finished.await() }
+        } finally {
+            session.close()
+        }
+
+        // close() is idempotent, so a Swift deinit can call it without tracking whether it ran.
+        session.close()
+    }
+
+    @Test
+    fun `start rejects a blank goal and a runtime that is already running`() = runBlocking<Unit> {
+        val projectDir = arcProjectDir("bridge-guards")
+        val callerScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+        try {
+            val bus = EventSerialBus(scope = callerScope)
+            val runtime = AmpereRuntime(
+                arcConfig = arcConfig("bridge-guards-arc"),
+                projectDir = projectDir.toString().toPath(),
+                agentScope = callerScope,
+                maxFlowTicks = Int.MAX_VALUE,
+            )
+            val session = ArcSession(scope = callerScope, runtime = runtime, eventSerialBus = bus)
+
+            assertFailsWithMessage<IllegalArgumentException>("User goal cannot be blank") {
+                session.start("   ")
+            }
+
+            val handle = session.start("Implement a very long running goal")
+            awaitFlowUnderway(runtime)
+
+            assertFailsWithMessage<IllegalStateException>("Runtime is already executing") {
+                session.start("A second goal")
+            }
+
+            withTimeout(timeoutMillis) { handle.cancel() }
+        } finally {
+            callerScope.cancel()
+        }
+    }
+
+    private inline fun <reified T : Throwable> assertFailsWithMessage(
+        expected: String,
+        block: () -> Unit,
+    ) {
+        val thrown = kotlin.test.assertFailsWith<T> { block() }
+        assertEquals(expected, thrown.message)
+    }
+}

--- a/ampere-eval/src/commonMain/kotlin/link/socket/ampere/eval/trace/TraceRecorder.kt
+++ b/ampere-eval/src/commonMain/kotlin/link/socket/ampere/eval/trace/TraceRecorder.kt
@@ -46,7 +46,7 @@ class TraceRecorder(
         val buffer = Channel<Event>(Channel.UNLIMITED)
         val agentId = "trace-recorder/$runId/${idGenerator()}"
 
-        eventTypes.forEach { eventType ->
+        val subscriptions = eventTypes.map { eventType ->
             bus.subscribe(
                 agentId = agentId,
                 eventType = eventType,
@@ -62,7 +62,7 @@ class TraceRecorder(
             arcId = arcId,
             createdAt = clockMillis(),
             buffer = buffer,
-            subscribedTypes = eventTypes,
+            subscriptions = subscriptions,
             bus = bus,
             traceService = traceService,
             json = json,
@@ -79,7 +79,7 @@ class RecordingHandle internal constructor(
     private val arcId: String,
     private val createdAt: Long,
     private val buffer: Channel<Event>,
-    private val subscribedTypes: List<EventType>,
+    private val subscriptions: List<Subscription>,
     private val bus: EventSerialBus,
     private val traceService: TraceService,
     private val json: Json,
@@ -92,10 +92,9 @@ class RecordingHandle internal constructor(
      * channel is drained once; call exactly once.
      */
     suspend fun stop(): Result<Trace> {
-        // Stop receiving new events. NOTE: EventSerialBus.unsubscribe removes ALL
-        // handlers for a type (see RECON-trace.md §1) — fine for eval-controlled
-        // runs where the recorder is the sole subscriber.
-        subscribedTypes.forEach { bus.unsubscribe(it) }
+        // Stop receiving new events. Released per subscription, so a recorder running
+        // alongside other bus subscribers takes only its own handlers with it.
+        subscriptions.forEach { bus.unsubscribe(it) }
         buffer.close()
 
         // Dedup by eventId: an event with parentEventTypes is dispatched to more

--- a/ampere-ios/ampere-ios.xcodeproj/project.pbxproj
+++ b/ampere-ios/ampere-ios.xcodeproj/project.pbxproj
@@ -11,6 +11,9 @@
 		058557D9273AAEEB004C7B11 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */; };
 		2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152FB032600AC8F00CF470E /* iOSApp.swift */; };
 		7555FF83242A565900829871 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7555FF82242A565900829871 /* ContentView.swift */; };
+		AC243AAAAAAAAAAAAAAA0003 /* ArcExecutionBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC243AAAAAAAAAAAAAAA0002 /* ArcExecutionBridgeTests.swift */; };
+		AC243AAAAAAAAAAAAAAA0005 /* ArcRunHandle+AsyncStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC243AAAAAAAAAAAAAAA0004 /* ArcRunHandle+AsyncStream.swift */; };
+		AC243AAAAAAAAAAAAAAA0010 /* ArcRunHandle+AsyncStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC243AAAAAAAAAAAAAAA0004 /* ArcRunHandle+AsyncStream.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -21,10 +24,30 @@
 		7555FF82242A565900829871 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		7555FF8C242A565B00829871 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AB3632DC29227652001CCB65 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
+		AC243AAAAAAAAAAAAAAA0001 /* ampere-iosTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ampere-iosTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		AC243AAAAAAAAAAAAAAA0002 /* ArcExecutionBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArcExecutionBridgeTests.swift; sourceTree = "<group>"; };
+		AC243AAAAAAAAAAAAAAA0004 /* ArcRunHandle+AsyncStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ArcRunHandle+AsyncStream.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
+
+/* Begin PBXContainerItemProxy section */
+		AC243AAAAAAAAAAAAAAA000B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7555FF73242A565900829871 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7555FF7A242A565900829871;
+			remoteInfo = "ampere-ios";
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		F85CB1118929364A9C6EFABC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AC243AAAAAAAAAAAAAAA0008 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -54,6 +77,7 @@
 			children = (
 				AB1DB47929225F7C00F7AF9C /* Configuration */,
 				7555FF7D242A565900829871 /* ampere-ios */,
+				AC243AAAAAAAAAAAAAAA0006 /* ampere-iosTests */,
 				7555FF7C242A565900829871 /* Products */,
 				42799AB246E5F90AF97AA0EF /* Frameworks */,
 			);
@@ -63,6 +87,7 @@
 			isa = PBXGroup;
 			children = (
 				7555FF7B242A565900829871 /* Ampere.app */,
+				AC243AAAAAAAAAAAAAAA0001 /* ampere-iosTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -74,6 +99,7 @@
 				7555FF82242A565900829871 /* ContentView.swift */,
 				7555FF8C242A565B00829871 /* Info.plist */,
 				2152FB032600AC8F00CF470E /* iOSApp.swift */,
+				AC243AAAAAAAAAAAAAAA0004 /* ArcRunHandle+AsyncStream.swift */,
 				058557D7273AAEEB004C7B11 /* Preview Content */,
 			);
 			path = iosApp;
@@ -85,6 +111,14 @@
 				AB3632DC29227652001CCB65 /* Config.xcconfig */,
 			);
 			path = Configuration;
+			sourceTree = "<group>";
+		};
+		AC243AAAAAAAAAAAAAAA0006 /* ampere-iosTests */ = {
+			isa = PBXGroup;
+			children = (
+				AC243AAAAAAAAAAAAAAA0002 /* ArcExecutionBridgeTests.swift */,
+			);
+			path = iosAppTests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -108,6 +142,24 @@
 			productReference = 7555FF7B242A565900829871 /* Ampere.app */;
 			productType = "com.apple.product-type.application";
 		};
+		AC243AAAAAAAAAAAAAAA000A /* ampere-iosTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AC243AAAAAAAAAAAAAAA000F /* Build configuration list for PBXNativeTarget "ampere-iosTests" */;
+			buildPhases = (
+				AC243AAAAAAAAAAAAAAA0007 /* Sources */,
+				AC243AAAAAAAAAAAAAAA0008 /* Frameworks */,
+				AC243AAAAAAAAAAAAAAA0009 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				AC243AAAAAAAAAAAAAAA000C /* PBXTargetDependency */,
+			);
+			name = "ampere-iosTests";
+			productName = "ampere-iosTests";
+			productReference = AC243AAAAAAAAAAAAAAA0001 /* ampere-iosTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -120,6 +172,9 @@
 				TargetAttributes = {
 					7555FF7A242A565900829871 = {
 						CreatedOnToolsVersion = 11.3.1;
+					};
+					AC243AAAAAAAAAAAAAAA000A = {
+						TestTargetID = 7555FF7A242A565900829871;
 					};
 				};
 			};
@@ -137,6 +192,7 @@
 			projectRoot = "";
 			targets = (
 				7555FF7A242A565900829871 /* ampere-ios */,
+				AC243AAAAAAAAAAAAAAA000A /* ampere-iosTests */,
 			);
 		};
 /* End PBXProject section */
@@ -148,6 +204,13 @@
 			files = (
 				058557D9273AAEEB004C7B11 /* Preview Assets.xcassets in Resources */,
 				058557BB273AAA24004C7B11 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AC243AAAAAAAAAAAAAAA0009 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -174,6 +237,14 @@
 		};
 /* End PBXShellScriptBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		AC243AAAAAAAAAAAAAAA000C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 7555FF7A242A565900829871 /* ampere-ios */;
+			targetProxy = AC243AAAAAAAAAAAAAAA000B /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin PBXSourcesBuildPhase section */
 		7555FF77242A565900829871 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
@@ -181,6 +252,16 @@
 			files = (
 				2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */,
 				7555FF83242A565900829871 /* ContentView.swift in Sources */,
+				AC243AAAAAAAAAAAAAAA0005 /* ArcRunHandle+AsyncStream.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AC243AAAAAAAAAAAAAAA0007 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AC243AAAAAAAAAAAAAAA0010 /* ArcRunHandle+AsyncStream.swift in Sources */,
+				AC243AAAAAAAAAAAAAAA0003 /* ArcExecutionBridgeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -239,7 +320,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -295,7 +376,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
@@ -318,8 +399,9 @@
 					"$(inherited)",
 					"$(SRCROOT)/../ampere-core/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)",
 				);
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				INFOPLIST_FILE = iosApp/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -327,7 +409,7 @@
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-framework",
-					"ampere-core",
+					shared,
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID}${TEAM_ID}";
 				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = link.socket.ampere;
@@ -351,8 +433,9 @@
 					"$(inherited)",
 					"$(SRCROOT)/../ampere-core/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)",
 				);
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				INFOPLIST_FILE = iosApp/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -360,7 +443,7 @@
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-framework",
-					"ampere-core",
+					shared,
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID}${TEAM_ID}";
 				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = link.socket.ampere;
@@ -368,6 +451,70 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		AC243AAAAAAAAAAAAAAA000D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB3632DC29227652001CCB65 /* Config.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../ampere-core/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)",
+				);
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-framework",
+					shared,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID}.tests${TEAM_ID}";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/${APP_NAME}.app/${APP_NAME}";
+			};
+			name = Debug;
+		};
+		AC243AAAAAAAAAAAAAAA000E /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB3632DC29227652001CCB65 /* Config.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../ampere-core/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)",
+				);
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-framework",
+					shared,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID}.tests${TEAM_ID}";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/${APP_NAME}.app/${APP_NAME}";
 			};
 			name = Release;
 		};
@@ -388,6 +535,15 @@
 			buildConfigurations = (
 				7555FFA6242A565B00829871 /* Debug */,
 				7555FFA7242A565B00829871 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		AC243AAAAAAAAAAAAAAA000F /* Build configuration list for PBXNativeTarget "ampere-iosTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AC243AAAAAAAAAAAAAAA000D /* Debug */,
+				AC243AAAAAAAAAAAAAAA000E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ampere-ios/iosApp/ArcRunHandle+AsyncStream.swift
+++ b/ampere-ios/iosApp/ArcRunHandle+AsyncStream.swift
@@ -1,0 +1,52 @@
+import Foundation
+import shared
+
+/// Swift's view of a running Arc.
+///
+/// This extension is the only hand-written part of the KMP↔Swift Arc bridge. Everything else —
+/// `start`, `await`, `observe`, `cancel` — crosses the boundary as a plain Objective-C export,
+/// which Swift re-imports as `async`. The one thing the export cannot do is turn a Kotlin
+/// callback into an `AsyncSequence`, so that is what lives here.
+///
+/// Deliberately shaped like what SKIE would emit. If the project adopts SKIE later, this file
+/// goes away and no call site changes.
+///
+/// ```swift
+/// let session = ArcSession.companion.create(
+///     arcConfig: ArcRegistry.shared.getDefault(),
+///     projectDirPath: projectPath,
+///     maxFlowTicks: 100
+/// )
+/// let handle = session.start(userGoal: goal)
+///
+/// Task { for await emission in handle.emissions { await reporter.update(emission) } }
+/// let outcome = try await handle.outcome()
+/// ```
+extension ArcRunHandle {
+
+    /// This run's progress Emissions, in the order the bus delivered them.
+    ///
+    /// The stream finishes on its own when the run reaches a terminal outcome, so a `for await`
+    /// loop ends without being told to — which is what keeps a `ProgressReportingIntent` from
+    /// hanging on a run that is already over. Breaking out of the loop, or cancelling the
+    /// enclosing `Task`, releases the underlying bus subscription.
+    ///
+    /// Buffering is `.unbounded` here because the Kotlin side already applies the overflow
+    /// policy: a collector that falls behind loses the *oldest* Emissions and is told how many.
+    /// Adding a second bound on this side would drop the newest instead.
+    var emissions: AsyncStream<Emission> {
+        AsyncStream(Emission.self, bufferingPolicy: .unbounded) { continuation in
+            let token = self.observe(
+                onEmission: { emission in continuation.yield(emission) },
+                onFinished: { continuation.finish() }
+            )
+            continuation.onTermination = { _ in token.cancel() }
+        }
+    }
+
+    /// The run's terminal outcome — the same call as `await()`, under a name that does not read
+    /// as a keyword at the call site.
+    func outcome() async throws -> ArcOutcome {
+        try await self.`await`()
+    }
+}

--- a/ampere-ios/iosAppTests/ArcExecutionBridgeTests.swift
+++ b/ampere-ios/iosAppTests/ArcExecutionBridgeTests.swift
@@ -1,0 +1,223 @@
+import XCTest
+import shared
+
+/// The Arc execution bridge, exercised across the Objective-C boundary (AMPR-243).
+///
+/// The Kotlin-side behaviour is pinned by `ArcSessionTest` (JVM) and `EmissionStreamTest`
+/// (JVM + iOS Native). What can only be proved *here* is that the export survives: that Swift
+/// can build a session without touching a `CoroutineScope`, drive `async` methods off the main
+/// actor, consume the progress stream as an `AsyncSequence`, and pattern-match the Emission
+/// hierarchy after it has been flattened into Objective-C classes.
+final class ArcExecutionBridgeTests: XCTestCase {
+
+    private var projectDir: URL!
+    private var session: ArcSession?
+
+    override func setUpWithError() throws {
+        projectDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("arc-bridge-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: projectDir, withIntermediateDirectories: true)
+
+        // ChargePhase reads its project context from these two files.
+        try "# BridgeProject\n\nA test project for the Arc bridge.\n"
+            .write(to: projectDir.appendingPathComponent("README.md"), atomically: true, encoding: .utf8)
+        try """
+        # AGENTS
+
+        ## Dependencies
+        - Kotlin
+
+        ## Conventions
+        - Use suspend functions
+
+        ## Architecture
+        - Clean architecture
+        """.write(to: projectDir.appendingPathComponent("AGENTS.md"), atomically: true, encoding: .utf8)
+    }
+
+    override func tearDownWithError() throws {
+        session?.close()
+        session = nil
+        try? FileManager.default.removeItem(at: projectDir)
+    }
+
+    private func makeSession(maxFlowTicks: Int32) -> ArcSession {
+        // Every argument is something Swift can build. That is the point of the factory:
+        // kotlinx.coroutines is not exported, so `CoroutineScope` has no Swift constructor and
+        // the three-argument `ArcSession.init` is unreachable from here.
+        let session = ArcSession.companion.create(
+            arcConfig: ArcRegistry.shared.getDefault(),
+            projectDirPath: projectDir.path,
+            maxFlowTicks: maxFlowTicks
+        )
+        self.session = session
+        return session
+    }
+
+    private func progressEvent(runId: String, text: String) -> EmissionEventBaseProduced {
+        EmissionEventBaseProduced(
+            eventId: "evt-\(text)",
+            timestamp: Kotlinx_datetimeInstant.Companion.shared.fromEpochMilliseconds(
+                epochMilliseconds: Int64(Date().timeIntervalSince1970 * 1000)
+            ),
+            // Nested, not flattened: EventSource is a sealed *class*, so the export keeps the
+            // nesting. The sealed *interfaces* below (EmissionKind, EmissionPayload) do not.
+            eventSource: EventSource.Agent(agentId: "code"),
+            urgency: Urgency.medium,
+            emission: Emission(
+                id: "emission-\(text)",
+                kind: EmissionKindProse(),
+                payload: EmissionPayloadProse(text: text, format: .plain),
+                affordances: [],
+                confidence: nil,
+                provenance: EmissionProvenance(
+                    runId: runId,
+                    workflowId: nil,
+                    sourceEventId: nil,
+                    toolInvocationId: nil,
+                    plugId: nil,
+                    modelId: nil,
+                    inputDigest: "digest-\(text)"
+                ),
+                dedupKey: nil,
+                producedAt: Kotlinx_datetimeInstant.Companion.shared.fromEpochMilliseconds(
+                    epochMilliseconds: Int64(Date().timeIntervalSince1970 * 1000)
+                ),
+                surfaces: [],
+                fallbackUrl: nil
+            )
+        )
+    }
+
+    /// The launch scenario end to end: start an Arc, watch progress arrive on the `AsyncStream`,
+    /// then cancel mid-flight and get a settled `Cancelled` back.
+    ///
+    /// This is a `ProgressReportingIntent` plus a `CancellableIntent`, minus the App Intents.
+    func testObserveProgressThenCancelMidFlight() async throws {
+        let session = makeSession(maxFlowTicks: Int32.max)
+        let handle = session.start(userGoal: "Implement a very long running goal")
+
+        let expected = 3
+        let received = XCTestExpectation(description: "\(expected) progress Emissions observed")
+        received.expectedFulfillmentCount = expected
+
+        var texts: [String] = []
+        let collected = _Concurrency.Task { () -> [String] in
+            for await emission in handle.emissions {
+                if let prose = emission.payload as? EmissionPayloadProse {
+                    texts.append(prose.text)
+                    received.fulfill()
+                }
+            }
+            return texts
+        }
+
+        for index in 0..<expected {
+            try await session.bus.publish(event: progressEvent(runId: handle.runId, text: "progress-\(index)"))
+        }
+        await fulfillment(of: [received], timeout: 30)
+
+        let outcome = try await handle.cancel()
+        XCTAssertTrue(outcome is ArcOutcomeCancelled, "Expected Cancelled, got \(outcome)")
+
+        // Cancelling ends the run, which ends the stream, which lets this task return.
+        let seen = await collected.value
+        XCTAssertEqual(
+            Set(seen),
+            Set((0..<expected).map { "progress-\($0)" }),
+            "Every published Emission must reach the Swift consumer"
+        )
+    }
+
+    /// A run that is allowed to finish reports `Completed`, and its progress stream ends with it.
+    func testRunCompletesAndFinishesItsEmissionStream() async throws {
+        let session = makeSession(maxFlowTicks: 1)
+        let handle = session.start(userGoal: "Add a health check endpoint")
+
+        // Draining the stream must terminate. If `onFinished` never crossed the boundary this
+        // would hang until the test timeout rather than fail — which is the bug worth catching,
+        // because a Live Activity would hang the same way.
+        let drained = _Concurrency.Task { () -> Int in
+            var count = 0
+            for await _ in handle.emissions { count += 1 }
+            return count
+        }
+
+        let outcome = try await handle.outcome()
+        XCTAssertTrue(outcome is ArcOutcomeCompleted, "Expected Completed, got \(outcome)")
+        XCTAssertEqual(outcome.runId, handle.runId)
+
+        _ = await drained.value
+        XCTAssertFalse(handle.isActive)
+    }
+
+    /// The stop button: `cancel` halts a run in flight and settles before it returns.
+    func testCancelHaltsARunInFlight() async throws {
+        let session = makeSession(maxFlowTicks: Int32.max)
+        let handle = session.start(userGoal: "Implement a very long running goal")
+
+        let outcome = try await handle.cancel()
+
+        XCTAssertTrue(outcome is ArcOutcomeCancelled, "Expected Cancelled, got \(outcome)")
+        XCTAssertEqual(outcome.runId, handle.runId)
+        XCTAssertFalse(handle.isActive)
+
+        // Idempotent, so a stop button can be pressed twice without special-casing.
+        let again = try await handle.cancel()
+        XCTAssertTrue(again is ArcOutcomeCancelled)
+    }
+
+    /// Phase-2 empirical check 1: an App Intent's `perform()` is not guaranteed to run on the
+    /// main actor, so the exported suspend functions have to work off it.
+    func testSuspendFunctionsWorkOffTheMainActor() async throws {
+        let session = makeSession(maxFlowTicks: Int32.max)
+        let handle = session.start(userGoal: "Implement a very long running goal")
+
+        let outcome = try await _Concurrency.Task.detached(priority: .background) { () -> ArcOutcome in
+            XCTAssertFalse(Thread.isMainThread, "Precondition: this must not be the main thread")
+            return try await handle.cancel()
+        }.value
+
+        XCTAssertTrue(outcome is ArcOutcomeCancelled, "Expected Cancelled, got \(outcome)")
+    }
+
+    /// Phase-2 empirical check 2: `EmissionKind` and `EmissionPayload` are Kotlin sealed
+    /// interfaces, which the Objective-C export flattens into unrelated classes. Exhaustive
+    /// matching is gone; this pins that non-exhaustive matching still works, which is all a
+    /// renderer needs.
+    func testEmissionHierarchiesArePatternMatchable() throws {
+        let payload: EmissionPayload = EmissionPayloadProse(text: "hello", format: .plain)
+        let kind: EmissionKind = EmissionKindProse()
+
+        switch payload {
+        case let prose as EmissionPayloadProse:
+            XCTAssertEqual(prose.text, "hello")
+            XCTAssertEqual(prose.format, ProseFormat.plain)
+        case is EmissionPayloadDecision, is EmissionPayloadConfirmation, is EmissionPayloadSensor:
+            XCTFail("Prose payload matched the wrong case")
+        default:
+            XCTFail("Prose payload matched no case at all")
+        }
+
+        XCTAssertTrue(kind is EmissionKindProse)
+        XCTAssertFalse(kind is EmissionKindSensor)
+    }
+
+    /// Cancelling the consuming `Task` releases the bus subscription rather than leaking it.
+    func testCancellingTheConsumerReleasesTheObservation() async throws {
+        let session = makeSession(maxFlowTicks: Int32.max)
+        let handle = session.start(userGoal: "Implement a very long running goal")
+
+        let consumer = _Concurrency.Task {
+            for await _ in handle.emissions { /* drained until cancelled */ }
+        }
+        consumer.cancel()
+        _ = await consumer.result
+
+        // The run is untouched by the consumer going away.
+        XCTAssertTrue(handle.isActive)
+
+        let outcome = try await handle.cancel()
+        XCTAssertTrue(outcome is ArcOutcomeCancelled)
+    }
+}

--- a/ampere-phosphor/src/commonMain/kotlin/link/socket/ampere/phosphor/AmperePhosphorBridge.kt
+++ b/ampere-phosphor/src/commonMain/kotlin/link/socket/ampere/phosphor/AmperePhosphorBridge.kt
@@ -45,7 +45,7 @@ class AmperePhosphorBridge(
 ) {
     private val mutex = Mutex()
     private var pendingAtmosphere: AtmosphereState? = null
-    private val subscribedEventTypes: MutableList<EventType> = mutableListOf()
+    private val subscriptions: MutableList<Subscription> = mutableListOf()
     private var started: Boolean = false
 
     /** Register handlers on the bus. Subsequent calls while started are no-ops. */
@@ -71,29 +71,26 @@ class AmperePhosphorBridge(
     /**
      * Unsubscribe the bridge's handlers from the bus.
      *
-     * Note: [EventSerialBus.unsubscribe] removes every handler registered for
-     * the affected event types, not just the bridge's. Consumers that share
-     * those event types with other subscribers should defer [stop] until those
-     * subscribers are also being torn down.
+     * Released per subscription, so other subscribers on the same event types keep
+     * receiving events after the bridge stops.
      */
     fun stop() {
         if (!started) return
         started = false
-        for (eventType in subscribedEventTypes) {
-            bus.unsubscribe(eventType)
+        for (subscription in subscriptions) {
+            bus.unsubscribe(subscription)
         }
-        subscribedEventTypes.clear()
+        subscriptions.clear()
     }
 
     private fun register(eventType: EventType, dispatch: suspend (Event) -> Unit) {
-        bus.subscribe(
+        subscriptions += bus.subscribe(
             agentId = agentId,
             eventType = eventType,
             handler = EventHandler<Event, Subscription> { event, _ ->
                 if (started) dispatch(event)
             },
         )
-        subscribedEventTypes += eventType
     }
 
     /**

--- a/docs/concepts/event-serial-bus.md
+++ b/docs/concepts/event-serial-bus.md
@@ -51,7 +51,8 @@ properties for free:
 
 ## Where it lives
 
-- `ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/bus/EventSerialBus.kt` — the bus itself; `publish`, `publishAsync`, `subscribe`, `unsubscribe`.
+- `ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/bus/EventSerialBus.kt` — the bus itself; `publish`, `publishAsync`, `subscribe`/`subscribeSuspending`, `unsubscribe`/`unsubscribeSuspending`.
+- `agents/events/relay/EmissionStream.kt` — `EventSerialBus.emissions(runId)`, the per-run Emission Flow the Swift Arc bridge streams progress through.
 - `agents/events/bus/EventSerialBusFactory.kt` — wiring the bus into the application graph.
 - `agents/events/api/AgentEventApi.kt` — the agent-facing facade for emitting events without touching the bus directly.
 - `agents/events/relay/EventRelayService.kt` — out-of-process bridging (e.g., CLI streaming).
@@ -70,12 +71,17 @@ properties for free:
 - **The bus does not persist; loggers and stores do.** A change that makes `EventSerialBus.publish` write to a database directly violates the layering — persistence belongs to `EventStore` invoked by an event-aware logger or projector.
 - **`run_id` is propagated through the event chain.** Events emitted within an Arc run carry the originating `run_id` so trace projection can find them. Lossy event handlers that strip `run_id` break time-travel.
 - **No mutex held across handler invocation.** The bus snapshots handlers under the mutex and releases before launching coroutines. A change that holds `mutex` while running handlers would serialize the entire system.
+- **A subscription is a handle, not a label.** `unsubscribe(subscription)` removes exactly the handler that subscription was minted for, matched by object identity. Identity, not equality: two subscribers with the same `agentId` on the same event type produce equal `subscriptionId`s, so a value comparison would release both. The `unsubscribe(eventType)` overload is the blunt instrument — it removes every handler for that type — and exists only for callers that genuinely own the type.
+- **A Flow built on the bus tears down only itself.** Any adapter that turns bus callbacks into a `Flow` must release per subscription on cancellation. Unsubscribing by event type from a cancelled collector silences every other subscriber on those types — with no filters, every type in `EventRegistry`, including the emission reply routers an Arc depends on to receive replies.
+- **Overflow is a policy, never an accident.** A bus→Flow adapter buffers with an explicit `BufferOverflow` and reports what it dropped. A bare `trySend` into a default-capacity channel discards its own return value, so a slow consumer loses events with no signal at all.
 
 ## Common operations
 
 - **Publish an event** — `agentEventApi.publish(SomeEvent(...))`. The api wraps the bus and is the agent-facing entry point.
 - **Publish from a synchronous boundary hook** — use `EventSerialBus.publishAsync(event)` only when the caller cannot suspend, such as phase boundary hooks. Prefer `AgentEventApi.publish` elsewhere.
-- **Subscribe** — `bus.subscribe(eventType, scope) { event, subscription -> ... }`. Hold onto the returned `EventSubscription` so you can `unsubscribe` on shutdown.
+- **Subscribe** — `bus.subscribe(eventType, scope) { event, subscription -> ... }`. Hold onto the returned `EventSubscription` and pass *that instance* to `unsubscribe` on shutdown.
+- **Subscribe from a coroutine** — `bus.subscribeSuspending(...)` / `unsubscribeSuspending(...)`. The non-suspending overloads take the bus mutex under `runBlockingCompat`, which blocks the calling thread and throws outright on JS/WasmJS. Anything that can suspend — every Flow builder, every Swift-facing bridge — uses the suspending pair.
+- **Stream one Arc's Emissions** — `bus.emissions(runId, capacity, onDropped)` in `events/relay/EmissionStream.kt`. Per-collector subscription, `DROP_OLDEST`, and a running count of what was lost.
 - **Add a new event type** — extend `Event` (or the appropriate sub-sealed family in `agents/domain/event/`), register a `@Serializable` subclass with a stable `@SerialName`, add a CLI display handler, and add a logger summary in `Event.getSummary` if relevant.
 - **Observe phase transitions** — subscribe to `CognitivePhaseEvent.PhaseEntered.EVENT_TYPE` and/or `PhaseExited.EVENT_TYPE`; use `nestingDepth == 0` for outermost phase changes only.
 - **Publish an agent milestone** — call `AgentEventApi.reachMilestone(...)` or, for observable agents, `agent.reachMilestone(...)`. Milestones emit `MemoryEvent.MilestoneReached`, a low-volume sibling event to routine memory writes.
@@ -88,3 +94,5 @@ properties for free:
 - **Using `runBlocking` inside a handler.** Handlers run on the bus's `CoroutineScope`. Blocking that scope blocks the next dispatch loop. Suspend functions only.
 - **Emitting events outside an agent's `AgentEventApi`.** Direct `bus.publish` calls in domain code skip the source-tagging the api adds, which means the trace can't attribute the event to an agent.
 - **Persisting state in the bus.** The bus is a router. Anything that needs persistence belongs in a store one layer up.
+- **Unsubscribing by event type from a shared consumer.** It reads like "stop listening" and behaves like "nobody listens." Use the `Subscription` handle unless you are certain you are the only subscriber on that type, and say so in a comment if you are.
+- **Exposing `subscribe` across the FFI boundary.** It calls `runBlockingCompat`, so a Swift call from the main thread blocks the UI and can deadlock on Kotlin/Native. Swift gets a Flow or a callback facade, never the bus.


### PR DESCRIPTION
Adds `ArcSession` / `ArcRunHandle` / `ArcCancellable` in commonMain so an Arc can be started, observed, and cancelled from Swift — the surface App Intents and the Siri provider ([SCKT-412](https://linear.app/miley/issue/SCKT-412)) are hard-blocked on — plus the Xcode test target, `AsyncStream` adapter, and `xcodebuild test` in CI.

The bus was the obstacle: `EventSerialBus.unsubscribe` removed *every* handler for an event type, so one cancelled collector silenced all other subscribers (including the emission reply routers an Arc depends on); it now holds per-subscription handles matched by object identity, gains non-blocking `subscribeSuspending`/`unsubscribeSuspending`, and exposes `emissions(runId)` — a per-run Flow with `DROP_OLDEST` and a running count of what it dropped, since the old `trySend` discarded its return value and lost Emissions silently.

Three things the recon missed, all found by actually building it: `kotlinx.coroutines` is not an `export()`ed dependency so the ticket's proposed `ArcSession(scope:runtime:eventSerialBus:)` is unreachable from Swift (hence `Companion.create`), the iOS app target never linked (`-framework ampere-core` vs `shared.framework`), and `AmpereRuntime.cancel()` was silently dropped when it raced the start of a run.

Two deliberate deviations: `cancel()` returns `ArcOutcome` rather than `ArcOutcome.Cancelled` so a run that finished first is reported honestly instead of relabelled, and since `ArcOutcome` carries no `wattCost` the ledger fold became `handle.trace(): ArcRunTrace?`.

Verified green on all four gates — `ktlintCheck`, `compileCommonMainKotlinMetadata`, `jvmTest` across five modules (8 new bridge tests), `iosSimulatorArm64Test` (782 tests, 2 new commonTest suites), and `xcodebuild test` (6 Swift tests driving a real Arc through the ObjC boundary, answering both of the ticket's Phase-2 empirical checks).

Closes #619

Written by Claude (claude-opus-5) via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)