### PR TITLE
AMPR-252 #640: Widen thin Canon types for the P0 Plug wave

### DIFF
--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/CanonRing2Entities.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/CanonRing2Entities.kt
@@ -72,6 +72,15 @@ data class CanonMediaItem(
     override val canonType: CanonType get() = CanonType.MEDIA_ITEM
 }
 
+/**
+ * Canon-external for the P0 Plug wave (AMPR-252) — HealthKit is fast-follow,
+ * not in this wave, and no Plug emits this type yet. [quantityType] and [unit]
+ * are untyped `String`s mirroring HealthKit's own closed
+ * `HKQuantityTypeIdentifier` / `HKUnit` catalogs; the recorded direction for
+ * whoever opens the HealthKit Plug ticket is to replace both with closed
+ * enums — one canonical unit per quantity type, eliminating unit-mismatch
+ * bugs by construction rather than by convention.
+ */
 @Serializable
 @SerialName("canon.health_sample")
 data class CanonHealthSample(
@@ -106,8 +115,24 @@ data class CanonTransaction(
     val currencyCode: String,
     val merchantName: String? = null,
     val postedAt: Instant? = null,
+    val category: String? = null,
+    val status: CanonTransactionStatus = CanonTransactionStatus.POSTED,
 ) : CanonEntity {
     override val canonType: CanonType get() = CanonType.TRANSACTION
+}
+
+/**
+ * Whether a [CanonTransaction] has cleared. FinanceKit distinguishes pending
+ * from posted; a canon with no such distinction cannot tell "you have a
+ * pending charge" from "you were charged".
+ */
+@Serializable
+enum class CanonTransactionStatus {
+    @SerialName("pending")
+    PENDING,
+
+    @SerialName("posted")
+    POSTED,
 }
 
 @Serializable
@@ -131,9 +156,23 @@ data class CanonWeatherForecast(
     val validAt: Instant,
     val temperatureCelsius: Double? = null,
     val conditionSummary: String? = null,
+    val series: List<CanonWeatherPoint> = emptyList(),
 ) : CanonEntity {
     override val canonType: CanonType get() = CanonType.WEATHER_FORECAST
 }
+
+/**
+ * One point in a forecast series. WeatherKit's entire value is the
+ * hourly/daily series, not a single instant — [CanonWeatherForecast.series]
+ * is what lets an Arc reason over "will it rain later" rather than only
+ * "what is it doing right now".
+ */
+@Serializable
+data class CanonWeatherPoint(
+    val validAt: Instant,
+    val temperatureCelsius: Double? = null,
+    val conditionSummary: String? = null,
+)
 
 @Serializable
 @SerialName("canon.bluetooth_peripheral")
@@ -146,6 +185,15 @@ data class CanonBluetoothPeripheral(
     override val canonType: CanonType get() = CanonType.BLUETOOTH_PERIPHERAL
 }
 
+/**
+ * Canon-external for the P0 Plug wave (AMPR-252) — Core Motion is fast-follow,
+ * not in this wave, and no Plug emits this type yet. [activity] is an untyped
+ * `String` mirroring Core Motion's own closed `CMMotionActivity` booleans; the
+ * recorded direction for whoever opens the Motion Plug ticket is to replace it
+ * with a closed enum (`WALKING`, `RUNNING`, `AUTOMOTIVE`, `CYCLING`,
+ * `STATIONARY`, `UNKNOWN`) so an Arc can exhaustively `when` over it instead of
+ * matching an unenforced string vocabulary.
+ */
 @Serializable
 @SerialName("canon.motion_sample")
 data class CanonMotionSample(

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/CanonRing3Entities.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/CanonRing3Entities.kt
@@ -50,10 +50,11 @@ data class CanonNote(
 data class CanonRide(
     override val canonId: CanonId,
     override val provenance: CanonProvenance,
-    val status: String,
+    val status: CanonServiceStatus,
     val pickup: CanonPlace? = null,
     val dropoff: CanonPlace? = null,
     val requestedAt: Instant? = null,
+    val providerStatus: String? = null,
 ) : CanonEntity {
     override val canonType: CanonType get() = CanonType.RIDE
 }
@@ -63,9 +64,10 @@ data class CanonRide(
 data class CanonOrder(
     override val canonId: CanonId,
     override val provenance: CanonProvenance,
-    val status: String,
+    val status: CanonServiceStatus,
     val merchantName: String? = null,
     val placedAt: Instant? = null,
+    val providerStatus: String? = null,
 ) : CanonEntity {
     override val canonType: CanonType get() = CanonType.ORDER
 }
@@ -75,12 +77,37 @@ data class CanonOrder(
 data class CanonDelivery(
     override val canonId: CanonId,
     override val provenance: CanonProvenance,
-    val status: String,
+    val status: CanonServiceStatus,
     val carrier: String? = null,
     val expectedAt: Instant? = null,
     val destination: CanonPlace? = null,
+    val providerStatus: String? = null,
 ) : CanonEntity {
     override val canonType: CanonType get() = CanonType.DELIVERY
+}
+
+/**
+ * A coarse lifecycle shared by [CanonRide], [CanonOrder], and [CanonDelivery].
+ *
+ * Ring 3 types arrive from independent services with independent status
+ * vocabularies (AMPR-252) — an untyped `status: String` meant an Arc written
+ * against one provider's strings silently broke against another's. This is
+ * the cross-provider lifecycle only; a provider's exact wording is preserved
+ * verbatim in `providerStatus` for callers that need it.
+ */
+@Serializable
+enum class CanonServiceStatus {
+    @SerialName("requested")
+    REQUESTED,
+
+    @SerialName("in_progress")
+    IN_PROGRESS,
+
+    @SerialName("completed")
+    COMPLETED,
+
+    @SerialName("cancelled")
+    CANCELLED,
 }
 
 @Serializable

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/CanonType.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/CanonType.kt
@@ -190,7 +190,10 @@ enum class CanonType(
     REMINDER(
         wireName = "reminder",
         ring = CanonRing.PLATFORM,
-        binding = CanonBinding(apple = null, lossyFields = listOf("eventKitAlarms", "recurrenceRules")),
+        binding = CanonBinding(
+            apple = null,
+            lossyFields = listOf("eventKitAlarms", "recurrenceRules", "priority", "subtasks"),
+        ),
     ),
 
     @SerialName("alarm")
@@ -209,7 +212,13 @@ enum class CanonType(
         ring = CanonRing.PLATFORM,
         binding = CanonBinding(
             apple = null,
-            lossyFields = listOf("playbackState", "libraryIdentity", "drmAssetHandle"),
+            lossyFields = listOf(
+                "playbackState",
+                "libraryIdentity",
+                "drmAssetHandle",
+                "albumTitle",
+                "artworkUrl",
+            ),
         ),
     ),
 
@@ -241,7 +250,10 @@ enum class CanonType(
     PASS(
         wireName = "pass",
         ring = CanonRing.PLATFORM,
-        binding = CanonBinding(apple = null, lossyFields = listOf("passKitFields", "barcodePayload")),
+        binding = CanonBinding(
+            apple = null,
+            lossyFields = listOf("passType", "structuredFields", "barcodePayload", "relevantDate"),
+        ),
     ),
 
     @SerialName("weather_forecast")
@@ -250,7 +262,15 @@ enum class CanonType(
         ring = CanonRing.PLATFORM,
         binding = CanonBinding(
             apple = AppleSchemaBinding.SystemValueType("Measurement"),
-            lossyFields = listOf("weatherKitAttribution", "hourlyBreakdown"),
+            // AMPR-252: series is now modelled via CanonWeatherForecast.series;
+            // per-point richness beyond temperature/condition is still lossy.
+            lossyFields = listOf(
+                "weatherKitAttribution",
+                "precipitationChance",
+                "windSpeed",
+                "uvIndex",
+                "humidity",
+            ),
         ),
     ),
 

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/canon/CanonSerializationTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/canon/CanonSerializationTest.kt
@@ -79,6 +79,8 @@ class CanonSerializationTest {
             provenance,
             amountMinorUnits = 1250,
             currencyCode = "USD",
+            category = "groceries",
+            status = CanonTransactionStatus.PENDING,
         ),
         "canon.pass" to CanonPass(CanonId("pa"), provenance, description = "Boarding"),
         "canon.weather_forecast" to CanonWeatherForecast(
@@ -86,6 +88,13 @@ class CanonSerializationTest {
             provenance,
             place = null,
             validAt = Instant.fromEpochMilliseconds(1_700_000_300_000),
+            series = listOf(
+                CanonWeatherPoint(
+                    validAt = Instant.fromEpochMilliseconds(1_700_003_900_000),
+                    temperatureCelsius = 18.5,
+                    conditionSummary = "Light rain",
+                ),
+            ),
         ),
         "canon.bluetooth_peripheral" to CanonBluetoothPeripheral(CanonId("bp"), provenance),
         "canon.motion_sample" to CanonMotionSample(
@@ -96,9 +105,24 @@ class CanonSerializationTest {
         ),
         "canon.message" to CanonMessage(CanonId("msg"), provenance, bodyText = "yo"),
         "canon.note" to CanonNote(CanonId("n"), provenance),
-        "canon.ride" to CanonRide(CanonId("rd"), provenance, status = "requested"),
-        "canon.order" to CanonOrder(CanonId("or"), provenance, status = "placed"),
-        "canon.delivery" to CanonDelivery(CanonId("dl"), provenance, status = "in_transit"),
+        "canon.ride" to CanonRide(
+            CanonId("rd"),
+            provenance,
+            status = CanonServiceStatus.REQUESTED,
+            providerStatus = "requested",
+        ),
+        "canon.order" to CanonOrder(
+            CanonId("or"),
+            provenance,
+            status = CanonServiceStatus.IN_PROGRESS,
+            providerStatus = "placed",
+        ),
+        "canon.delivery" to CanonDelivery(
+            CanonId("dl"),
+            provenance,
+            status = CanonServiceStatus.IN_PROGRESS,
+            providerStatus = "in_transit",
+        ),
         "canon.third_party_playlist" to CanonThirdPartyPlaylist(CanonId("pp"), provenance, title = "Focus"),
     )
 


### PR DESCRIPTION
## Summary
- Executes the AMPR-252 canon-fitness recon: widens `CanonWeatherForecast` (`series`), `CanonTransaction` (`category`/`status`), and Ring 3 `status` (`CanonRide`/`CanonOrder`/`CanonDelivery`, now a shared `CanonServiceStatus` enum plus raw `providerStatus`)
- Corrects `CanonBinding.lossyFields` for `CanonPass`/`CanonReminder`/`CanonMediaItem` to name the actually-dropped fields
- Records the canon-external decision (with intended future-widen direction) in KDoc on `CanonMotionSample`/`CanonHealthSample`, both fast-follow
- Updates `CanonSerializationTest.samples()` to exercise every changed field

I (Claude) wrote this PR on Miley's behalf.

Closes #640

## Test plan
- [x] `./gradlew jvmTest`
- [x] `./gradlew :ampere-core:compileCommonMainKotlinMetadata`
- [x] `./gradlew :ampere-core:compileTestKotlinIosSimulatorArm64`