### PR TITLE
Fix Dokka link-resolution and Kotlin/Native cast warnings

### DIFF
--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/AutonomousAgent.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/definition/AutonomousAgent.kt
@@ -64,7 +64,7 @@ abstract class AutonomousAgent<S : AgentState> : Agent<S>, NeuralAgent<S> {
      * tools that are registered at runtime, not just their statically-defined [requiredTools].
      *
      * Set this after agent creation (e.g., during system initialization) via
-     * [AmpereStartupResult.registry].
+     * [link.socket.ampere.startup.AmpereStartupResult.registry].
      */
     @Transient
     var toolRegistry: ToolRegistry? = null

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/Identifiers.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/Identifiers.kt
@@ -15,7 +15,7 @@ typealias RunId = String
 
 /**
  * Correlation id for a broader reasoning unit (a perception, a plan, a task)
- * that spans multiple [Event]s.
+ * that spans multiple [link.socket.ampere.agents.domain.event.Event]s.
  *
  * AMPR-240 resolved the historical ambiguity between this and [RunId]: for
  * the duration of one Arc execution, `WorkflowId` collapses into [RunId] —

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/cognition/sparks/DeclarativeSparkSource.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/cognition/sparks/DeclarativeSparkSource.kt
@@ -69,7 +69,7 @@ internal sealed interface DeclarativeSparkSource {
 
 /**
  * Bridges a parsed [DeclarativeSparkSource.Phase] back into the existing
- * [DeclarativePhaseSparkSource] data path used by [DeclarativePhaseSpark.toPhaseSpark].
+ * [DeclarativePhaseSparkSource] data path used by [DeclarativePhaseSparkSource.toPhaseSpark].
  * Keeping this adapter local to the parser layer means downstream phase-spark
  * consumers don't need to know the JSON variant exists.
  */

--- a/ampere-core/src/iosMain/kotlin/link/socket/ampere/agents/execution/tools/ToolReadCodebase.ios.kt
+++ b/ampere-core/src/iosMain/kotlin/link/socket/ampere/agents/execution/tools/ToolReadCodebase.ios.kt
@@ -43,12 +43,11 @@ actual suspend fun executeReadCodebase(
             )
         }
 
-        @Suppress("UNCHECKED_CAST")
         val content = NSString.stringWithContentsOfFile(
             fullPath,
             NSUTF8StringEncoding,
             null,
-        ) as? String ?: ""
+        ) ?: ""
 
         ExecutionOutcome.CodeReading.Success(
             executorId = context.executorId,


### PR DESCRIPTION
## Summary
- I qualified three unresolved Dokka KDoc `[...]` links (`AmpereStartupResult.registry`, `Event`, `DeclarativePhaseSparkSource.toPhaseSpark`) so they point at the correct fully-qualified/receiver type.
- I removed a redundant `as? String` cast in `ToolReadCodebase.ios.kt`, since Kotlin/Native's Foundation bridging already returns `String?` from `NSString.stringWithContentsOfFile`.

## Test plan
- [x] `./gradlew :ampere-core:dokkaGeneratePublicationHtml` — confirmed the four targeted warnings no longer appear
- [x] `./gradlew :ampere-core:compileTestKotlinIosSimulatorArm64` — "No cast needed" warning gone, build succeeds
- [x] `./gradlew :ampere-core:ktlintFormat` — clean, no changes needed
- [x] `./gradlew jvmTest` — pre-existing `AnimationDemoRunnerTest` failures confirmed unrelated (reproduce identically on `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)