### PR TITLE
AMPR-255 #648: Overlap the iOS simulator boot instead of paying it serially

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,22 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # The simulator takes ~5m of mostly-idle wall clock to come up, and AMPR-253 left that fully
+      # serial in "Run Swift bridge tests" — 346s of a 638s job. Kick it off first so it overlaps
+      # the JDK/Gradle setup, the framework link and the Swift build (~245s of cover).
+      #
+      # simctl hands the boot to CoreSimulator and returns, so this does not need backgrounding
+      # with '&': there is no child process to outlive the step. AMPR-244 backgrounded it and it
+      # still hurt, because back then it overlapped the framework link inside the same step on a
+      # 3-core runner. The link is now upstream of this and already done by the time tests run.
+      - name: Start simulator boot
+        run: |
+          UDID=$(xcrun simctl list devices available -j \
+            | jq -r '[.devices[][] | select(.name | startswith("iPhone"))][0].udid')
+          test -n "$UDID" || { echo "No iPhone simulator available"; exit 1; }
+          echo "SIMULATOR_UDID=$UDID" >> "$GITHUB_ENV"
+          xcrun simctl boot "$UDID" || true
+
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
@@ -214,27 +230,22 @@ jobs:
       - name: Build Swift bridge tests
         timeout-minutes: 30
         run: |
-          UDID=$(xcrun simctl list devices available -j \
-            | jq -r '[.devices[][] | select(.name | startswith("iPhone"))][0].udid')
-          test -n "$UDID" || { echo "No iPhone simulator available"; exit 1; }
-          echo "SIMULATOR_UDID=$UDID" >> "$GITHUB_ENV"
-
           xcodebuild build-for-testing \
             -project ampere-ios/ampere-ios.xcodeproj \
             -scheme ampere-ios \
-            -destination "id=$UDID" \
+            -destination "id=$SIMULATOR_UDID" \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGN_IDENTITY="" \
             DEVELOPMENT_TEAM=""
 
-      # Booting is ~3m of mostly-idle wall clock. AMPR-244 overlapped it with the framework link
-      # by backgrounding it, but the runner only has 3 cores / 7GB and the boot competed with the
-      # linker for them. Boot it here instead, where the only thing waiting is the test run.
+      # The boot was started at the top of the job; by now it is usually finished. bootstatus just
+      # collects it, and returns immediately if the device is already booted — so this step's
+      # duration is a direct readout of how much boot time the overlap failed to hide.
       - name: Run Swift bridge tests
         timeout-minutes: 15
         run: |
-          xcrun simctl boot "$SIMULATOR_UDID" 2>/dev/null || true
+          xcrun simctl bootstatus "$SIMULATOR_UDID" -b || true
 
           xcodebuild test-without-building \
             -project ampere-ios/ampere-ios.xcodeproj \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,9 +115,14 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      # Keyed per job: this job populates the test-binary cache bucket and the Swift bridge job
+      # Keyed per job: this job populates the test-binary gSTATIC bucket and the Swift bridge job
       # populates the framework one, so a shared key would make the two races overwrite each
       # other's entry on every run.
+      #
+      # Do NOT add a cross-job "konan-<os>-" restore-key. AMPR-253 did, and on any branch without
+      # its own entry yet the Swift bridge job restored *this* job's bucket instead. A mismatched
+      # Konan cache is far worse than none: the framework link went 323s (no cache) -> 1208s
+      # (wrong bucket) -> 138s (right bucket). A clean miss is the good failure mode here.
       - name: Cache Kotlin/Native toolchain
         uses: actions/cache@v4
         with:
@@ -125,7 +130,6 @@ jobs:
           key: konan-${{ runner.os }}-kotlin-tests-${{ hashFiles('gradle.properties') }}
           restore-keys: |
             konan-${{ runner.os }}-kotlin-tests-
-            konan-${{ runner.os }}-
 
       - name: Create local.properties
         run: |
@@ -190,7 +194,6 @@ jobs:
           key: konan-${{ runner.os }}-swift-bridge-${{ hashFiles('gradle.properties') }}
           restore-keys: |
             konan-${{ runner.os }}-swift-bridge-
-            konan-${{ runner.os }}-
 
       # Per AMPR-244 this had never successfully populated on any branch, and it still restores in
       # ~1s / saves in ~5s, so it is not currently buying anything. Kept because it only starts


### PR DESCRIPTION
Closes #648

AMPR-253 cut the iOS critical path from ~20m06s to **10m38s**, but regressed the simulator boot by making it fully serial — `Run Swift bridge tests` is now **346s of the 638s** job. This starts the boot in the job's first step and collects it with `simctl bootstatus -b` just before `test-without-building`, giving ~245s of cover (setup + link + Swift build) against a ~300s boot.

AMPR-244 had backgrounded the boot and it still hurt, which is why AMPR-253 serialized it; but that only held while the boot and the framework link shared a step. The link now runs upstream and is done before tests start, so the contention argument no longer applies.

Measured locally: `simctl boot` returns in **4s** because it hands the boot to CoreSimulator rather than doing the work itself, `bootstatus -b` then waits **131s** for real readiness, and returns in **0s** once the device is up. So no `&` is needed — there is no child process to outlive the step, which is also why AMPR-244's backgrounding was never the part that hurt.

Expected ~6–7 min for this job, after which `iOS Kotlin Tests` (403–516s) becomes the critical path. Note that the first run on this branch may still look slow if it cannot yet restore `main`'s `konan-macOS-*` cache — per AMPR-253 that cold path costs an extra ~7 min and is not a regression.

Linear: [AMPR-255](https://linear.app/miley/issue/AMPR-255/ios-swift-bridge-job-overlap-the-simulator-boot-instead-of-paying-it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
