### PR TITLE
AMPR-249 #637: PlugPermission device-capability variant

### DIFF
--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/bundle/PlugBundleValidator.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/bundle/PlugBundleValidator.kt
@@ -64,6 +64,7 @@ class PlugBundleValidator {
             is PlugPermission.KnowledgeQuery -> "scope" to permission.scope
             is PlugPermission.NativeAction -> "actionId" to permission.actionId
             is PlugPermission.LinkAccess -> "linkId" to permission.linkId
+            is PlugPermission.DeviceCapability -> "capability" to permission.capability
         }
         return if (value.isBlank()) {
             "requiredPermissions[$index] (${permission::class.simpleName}) has blank $field."

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/PlugManifestValidator.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/PlugManifestValidator.kt
@@ -13,6 +13,11 @@ import link.socket.ampere.plug.permission.PlugPermission
  *
  * Returning a sealed result keeps the validator usable both for early failure
  * (during plug install) and for surfacing diagnostics in tooling.
+ *
+ * This validator does not check [PlugManifest.emits] / [PlugManifest.consumes]
+ * at all, and the only production call site today is [PlugContext.create].
+ * It is expected to run at plug install time on every host that accepts
+ * manifests — including Socket, which does not currently call it.
  */
 object PlugManifestValidator {
 
@@ -43,6 +48,7 @@ object PlugManifestValidator {
         }
 
         reasons += validateLinkRequirements(manifest)
+        reasons += validateDeviceCapabilities(manifest)
 
         return if (reasons.isEmpty()) {
             ManifestValidationResult.Valid
@@ -79,6 +85,22 @@ object PlugManifestValidator {
             }
 
         return reasons
+    }
+
+    /**
+     * A manifest declaring the same device capability token more than once
+     * is almost always a copy-paste mistake, not two distinct grants — the
+     * OS authorization APIs this maps to have no notion of "granted twice".
+     */
+    private fun validateDeviceCapabilities(
+        manifest: PlugManifest,
+    ): List<ManifestValidationReason> {
+        return manifest.requiredPermissions
+            .filterIsInstance<PlugPermission.DeviceCapability>()
+            .groupBy { it.capability }
+            .filterValues { it.size > 1 }
+            .keys
+            .map { ManifestValidationReason.DuplicateDeviceCapability(it) }
     }
 }
 
@@ -122,5 +144,13 @@ sealed interface ManifestValidationReason {
      */
     data class EmptyLinkRequirementScope(
         val name: String,
+    ) : ManifestValidationReason
+
+    /**
+     * The same [PlugPermission.DeviceCapability] token was declared more
+     * than once in [PlugManifest.requiredPermissions].
+     */
+    data class DuplicateDeviceCapability(
+        val capability: String,
     ) : ManifestValidationReason
 }

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/permission/NativeAuthorizationStatus.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/permission/NativeAuthorizationStatus.kt
@@ -1,0 +1,51 @@
+package link.socket.ampere.plug.permission
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * The OS's answer to a [PlugPermission.DeviceCapability] authorization
+ * request.
+ *
+ * This models the state EventKit/HealthKit/CoreLocation/PassKit-style
+ * authorization APIs expose, which [PlugPermissionGate]'s Ampere-internal
+ * [GateResult] does not: a `GateResult.Allow` only proves Ampere *thinks*
+ * the wire is fine, not that the OS actually granted the capability.
+ *
+ * [Restricted] and [EntitlementMissing] are kept distinct from [Denied] on
+ * purpose — they have different remedies and must not collapse:
+ * - [Denied] is a user decision; re-prompting is legitimate.
+ * - [Restricted] is a device policy (MDM, Screen Time, parental controls);
+ *   no in-app prompt can change it.
+ * - [EntitlementMissing] is a developer-account gap (e.g. FinanceKit case
+ *   grants, PassKit pass type ID certificates); prompting the user is
+ *   pointless because there is nothing for them to approve.
+ *
+ * Determining and producing this status is a client-side concern
+ * (`NativeAuthorizationGate` in Socket, per-platform). This type only
+ * defines the shared vocabulary so a status can cross the wire and be
+ * reasoned about upstream.
+ */
+@Serializable
+sealed interface NativeAuthorizationStatus {
+
+    @Serializable
+    @SerialName("granted")
+    data object Granted : NativeAuthorizationStatus
+
+    @Serializable
+    @SerialName("not_determined")
+    data object NotDetermined : NativeAuthorizationStatus
+
+    @Serializable
+    @SerialName("denied")
+    data object Denied : NativeAuthorizationStatus
+
+    @Serializable
+    @SerialName("restricted")
+    data object Restricted : NativeAuthorizationStatus
+
+    @Serializable
+    @SerialName("entitlement_missing")
+    data object EntitlementMissing : NativeAuthorizationStatus
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/permission/PlugPermission.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/permission/PlugPermission.kt
@@ -28,4 +28,19 @@ sealed interface PlugPermission {
     @Serializable
     @SerialName("link_access")
     data class LinkAccess(val linkId: String) : PlugPermission
+
+    /**
+     * A device/OS capability the plug needs (e.g. `"calendar"`,
+     * `"contacts_read"`, `"location"`). Unlike the other variants, this is
+     * not an Ampere-internal grant: authorizing it is an OS-level decision
+     * the user makes outside Ampere (an EventKit/HealthKit/CoreLocation
+     * prompt, etc.), reported back via [NativeAuthorizationStatus].
+     *
+     * The token vocabulary matches Socket's `PlugPermission.parse` tokens
+     * so a manifest declaring `device_capability` round-trips identically
+     * on both sides of the wire.
+     */
+    @Serializable
+    @SerialName("device_capability")
+    data class DeviceCapability(val capability: String) : PlugPermission
 }

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/bundle/PlugBundleValidatorTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/bundle/PlugBundleValidatorTest.kt
@@ -93,6 +93,7 @@ class PlugBundleValidatorTest {
             PlugPermission.KnowledgeQuery("") to "scope",
             PlugPermission.NativeAction("") to "actionId",
             PlugPermission.LinkAccess(" ") to "linkId",
+            PlugPermission.DeviceCapability("") to "capability",
         )
 
         variants.forEach { (permission, field) ->
@@ -111,6 +112,25 @@ class PlugBundleValidatorTest {
             assertTrue(failed.reasons.single().contains(field))
             assertTrue(failed.reasons.single().contains(permission::class.simpleName!!))
         }
+    }
+
+    @Test
+    fun `an unrecognised device capability token does not fail install`() {
+        val result = validator.validate(
+            bundle(
+                manifest = PlugManifest(
+                    id = "exotic-plug",
+                    name = "Exotic",
+                    version = "1.0.0",
+                    requiredPermissions = listOf(
+                        PlugPermission.DeviceCapability("some_future_capability"),
+                    ),
+                ),
+            ),
+        )
+
+        val ok = assertIs<BundleValidation.Ok>(result)
+        assertEquals(listOf(PlugPermission.DeviceCapability("some_future_capability")), ok.permissions)
     }
 
     @Test

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/plug/PlugManifestValidationTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/plug/PlugManifestValidationTest.kt
@@ -203,6 +203,65 @@ class PlugManifestValidationTest {
         )
     }
 
+    // -----------------------------------------------------------------
+    // Device capabilities
+    // -----------------------------------------------------------------
+
+    @Test
+    fun `a manifest declaring a device capability validates`() {
+        val manifest = PlugManifest(
+            id = "calendar-plug",
+            name = "Calendar Plug",
+            version = "1.0.0",
+            requiredPermissions = listOf(
+                PlugPermission.DeviceCapability("calendar"),
+            ),
+        )
+
+        assertEquals(ManifestValidationResult.Valid, PlugManifestValidator.validate(manifest))
+    }
+
+    @Test
+    fun `a manifest declaring an unrecognised device capability still validates`() {
+        // The validator only enforces structural rules; an unrecognised
+        // capability token is a renderer-time concern, not an install-time
+        // failure.
+        val manifest = PlugManifest(
+            id = "exotic-plug",
+            name = "Exotic Plug",
+            version = "1.0.0",
+            requiredPermissions = listOf(
+                PlugPermission.DeviceCapability("some_future_capability"),
+            ),
+        )
+
+        assertEquals(ManifestValidationResult.Valid, PlugManifestValidator.validate(manifest))
+    }
+
+    @Test
+    fun `duplicate device capability declarations are rejected`() {
+        val manifest = PlugManifest(
+            id = "calendar-plug",
+            name = "Calendar Plug",
+            version = "1.0.0",
+            requiredPermissions = listOf(
+                PlugPermission.DeviceCapability("calendar"),
+                PlugPermission.DeviceCapability("calendar"),
+            ),
+        )
+
+        val invalid = assertIs<ManifestValidationResult.Invalid>(
+            PlugManifestValidator.validate(manifest),
+        )
+
+        assertEquals(
+            listOf("calendar"),
+            invalid.reasons
+                .filterIsInstance<ManifestValidationReason.DuplicateDeviceCapability>()
+                .map { it.capability },
+        )
+    }
+
     @Test
     fun `a manifest written before link requirements existed still decodes`() {
         // The defaults are what keep pre-AMPR-223 manifests valid.

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/plug/permission/PlugPermissionSerializationTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/plug/permission/PlugPermissionSerializationTest.kt
@@ -2,6 +2,7 @@ package link.socket.ampere.plug.permission
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 import kotlinx.serialization.json.Json
 import link.socket.ampere.plug.McpServerDependency
 import link.socket.ampere.plug.PlugManifest
@@ -21,6 +22,7 @@ class PlugPermissionSerializationTest {
             PlugPermission.KnowledgeQuery("workspace"),
             PlugPermission.NativeAction("open-url"),
             PlugPermission.LinkAccess("linear-AMPR-149"),
+            PlugPermission.DeviceCapability("calendar"),
         )
 
         permissions.forEach { permission ->
@@ -29,6 +31,47 @@ class PlugPermissionSerializationTest {
 
             assertEquals(permission, decoded)
         }
+    }
+
+    @Test
+    fun `device capability permission uses a stable serial name`() {
+        val encoded = json.encodeToString(
+            PlugPermission.serializer(),
+            PlugPermission.DeviceCapability("calendar"),
+        )
+
+        assertEquals("""{"type":"device_capability","capability":"calendar"}""", encoded)
+    }
+
+    @Test
+    fun `round-trips all native authorization status variants through json`() {
+        val statuses = listOf(
+            NativeAuthorizationStatus.Granted,
+            NativeAuthorizationStatus.NotDetermined,
+            NativeAuthorizationStatus.Denied,
+            NativeAuthorizationStatus.Restricted,
+            NativeAuthorizationStatus.EntitlementMissing,
+        )
+
+        statuses.forEach { status ->
+            val encoded = json.encodeToString(NativeAuthorizationStatus.serializer(), status)
+            val decoded = json.decodeFromString(NativeAuthorizationStatus.serializer(), encoded)
+
+            assertEquals(status, decoded)
+        }
+    }
+
+    @Test
+    fun `entitlement missing is distinguishable from denied at the type level`() {
+        val denied: NativeAuthorizationStatus = NativeAuthorizationStatus.Denied
+        val entitlementMissing: NativeAuthorizationStatus = NativeAuthorizationStatus.EntitlementMissing
+
+        assertEquals("""{"type":"denied"}""", json.encodeToString(NativeAuthorizationStatus.serializer(), denied))
+        assertEquals(
+            """{"type":"entitlement_missing"}""",
+            json.encodeToString(NativeAuthorizationStatus.serializer(), entitlementMissing),
+        )
+        assertNotEquals(denied, entitlementMissing)
     }
 
     @Test

--- a/docs/concepts/plug-permissions.md
+++ b/docs/concepts/plug-permissions.md
@@ -4,10 +4,11 @@ status: stable
 tracked_sources:
   - ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/permission/**
   - ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/PlugManifest.kt
+  - ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/PlugManifestValidator.kt
   - ampere-core/src/commonMain/sqldelight/link/socket/ampere/db/PlugGrants.sq
   - ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/execution/ToolExecutionEngine.kt
 related: [SparkSystem, AgentSurface, EventSerialBus, LinkLayer]
-last_verified: 2026-07-28
+last_verified: 2026-07-30
 ---
 
 # Plug Permissions
@@ -26,7 +27,21 @@ specific permissions the tool call requested, against the user's
 
 Permissions are typed and sealed: `NetworkDomain(host)`,
 `MCPServer(uri)`, `KnowledgeQuery(scope)`, `NativeAction(actionId)`,
-`LinkAccess(linkId)`. User grants persist in `PlugGrants.sq`.
+`LinkAccess(linkId)`, `DeviceCapability(capability)`. User grants persist
+in `PlugGrants.sq`.
+
+`DeviceCapability` is different from the other five: it names an OS
+permission (calendar, contacts, location, ...), not an Ampere-internal
+capability grant. `GateResult.Allow` only proves Ampere's own grant
+bookkeeping is satisfied — it says nothing about whether the OS itself
+authorized the capability. That is reported separately via
+`NativeAuthorizationStatus` (`Granted` / `NotDetermined` / `Denied` /
+`Restricted` / `EntitlementMissing`), which a client (e.g. Socket's
+`NativeAuthorizationGate`) produces by calling the platform framework.
+`Restricted` (device policy, MDM, Screen Time) and `EntitlementMissing`
+(developer-account gap, e.g. FinanceKit grants or PassKit certificates)
+are kept distinct from `Denied` because they have different remedies —
+neither is fixed by re-prompting the user.
 
 ## Why it exists
 
@@ -51,9 +66,11 @@ Two design pressures shaped the gate:
 ## Where it lives
 
 - `plug/permission/PlugPermission.kt` — the sealed permission types.
+- `plug/permission/NativeAuthorizationStatus.kt` — the sealed OS-authorization outcome, distinct from `GateResult`.
 - `plug/permission/PlugPermissionGate.kt` — `check(toolCall, manifest, userGrants): GateResult`.
 - `plug/permission/UserGrantStore.kt` — persistence facade.
 - `plug/PlugManifest.kt` — declares `requiredPermissions`, plus the `requiredLinks` / `emits` / `consumes` declarations owned by [LinkLayer](link-layer.md).
+- `plug/PlugManifestValidator.kt` — structural manifest checks, including duplicate `DeviceCapability` declarations. Expected to run at plug install time on every host that accepts manifests; today only `PlugContext.create` calls it.
 - `commonMain/sqldelight/link/socket/ampere/db/PlugGrants.sq` — schema for user grants.
 - `agents/execution/ToolExecutionEngine.kt` — the call site that gates dispatch.
 - `agents/domain/event/PermissionDeniedEvent.kt` — emitted on `Deny*` results.
@@ -69,7 +86,8 @@ Two design pressures shaped the gate:
 
 ## Common operations
 
-- **Add a permission kind** — extend `PlugPermission` with a new `@Serializable` data class, give it a stable `@SerialName`, update the renderer that maps permissions to user-friendly prompts (`AgentSurface.Confirmation` is the standard channel for grant requests).
+- **Add a permission kind** — extend `PlugPermission` with a new `@Serializable` data class, give it a stable `@SerialName`, update the renderer that maps permissions to user-friendly prompts (`AgentSurface.Confirmation` is the standard channel for grant requests). Note that no such renderer exists yet — the only exhaustive `when` over `PlugPermission` today is `PlugBundleValidator.validatePermission`, which the compiler will force you to update.
+- **Report OS authorization state** — for a `DeviceCapability`, use `NativeAuthorizationStatus`, not `GateResult`. `GateResult` only says whether Ampere's own grant bookkeeping allows the call; it cannot represent `Restricted` or `EntitlementMissing`.
 - **Grant / revoke** — `UserGrantStore.grant(permission)` / `revoke(permission)`. These persist to `PlugGrants` and emit grant events.
 - **Gate a tool dispatch** — `ToolExecutionEngine` calls `PlugPermissionGate.check(toolCall, manifest, userGrants)`. On `Deny*`, emit `PermissionDeniedEvent` and surface a `Confirmation` to the user via `AgentSurface`.
 - **Audit grants** — read `PlugGrants` directly; rows are append-only. The user's current state is the most recent grant/revoke per permission.


### PR DESCRIPTION
## Summary
- Adds `PlugPermission.DeviceCapability(capability: String)` so a manifest can declare the OS permission it needs (calendar, contacts, location, ...), matching the string-carrying-data-class shape of the other five variants.
- Adds `NativeAuthorizationStatus` (`Granted`/`NotDetermined`/`Denied`/`Restricted`/`EntitlementMissing`) upstream in `ampere-core` so `Restricted` (device policy) and `EntitlementMissing` (developer-account gap) don't collapse into `Denied`; per-platform authorization checks stay client-side.
- `PlugManifestValidator` gains a duplicate-device-capability rule and a KDoc note on where it's expected to run; `PlugBundleValidator` handles the new variant in its exhaustive `when`.
- `docs/concepts/plug-permissions.md` updated to document both new types and flag that the permission-prompt renderer referenced by the extension recipe doesn't exist yet.

Closes #637

## Test plan
- [x] `./gradlew :ampere-core:jvmTest` passes, including new serialization round-trip, manifest-validation, and bundle-validation tests
- [x] `./gradlew :ampere-core:compileCommonMainKotlinMetadata` passes
- [x] `./gradlew :ampere-core:compileTestKotlinIosSimulatorArm64` passes
- [x] `./gradlew ktlintFormat` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)