### PR TITLE
AMPR-247 #635: Split CanonAdapter into Readable/Writable/CreatingCanonAdapter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,8 +140,15 @@ jobs:
       # simulator boot are independent and were previously fully serialized. Kick the boot off
       # in the background before the build so the ~7m link and the ~3m boot overlap instead of
       # stacking.
+      #
+      # The 20-minute budget was too tight: observed real durations across recent runs are
+      # 11m, 14m, and >20m (timed out) with no code change in common — this step's actual
+      # variance on shared macOS runners, not a regression. The Xcode DerivedData cache that's
+      # meant to smooth this out had also never successfully populated on any branch until just
+      # now, so every run so far has paid the full cold-build cost. 30m gives real headroom
+      # instead of chasing this exact number every time a run runs a little hot.
       - name: Build Swift bridge tests
-        timeout-minutes: 20
+        timeout-minutes: 30
         run: |
           UDID=$(xcrun simctl list devices available -j \
             | jq -r '[.devices[][] | select(.name | startswith("iPhone"))][0].udid')

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/CanonBinding.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/CanonBinding.kt
@@ -15,7 +15,7 @@ import kotlinx.serialization.Serializable
  * The canon type is the superset; a binding is a *projection* of it. Everything
  * the projection drops is named in [lossyFields] and is what the
  * preserve-and-merge write-back contract
- * ([link.socket.ampere.canon.adapter.CanonAdapter]) exists to protect.
+ * ([link.socket.ampere.canon.adapter.WritableCanonAdapter]) exists to protect.
  */
 @Serializable
 data class CanonBinding(

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/adapter/CreatingCanonAdapter.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/adapter/CreatingCanonAdapter.kt
@@ -1,0 +1,52 @@
+package link.socket.ampere.canon.adapter
+
+import kotlinx.serialization.json.JsonObject
+import link.socket.ampere.canon.CanonEntity
+import link.socket.ampere.canon.SourceHandle
+
+/**
+ * Adds creation on top of [WritableCanonAdapter].
+ *
+ * [WritableCanonAdapter.writeBack] resolves `entity.provenance.sourceHandle`
+ * and merges onto an existing native object. A new reminder, alarm, or pass
+ * has no prior object and no handle — [create] is the separate path for that.
+ * It never reads the entity's provenance, only [canonFields]: pass any [E]
+ * instance that satisfies the type (its provenance is ignored) and use the
+ * [SourceHandle] [create] returns to [ReadableCanonAdapter.project] the entity
+ * that actually carries real provenance.
+ *
+ * Creation touches no existing native object, so there is nothing for it to
+ * clobber — the failure mode [WritableCanonAdapter.writeBack] guards against
+ * cannot occur here. That is why this is a separate, final entry point rather
+ * than an overload of `writeBack`, not a relaxation of it: the [ownedFields]
+ * guard still applies, because an adapter that can create with unowned fields
+ * can create a malformed native object.
+ */
+abstract class CreatingCanonAdapter<E : CanonEntity> : WritableCanonAdapter<E>() {
+
+    /** Terminal create. The fields handed in already passed the [ownedFields] guard. */
+    protected abstract suspend fun createNative(fields: JsonObject): Result<SourceHandle>
+
+    /**
+     * The only creation path. Guards, then creates.
+     *
+     * Final by Kotlin default — overriding it would be the one way to
+     * reintroduce an unguarded write, this time on creation rather than
+     * update.
+     */
+    suspend fun create(entity: E): Result<SourceHandle> {
+        val fields = canonFields(entity).getOrElse { return Result.failure(it) }
+
+        fields.keys.firstOrNull { it !in ownedFields }?.let { stray ->
+            return canonFailure(
+                CanonConversionFailure.UnownedFieldWrite(
+                    canonType = canonType,
+                    field = stray,
+                    ownedFields = ownedFields,
+                ),
+            )
+        }
+
+        return createNative(JsonObject(fields))
+    }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/adapter/ReadableCanonAdapter.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/adapter/ReadableCanonAdapter.kt
@@ -1,0 +1,87 @@
+package link.socket.ampere.canon.adapter
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.json.JsonObject
+import link.socket.ampere.canon.CanonEntity
+import link.socket.ampere.canon.CanonProvenance
+import link.socket.ampere.canon.CanonType
+import link.socket.ampere.canon.NativePayload
+import link.socket.ampere.canon.SourceHandle
+
+/**
+ * The transport-agnostic read contract between a canon type and one native source.
+ *
+ * One adapter shape serves every wire: an AppFunction call, an MCP tool, a
+ * bespoke iOS integration, a Shortcuts/URI route, a direct API. Arc logic never
+ * learns which one carried the data — that is the Link's business, not the
+ * canon's.
+ *
+ * A Plug that only reads subclasses this directly and gets no write surface at
+ * all — no `WriteRejected` stub to author, no `ownedFields` to declare and
+ * never honour. [WritableCanonAdapter] adds a guarded write-back path on top
+ * of this; [CreatingCanonAdapter] adds creation on top of that.
+ */
+abstract class ReadableCanonAdapter<E : CanonEntity> {
+
+    /** The canon type this adapter projects to. */
+    abstract val canonType: CanonType
+
+    /**
+     * The native shape identifier this adapter reads, e.g. `MailMessageEntity`.
+     * Checked on every projection.
+     */
+    abstract val nativeSchema: String
+
+    /**
+     * Native → canon. The provenance is built for you and cannot be omitted.
+     *
+     * @param fields The native object's fields, already schema-checked.
+     * @param provenance Carries the source handle, the observation time, and
+     *   the lossless native payload when the caller asked to retain it.
+     */
+    protected abstract fun projectFields(
+        fields: JsonObject,
+        provenance: CanonProvenance,
+    ): Result<E>
+
+    /**
+     * Re-read the native object by handle. [WritableCanonAdapter] calls this to
+     * get a base to merge onto when an entity carries no native payload of its
+     * own.
+     */
+    protected abstract suspend fun fetchNative(handle: SourceHandle): Result<NativePayload>
+
+    /**
+     * Native → canon, with the schema check and provenance wiring applied.
+     *
+     * @param carryNativePayload Retain the lossless native object on the
+     *   entity. Default on: it makes write-back a pure merge with no re-fetch.
+     *   Turn it off for payloads too large to carry, at the cost of a
+     *   [fetchNative] round trip on write.
+     */
+    fun project(
+        payload: NativePayload,
+        handle: SourceHandle,
+        observedAt: Instant,
+        carryNativePayload: Boolean = true,
+    ): Result<E> {
+        if (payload.schema != nativeSchema) {
+            return canonFailure(
+                CanonConversionFailure.SchemaMismatch(
+                    canonType = canonType,
+                    expectedSchema = nativeSchema,
+                    actualSchema = payload.schema,
+                ),
+            )
+        }
+
+        return projectFields(
+            fields = payload.fields,
+            provenance = CanonProvenance(
+                sourceHandle = handle,
+                observedAt = observedAt,
+                nativePayload = if (carryNativePayload) payload else null,
+            ),
+        )
+    }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/adapter/WritableCanonAdapter.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/adapter/WritableCanonAdapter.kt
@@ -1,21 +1,13 @@
 package link.socket.ampere.canon.adapter
 
-import kotlinx.datetime.Instant
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import link.socket.ampere.canon.CanonEntity
-import link.socket.ampere.canon.CanonProvenance
-import link.socket.ampere.canon.CanonType
 import link.socket.ampere.canon.NativePayload
 import link.socket.ampere.canon.SourceHandle
 
 /**
- * The transport-agnostic contract between a canon type and one native source.
- *
- * One adapter shape serves every wire: an AppFunction call, an MCP tool, a
- * bespoke iOS integration, a Shortcuts/URI route, a direct API. Arc logic never
- * learns which one carried the data — that is the Link's business, not the
- * canon's.
+ * Adds a guarded write-back path on top of [ReadableCanonAdapter].
  *
  * ## Preserve-and-merge is structural, not remembered
  *
@@ -24,10 +16,9 @@ import link.socket.ampere.canon.SourceHandle
  * projection dropped. The usual fix — "adapters must remember to merge" — fails
  * the first time someone writes an adapter in a hurry.
  *
- * So this SPI does not expose a write path that *can* clobber. Subclasses
- * implement three narrow operations:
+ * So this SPI does not expose a write path that *can* clobber. Subclasses add
+ * two narrow operations to [ReadableCanonAdapter]'s read surface:
  *
- *  - [projectFields] — native fields in, canon entity out.
  *  - [canonFields] — canon entity in, *only the fields this adapter owns* out.
  *  - [writeNative] — a terminal write of an already-merged payload.
  *
@@ -39,18 +30,10 @@ import link.socket.ampere.canon.SourceHandle
  * The [ownedFields] declaration is the second half of that guarantee. If
  * [canonFields] returns a key outside it, the merge fails with
  * [CanonConversionFailure.UnownedFieldWrite] rather than quietly overwriting a
- * native field nobody accounted for.
+ * native field nobody accounted for. [CreatingCanonAdapter.create] routes
+ * through the same guard.
  */
-abstract class CanonAdapter<E : CanonEntity> {
-
-    /** The canon type this adapter projects to. */
-    abstract val canonType: CanonType
-
-    /**
-     * The native shape identifier this adapter reads and writes, e.g.
-     * `MailMessageEntity`. Checked on every projection and every merge.
-     */
-    abstract val nativeSchema: String
+abstract class WritableCanonAdapter<E : CanonEntity> : ReadableCanonAdapter<E>() {
 
     /**
      * Exactly the native field names this adapter's canon projection covers.
@@ -62,18 +45,6 @@ abstract class CanonAdapter<E : CanonEntity> {
     abstract val ownedFields: Set<String>
 
     /**
-     * Native → canon. The provenance is built for you and cannot be omitted.
-     *
-     * @param fields The native object's fields, already schema-checked.
-     * @param provenance Carries the source handle, the observation time, and
-     *   the lossless native payload when the caller asked to retain it.
-     */
-    protected abstract fun projectFields(
-        fields: JsonObject,
-        provenance: CanonProvenance,
-    ): Result<E>
-
-    /**
      * Canon → native deltas. Return only the fields named in [ownedFields].
      *
      * This is a *delta*, not a document: omit a key and the native value
@@ -81,51 +52,11 @@ abstract class CanonAdapter<E : CanonEntity> {
      */
     protected abstract fun canonFields(entity: E): Result<Map<String, JsonElement>>
 
-    /**
-     * Re-read the native object. Called only when the entity carries no native
-     * payload of its own, so the merge still has a base to overlay onto.
-     */
-    protected abstract suspend fun fetchNative(handle: SourceHandle): Result<NativePayload>
-
     /** Terminal write. The payload handed in is already merged. */
     protected abstract suspend fun writeNative(
         handle: SourceHandle,
         merged: NativePayload,
     ): Result<Unit>
-
-    /**
-     * Native → canon, with the schema check and provenance wiring applied.
-     *
-     * @param carryNativePayload Retain the lossless native object on the
-     *   entity. Default on: it makes write-back a pure merge with no re-fetch.
-     *   Turn it off for payloads too large to carry, at the cost of a
-     *   [fetchNative] round trip on write.
-     */
-    fun project(
-        payload: NativePayload,
-        handle: SourceHandle,
-        observedAt: Instant,
-        carryNativePayload: Boolean = true,
-    ): Result<E> {
-        if (payload.schema != nativeSchema) {
-            return canonFailure(
-                CanonConversionFailure.SchemaMismatch(
-                    canonType = canonType,
-                    expectedSchema = nativeSchema,
-                    actualSchema = payload.schema,
-                ),
-            )
-        }
-
-        return projectFields(
-            fields = payload.fields,
-            provenance = CanonProvenance(
-                sourceHandle = handle,
-                observedAt = observedAt,
-                nativePayload = if (carryNativePayload) payload else null,
-            ),
-        )
-    }
 
     /**
      * Produce the payload [writeBack] would write, without writing it.
@@ -180,7 +111,8 @@ abstract class CanonAdapter<E : CanonEntity> {
     }
 
     /**
-     * The only write path. Merges, then writes.
+     * The only path that writes to an *existing* native object. Merges, then
+     * writes.
      *
      * Final by Kotlin default — overriding it would be the one way to
      * reintroduce the destructive write this SPI exists to prevent.

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/canon/adapter/CanonAdapterFixtures.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/canon/adapter/CanonAdapterFixtures.kt
@@ -14,19 +14,26 @@ import link.socket.ampere.canon.CanonType
 import link.socket.ampere.canon.DocumentKind
 import link.socket.ampere.canon.NativePayload
 import link.socket.ampere.canon.SourceHandle
+import link.socket.ampere.link.LinkId
 
 /**
- * Reference adapters used to exercise the [CanonAdapter] contract.
+ * Reference adapters used to exercise the [ReadableCanonAdapter] /
+ * [WritableCanonAdapter] / [CreatingCanonAdapter] contracts.
  *
  * They live in the test source set on purpose. AMPR-222 ships the *SPI*; real
  * adapters are per-Plug work that lands with each transport. These fixtures
- * cover the three binding shapes a real adapter has to handle:
+ * cover the binding shapes a real adapter has to handle:
  *
  *  - [MailMessageAdapter] — an entity-schema binding with a write path.
  *  - [FileDocumentAdapter] — the `Document` fan-out, where the discriminator is
  *    itself the lossy axis.
  *  - [OverreachingMailAdapter] — a deliberately broken adapter that writes
  *    outside its declared `ownedFields`, to prove the guard fires.
+ *  - [ReadOnlyMailAdapter] — a read-only adapter with no write surface at all.
+ *  - [CreatingMailAdapter] — a creating adapter, to exercise [CreatingCanonAdapter.create].
+ *  - [OverreachingCreatingMailAdapter] — a creating adapter that overreaches
+ *    its `ownedFields`, to prove `create` routes through the same guard as
+ *    `writeBack`.
  */
 
 /** A tiny in-memory stand-in for a native mail store. */
@@ -53,9 +60,39 @@ class FakeNativeStore(
     }
 }
 
+private fun mailFields(entity: CanonEmailMessage): Map<String, JsonElement> =
+    buildMap {
+        put("subject", JsonPrimitive(entity.subject))
+        entity.bodyText?.let { put("bodyText", JsonPrimitive(it)) }
+        put("isRead", JsonPrimitive(entity.isRead))
+    }
+
+private fun projectMailFields(
+    canonType: CanonType,
+    nativeSchema: String,
+    fields: JsonObject,
+    provenance: CanonProvenance,
+): Result<CanonEmailMessage> {
+    val subject = fields["subject"]?.jsonPrimitive?.contentOrNull
+        ?: return canonFailure(
+            CanonConversionFailure.MissingRequiredField(canonType, "subject", nativeSchema),
+        )
+
+    return Result.success(
+        CanonEmailMessage(
+            canonId = CanonId(provenance.sourceHandle.nativeId),
+            provenance = provenance,
+            subject = subject,
+            from = null,
+            bodyText = fields["bodyText"]?.jsonPrimitive?.contentOrNull,
+            isRead = fields["isRead"]?.jsonPrimitive?.booleanOrNull ?: false,
+        ),
+    )
+}
+
 class MailMessageAdapter(
     private val store: FakeNativeStore,
-) : CanonAdapter<CanonEmailMessage>() {
+) : WritableCanonAdapter<CanonEmailMessage>() {
 
     override val canonType: CanonType = CanonType.EMAIL_MESSAGE
     override val nativeSchema: String = "MailMessageEntity"
@@ -64,32 +101,10 @@ class MailMessageAdapter(
     override fun projectFields(
         fields: JsonObject,
         provenance: CanonProvenance,
-    ): Result<CanonEmailMessage> {
-        val subject = fields["subject"]?.jsonPrimitive?.contentOrNull
-            ?: return canonFailure(
-                CanonConversionFailure.MissingRequiredField(canonType, "subject", nativeSchema),
-            )
-
-        return Result.success(
-            CanonEmailMessage(
-                canonId = CanonId(provenance.sourceHandle.nativeId),
-                provenance = provenance,
-                subject = subject,
-                from = null,
-                bodyText = fields["bodyText"]?.jsonPrimitive?.contentOrNull,
-                isRead = fields["isRead"]?.jsonPrimitive?.booleanOrNull ?: false,
-            ),
-        )
-    }
+    ): Result<CanonEmailMessage> = projectMailFields(canonType, nativeSchema, fields, provenance)
 
     override fun canonFields(entity: CanonEmailMessage): Result<Map<String, JsonElement>> =
-        Result.success(
-            buildMap {
-                put("subject", JsonPrimitive(entity.subject))
-                entity.bodyText?.let { put("bodyText", JsonPrimitive(it)) }
-                put("isRead", JsonPrimitive(entity.isRead))
-            },
-        )
+        Result.success(mailFields(entity))
 
     override suspend fun fetchNative(handle: SourceHandle): Result<NativePayload> =
         store.fetch(handle.nativeId)
@@ -102,7 +117,7 @@ class MailMessageAdapter(
 
 class FileDocumentAdapter(
     private val store: FakeNativeStore,
-) : CanonAdapter<CanonDocument>() {
+) : WritableCanonAdapter<CanonDocument>() {
 
     override val canonType: CanonType = CanonType.DOCUMENT
     override val nativeSchema: String = "FileEntity"
@@ -162,7 +177,7 @@ class FileDocumentAdapter(
  */
 class OverreachingMailAdapter(
     private val store: FakeNativeStore,
-) : CanonAdapter<CanonEmailMessage>() {
+) : WritableCanonAdapter<CanonEmailMessage>() {
 
     override val canonType: CanonType = CanonType.EMAIL_MESSAGE
     override val nativeSchema: String = "MailMessageEntity"
@@ -195,4 +210,115 @@ class OverreachingMailAdapter(
         handle: SourceHandle,
         merged: NativePayload,
     ): Result<Unit> = runCatching { store.write(handle.nativeId, merged) }
+}
+
+/**
+ * A read-only adapter. `ReadableCanonAdapter` declares no write member at all,
+ * so there is no `ownedFields` to declare and no `WriteRejected` stub to
+ * author — `readOnlyAdapter.writeBack(...)` does not compile, because
+ * `writeBack` is not a member of this class.
+ */
+class ReadOnlyMailAdapter(
+    private val store: FakeNativeStore,
+) : ReadableCanonAdapter<CanonEmailMessage>() {
+
+    override val canonType: CanonType = CanonType.EMAIL_MESSAGE
+    override val nativeSchema: String = "MailMessageEntity"
+
+    override fun projectFields(
+        fields: JsonObject,
+        provenance: CanonProvenance,
+    ): Result<CanonEmailMessage> = projectMailFields(canonType, nativeSchema, fields, provenance)
+
+    override suspend fun fetchNative(handle: SourceHandle): Result<NativePayload> =
+        store.fetch(handle.nativeId)
+}
+
+/**
+ * Exercises [CreatingCanonAdapter.create]: creates a new native mail object
+ * rather than merging onto an existing one.
+ */
+class CreatingMailAdapter(
+    private val store: FakeNativeStore,
+) : CreatingCanonAdapter<CanonEmailMessage>() {
+
+    override val canonType: CanonType = CanonType.EMAIL_MESSAGE
+    override val nativeSchema: String = "MailMessageEntity"
+    override val ownedFields: Set<String> = setOf("subject", "bodyText", "isRead")
+
+    private var nextId = 0
+
+    override fun projectFields(
+        fields: JsonObject,
+        provenance: CanonProvenance,
+    ): Result<CanonEmailMessage> = projectMailFields(canonType, nativeSchema, fields, provenance)
+
+    override fun canonFields(entity: CanonEmailMessage): Result<Map<String, JsonElement>> =
+        Result.success(mailFields(entity))
+
+    override suspend fun fetchNative(handle: SourceHandle): Result<NativePayload> =
+        store.fetch(handle.nativeId)
+
+    override suspend fun writeNative(
+        handle: SourceHandle,
+        merged: NativePayload,
+    ): Result<Unit> = runCatching { store.write(handle.nativeId, merged) }
+
+    override suspend fun createNative(fields: JsonObject): Result<SourceHandle> {
+        val nativeId = "created-${nextId++}"
+        store.write(nativeId, NativePayload(schema = nativeSchema, fields = fields))
+        return Result.success(
+            SourceHandle(
+                linkId = LinkId("google-oauth-1"),
+                sourceSystem = "apple.mail",
+                nativeId = nativeId,
+            ),
+        )
+    }
+}
+
+/**
+ * Creates with `providerLabels` — a field outside [ownedFields]. Exists to
+ * prove [CreatingCanonAdapter.create] routes through the same guard
+ * [WritableCanonAdapter.writeBack] does.
+ */
+class OverreachingCreatingMailAdapter(
+    private val store: FakeNativeStore,
+) : CreatingCanonAdapter<CanonEmailMessage>() {
+
+    override val canonType: CanonType = CanonType.EMAIL_MESSAGE
+    override val nativeSchema: String = "MailMessageEntity"
+    override val ownedFields: Set<String> = setOf("subject")
+
+    override fun projectFields(
+        fields: JsonObject,
+        provenance: CanonProvenance,
+    ): Result<CanonEmailMessage> = projectMailFields(canonType, nativeSchema, fields, provenance)
+
+    override fun canonFields(entity: CanonEmailMessage): Result<Map<String, JsonElement>> =
+        Result.success(
+            mapOf(
+                "subject" to JsonPrimitive(entity.subject),
+                "providerLabels" to JsonPrimitive("clobbered"),
+            ),
+        )
+
+    override suspend fun fetchNative(handle: SourceHandle): Result<NativePayload> =
+        store.fetch(handle.nativeId)
+
+    override suspend fun writeNative(
+        handle: SourceHandle,
+        merged: NativePayload,
+    ): Result<Unit> = runCatching { store.write(handle.nativeId, merged) }
+
+    override suspend fun createNative(fields: JsonObject): Result<SourceHandle> {
+        store.write("should-not-be-created", NativePayload(schema = nativeSchema, fields = fields))
+        return Result.success(
+            SourceHandle(
+                linkId = LinkId("google-oauth-1"),
+                sourceSystem = "apple.mail",
+                nativeId = "should-not-be-created",
+            ),
+        )
+    }
 }

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/canon/adapter/CanonAdapterTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/canon/adapter/CanonAdapterTest.kt
@@ -278,6 +278,57 @@ class CanonAdapterTest {
     }
 
     // -----------------------------------------------------------------
+    // Read-only adapters have no write surface
+    // -----------------------------------------------------------------
+
+    @Test
+    fun `a read-only adapter projects without exposing any write surface`() {
+        val adapter = ReadOnlyMailAdapter(FakeNativeStore())
+
+        val entity = adapter.project(nativeMail(), handle, observedAt).getOrThrow()
+
+        assertEquals("Quarterly review", entity.subject)
+        // `adapter.writeBack(entity)` does not compile here — `ReadableCanonAdapter`
+        // declares no such member, so there is nothing to call.
+    }
+
+    // -----------------------------------------------------------------
+    // Creation
+    // -----------------------------------------------------------------
+
+    @Test
+    fun `create with an unowned field fails UnownedFieldWrite`() = runTest {
+        val adapter = OverreachingCreatingMailAdapter(FakeNativeStore())
+        val draft = adapter.project(nativeMail(), handle, observedAt).getOrThrow()
+
+        val failure = failureOf(adapter.create(draft))
+
+        assertIs<CanonConversionFailure.UnownedFieldWrite>(failure)
+        assertEquals("providerLabels", failure.field)
+    }
+
+    @Test
+    fun `a created entity's returned handle re-projects to an equal entity`() = runTest {
+        val store = FakeNativeStore()
+        val adapter = CreatingMailAdapter(store)
+
+        // The entity's own provenance is a placeholder — `create` never reads
+        // it, since there is no existing native object to resolve a handle
+        // against yet.
+        val draft = adapter.project(nativeMail(), handle, observedAt).getOrThrow()
+            .copy(subject = "New thread", bodyText = "Hello", isRead = false)
+
+        val createdHandle = adapter.create(draft).getOrThrow()
+
+        val createdPayload = store.read(createdHandle.nativeId)!!
+        val reprojected = adapter.project(createdPayload, createdHandle, observedAt).getOrThrow()
+
+        assertEquals(draft.subject, reprojected.subject)
+        assertEquals(draft.bodyText, reprojected.bodyText)
+        assertEquals(draft.isRead, reprojected.isRead)
+    }
+
+    // -----------------------------------------------------------------
     // Coverage bookkeeping
     // -----------------------------------------------------------------
 

--- a/docs/concepts/domain-canon.md
+++ b/docs/concepts/domain-canon.md
@@ -4,7 +4,7 @@ status: stable
 tracked_sources:
   - ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/**
 related: [LinkLayer, PlugPermissions, AgentSurface, CognitionTrace]
-last_verified: 2026-07-28
+last_verified: 2026-07-29
 ---
 
 # Domain Canon
@@ -46,7 +46,7 @@ result. The canon earns its keep precisely where Apple's registry stops.
 - `canon/CanonBinding.kt` — `AppleSchemaBinding` (entity schema or system value type), `AndroidSchemaBinding`.
 - `canon/CanonProvenance.kt` — `CanonId`, `SourceHandle`, `NativePayload`, `CanonProvenance`.
 - `canon/CanonEntity.kt` — the sealed hierarchy; `CanonRing1Entities.kt`, `CanonRing2Entities.kt`, `CanonRing3Entities.kt`.
-- `canon/adapter/CanonAdapter.kt` — the transport-agnostic adapter SPI.
+- `canon/adapter/ReadableCanonAdapter.kt`, `WritableCanonAdapter.kt`, `CreatingCanonAdapter.kt` — the transport-agnostic adapter SPI, split by capability: read, write-back, create.
 - `canon/adapter/CanonConversionFailure.kt` — the closed failure set.
 - `ampere-core/src/commonTest/.../canon/` — round-trip, write-back-merge, and serialization-stability tests.
 - `.context/recon/apple-assistant-schemas-ios265.tsv` — the raw SDK enumeration.
@@ -55,8 +55,9 @@ result. The canon earns its keep precisely where Apple's registry stops.
 
 - **The canon set is closed for v1.** New nouns are a versioned change, not a Plug-declared extension. The escape hatch is `CanonProvenance.nativePayload`, not a new member.
 - **Every canon entity carries provenance.** An entity with no `SourceHandle` is a guess, not a canon entity.
-- **Write-back merges; it never replaces.** `CanonAdapter.writeBack` is the only write path and always routes through `mergeForWriteBack`, which overlays canon deltas onto the native payload. Adding a write path that bypasses the merge silently destroys every native field the projection dropped.
-- **An adapter may only write fields it declares in `ownedFields`.** A `canonFields` result reaching outside that set fails with `UnownedFieldWrite` rather than widening the write footprint.
+- **Write-back merges; it never replaces.** `WritableCanonAdapter.writeBack` is the only path that touches an *existing* native object, and it always routes through `mergeForWriteBack`, which overlays canon deltas onto the native payload. Adding a write path that bypasses the merge silently destroys every native field the projection dropped.
+- **An adapter may only write fields it declares in `ownedFields`.** A `canonFields` result reaching outside that set fails with `UnownedFieldWrite` rather than widening the write footprint. `CreatingCanonAdapter.create` routes through the same guard.
+- **`create` touches no existing object, so it cannot clobber — but it is still final and confined to `CreatingCanonAdapter`.** `ReadableCanonAdapter` and `WritableCanonAdapter` gain no create surface; a Plug that only reads or only updates cannot acquire the ability to create by inheritance.
 - **Ring membership is a binding-provenance claim, not a support level.** A Ring 1 type maps to an Apple assistant-schema entity or system value type *without contortion*. Promoting a type into Ring 1 requires an SDK pass, not an opinion.
 - **`@SerialName` and `wireName` are wire contracts.** These types cross the wire and land in traces; renaming a discriminator breaks `PlaybackRelay` replay of every trace already recorded.
 - **Conversions are `Result`-typed.** No adapter throws.
@@ -65,7 +66,12 @@ result. The canon earns its keep precisely where Apple's registry stops.
 ## Common operations
 
 - **Add a canon type** — add the `CanonType` member with a stable `wireName`, ring, and `CanonBinding`; add the `@Serializable` entity with a stable `@SerialName`; add a sample to `CanonSerializationTest.samples()` (the coverage test fails otherwise).
-- **Write an adapter** — subclass `CanonAdapter<E>`, implement `projectFields`, `canonFields`, `fetchNative`, `writeNative`, and declare `nativeSchema` + `ownedFields`. Never add a public write method.
+- **Write an adapter** — subclass the narrowest class the Plug's capability supports:
+  - Read-only: `ReadableCanonAdapter<E>`, implementing `projectFields` + `fetchNative` and declaring `nativeSchema`.
+  - Updates existing objects: `WritableCanonAdapter<E>`, additionally implementing `canonFields` + `writeNative` and declaring `ownedFields`.
+  - Also creates new objects: `CreatingCanonAdapter<E>`, additionally implementing `createNative`.
+
+  Never add a public write method outside `writeBack` and `create`.
 - **Preview a pending write** — `adapter.mergeForWriteBack(entity)` returns the merged payload without writing.
 - **Check a binding** — `CanonType.EMAIL_MESSAGE.binding.apple` gives the `mail.message` address and the fields the projection drops.
 - **Re-run the SDK pass** — the extraction commands are in the Appendix of `.context/issue-586-domain-type-canon-v1.md`; diff against the committed TSV.


### PR DESCRIPTION
## Summary
- Splits `CanonAdapter` into `ReadableCanonAdapter` → `WritableCanonAdapter` → `CreatingCanonAdapter`, so read-only Plugs no longer need a meaningless `ownedFields` declaration or a `WriteRejected` stub to compile.
- Adds a guarded `create()` path (final, routes through the same `ownedFields` guard as `writeBack`, confined to `CreatingCanonAdapter`) so Reminders/AlarmKit/PassKit-style Plugs can construct new native objects instead of only merging onto existing ones.
- Migrates the three commonTest fixtures and adds new fixtures/tests for the read-only and creating paths; existing preserve-and-merge assertions pass unmodified.
- Updates `docs/concepts/domain-canon.md` invariants and "write an adapter" instructions in the same commit, per the signed-off amendment.

Closes #635

## Test plan
- [x] `./gradlew ktlintFormat`
- [x] `./gradlew :ampere-core:jvmTest` (canon adapter tests all pass; one unrelated pre-existing flaky wall-clock test in `ArcTraceProjectionTest` confirmed unrelated)
- [x] `./gradlew :ampere-core:compileCommonMainKotlinMetadata`
- [x] `./gradlew :ampere-core:compileTestKotlinIosSimulatorArm64`

🤖 Generated with [Claude Code](https://claude.com/claude-code)