### PR TITLE
Bump ampereVersion to 0.11.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -28,4 +28,4 @@ sqldelight.version=2.2.1
 mosaic.version=0.18.0
 
 #Ampere
-ampereVersion=0.10.0
+ampereVersion=0.11.0


### PR DESCRIPTION
## Summary
- Bumps `ampereVersion` in `gradle.properties` from 0.10.0 to 0.11.0 to prepare the next library release.

Written by Claude.