### PR TITLE
AMPR-251 #639: Close the Plug manifest dead ends

### DIFF
--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/execution/ToolExecutionEngine.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/execution/ToolExecutionEngine.kt
@@ -276,11 +276,11 @@ class ToolExecutionEngine(
     ): ExecutionOutcome {
         eventApi?.publish(
             PermissionDeniedEvent(
-                eventId = generateUUID("permission-denied", manifest.id, tool.id, executorId),
+                eventId = generateUUID("permission-denied", manifest.id.value, tool.id, executorId),
                 timestamp = Clock.System.now(),
                 eventSource = EventSource.Agent(eventApi.agentId),
                 urgency = Urgency.HIGH,
-                plugId = manifest.id,
+                plugId = manifest.id.value,
                 toolId = tool.id,
                 toolName = tool.name,
                 permission = permission,
@@ -291,7 +291,7 @@ class ToolExecutionEngine(
         return createFailure(
             request = request,
             startTime = startTime,
-            message = "Permission denied for plug '${manifest.id}' tool '${tool.id}': " +
+            message = "Permission denied for plug '${manifest.id.value}' tool '${tool.id}': " +
                 "$reason for $permission",
         )
     }

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/bundle/PlugBundleSignatureVerifier.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/bundle/PlugBundleSignatureVerifier.kt
@@ -55,7 +55,7 @@ object NoOpPlugBundleSignatureVerifier : PlugBundleSignatureVerifier {
     override suspend fun verify(bundle: PlugBundle): PlugBundleSignatureVerification {
         log.w {
             "Signature verification is stubbed (no-op). " +
-                "Bundle '${bundle.manifest.id}' v${bundle.manifest.version} accepted without crypto."
+                "Bundle '${bundle.manifest.id.value}' v${bundle.manifest.version} accepted without crypto."
         }
         return PlugBundleSignatureVerification.Verified.Skipped
     }

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/bundle/PlugBundleValidator.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/bundle/PlugBundleValidator.kt
@@ -37,7 +37,9 @@ class PlugBundleValidator {
         }
 
         val manifest = bundle.manifest
-        if (manifest.id.isBlank()) reasons += "manifest.id is blank."
+        // manifest.id has no blank check here: PlugId's init already rejected
+        // an invalid id during deserialization, surfaced by the parser as
+        // BundleParseError.InvalidManifest before validate() ever runs.
         if (manifest.name.isBlank()) reasons += "manifest.name is blank."
         if (manifest.version.isBlank()) reasons += "manifest.version is blank."
 

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/link/LinkGrants.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/link/LinkGrants.kt
@@ -2,6 +2,7 @@ package link.socket.ampere.link
 
 import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
+import link.socket.ampere.plug.PlugId
 
 /**
  * One Plug's standing on one Link.
@@ -15,7 +16,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class LinkGrant(
-    val plugId: String,
+    val plugId: PlugId,
     val linkId: LinkId,
     val grantedAt: Instant,
     val revokedAt: Instant? = null,
@@ -32,7 +33,7 @@ data class LinkGrant(
  */
 @Serializable
 data class LinkGrants(
-    val plugId: String,
+    val plugId: PlugId,
     val grants: List<LinkGrant> = emptyList(),
 ) {
     private val byLink: Map<LinkId, LinkGrant> = grants.associateBy { it.linkId }
@@ -44,6 +45,6 @@ data class LinkGrants(
     fun isRevoked(linkId: LinkId): Boolean = byLink[linkId]?.isRevoked == true
 
     companion object {
-        fun empty(plugId: String): LinkGrants = LinkGrants(plugId)
+        fun empty(plugId: PlugId): LinkGrants = LinkGrants(plugId)
     }
 }

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/link/LinkRequirement.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/link/LinkRequirement.kt
@@ -2,6 +2,7 @@ package link.socket.ampere.link
 
 import kotlinx.serialization.Serializable
 import link.socket.ampere.canon.CanonType
+import link.socket.ampere.plug.PlugId
 
 /**
  * What a Plug declares it needs, before any concrete Link exists.
@@ -59,7 +60,7 @@ sealed interface LinkResolution {
 
 /** Every resolved Link for a Plug, keyed by [LinkRequirement.name]. */
 data class ResolvedLinks(
-    val plugId: String,
+    val plugId: PlugId,
     val byRequirement: Map<String, Link>,
 ) {
     operator fun get(requirementName: String): Link? = byRequirement[requirementName]

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/link/LinkResolutionService.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/link/LinkResolutionService.kt
@@ -6,6 +6,7 @@ import link.socket.ampere.agents.domain.event.EventSource
 import link.socket.ampere.agents.domain.event.LinkEvent
 import link.socket.ampere.agents.events.bus.EventSerialBus
 import link.socket.ampere.agents.events.utils.generateUUID
+import link.socket.ampere.plug.PlugId
 import link.socket.ampere.plug.PlugManifest
 
 /**
@@ -44,7 +45,7 @@ class LinkResolutionService(
      * [LinkResolutionException].
      */
     suspend fun resolve(
-        plugId: String,
+        plugId: PlugId,
         manifest: PlugManifest,
         agentId: AgentId? = null,
     ): Result<ResolvedLinks> {
@@ -86,7 +87,7 @@ class LinkResolutionService(
 
     /** Resolve a single requirement. Same rules, one result. */
     suspend fun resolveOne(
-        plugId: String,
+        plugId: PlugId,
         requirement: LinkRequirement,
         agentId: AgentId? = null,
     ): Result<LinkResolution> {
@@ -106,7 +107,7 @@ class LinkResolutionService(
 
     /** Record a Plug's grant on a Link and announce it. */
     suspend fun grant(
-        plugId: String,
+        plugId: PlugId,
         linkId: LinkId,
         agentId: AgentId? = null,
     ): Result<Unit> {
@@ -121,7 +122,7 @@ class LinkResolutionService(
                 timestamp = clock.now(),
                 eventSource = sourceFor(agentId),
                 linkId = linkId,
-                plugId = plugId,
+                plugId = plugId.value,
                 transport = link.transport,
             ),
         )
@@ -157,7 +158,7 @@ class LinkResolutionService(
 
     /** Revoke one Plug's grant, leaving every other Plug on the Link intact. */
     suspend fun revokeGrant(
-        plugId: String,
+        plugId: PlugId,
         linkId: LinkId,
         agentId: AgentId? = null,
     ): Result<Unit> {
@@ -171,7 +172,7 @@ class LinkResolutionService(
                 eventSource = sourceFor(agentId),
                 linkId = linkId,
                 scope = RevocationScope.PLUG_GRANT,
-                affectedPlugIds = listOf(plugId),
+                affectedPlugIds = listOf(plugId.value),
             ),
         )
 
@@ -179,7 +180,7 @@ class LinkResolutionService(
     }
 
     private suspend fun emitResolved(
-        plugId: String,
+        plugId: PlugId,
         resolution: LinkResolution.Resolved,
         agentId: AgentId?,
     ) {
@@ -189,7 +190,7 @@ class LinkResolutionService(
                 timestamp = clock.now(),
                 eventSource = sourceFor(agentId),
                 linkId = resolution.link.id,
-                plugId = plugId,
+                plugId = plugId.value,
                 requirementName = resolution.requirement.name,
                 transport = resolution.link.transport,
             ),
@@ -197,7 +198,7 @@ class LinkResolutionService(
     }
 
     private suspend fun emitFailed(
-        plugId: String,
+        plugId: PlugId,
         resolution: LinkResolution.Failed,
         agentId: AgentId?,
     ) {
@@ -207,7 +208,7 @@ class LinkResolutionService(
                 timestamp = clock.now(),
                 eventSource = sourceFor(agentId),
                 linkId = linkIdOf(resolution.failure),
-                plugId = plugId,
+                plugId = plugId.value,
                 failure = resolution.failure,
             ),
         )

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/link/LinkStore.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/link/LinkStore.kt
@@ -5,6 +5,7 @@ import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlinx.serialization.json.Json
 import link.socket.ampere.db.Database
+import link.socket.ampere.plug.PlugId
 import link.socket.ampere.util.ioDispatcher
 
 /**
@@ -27,18 +28,18 @@ interface LinkStore {
     suspend fun delete(linkId: LinkId): Result<Unit>
 
     suspend fun grant(
-        plugId: String,
+        plugId: PlugId,
         linkId: LinkId,
         grantedAt: Instant = Clock.System.now(),
     ): Result<Unit>
 
     suspend fun revokeGrant(
-        plugId: String,
+        plugId: PlugId,
         linkId: LinkId,
         revokedAt: Instant = Clock.System.now(),
     ): Result<Unit>
 
-    suspend fun grantsForPlug(plugId: String): Result<LinkGrants>
+    suspend fun grantsForPlug(plugId: PlugId): Result<LinkGrants>
 
     suspend fun grantsForLink(linkId: LinkId): Result<List<LinkGrant>>
 
@@ -106,14 +107,14 @@ class SqlDelightLinkStore(
         }
 
     override suspend fun grant(
-        plugId: String,
+        plugId: PlugId,
         linkId: LinkId,
         grantedAt: Instant,
     ): Result<Unit> =
         withContext(ioDispatcher) {
             runCatching {
                 queries.upsertLinkGrant(
-                    plug_id = plugId,
+                    plug_id = plugId.value,
                     link_id = linkId.value,
                     granted_at = grantedAt.toEpochMilliseconds(),
                     revoked_at = null,
@@ -122,18 +123,18 @@ class SqlDelightLinkStore(
         }
 
     override suspend fun revokeGrant(
-        plugId: String,
+        plugId: PlugId,
         linkId: LinkId,
         revokedAt: Instant,
     ): Result<Unit> =
         withContext(ioDispatcher) {
             runCatching {
-                val existing = queries.selectGrantsForPlug(plugId)
+                val existing = queries.selectGrantsForPlug(plugId.value)
                     .executeAsList()
                     .firstOrNull { it.link_id == linkId.value }
 
                 queries.upsertLinkGrant(
-                    plug_id = plugId,
+                    plug_id = plugId.value,
                     link_id = linkId.value,
                     granted_at = existing?.granted_at ?: revokedAt.toEpochMilliseconds(),
                     revoked_at = revokedAt.toEpochMilliseconds(),
@@ -141,14 +142,14 @@ class SqlDelightLinkStore(
             }.map { }
         }
 
-    override suspend fun grantsForPlug(plugId: String): Result<LinkGrants> =
+    override suspend fun grantsForPlug(plugId: PlugId): Result<LinkGrants> =
         withContext(ioDispatcher) {
             runCatching {
                 LinkGrants(
                     plugId = plugId,
-                    grants = queries.selectGrantsForPlug(plugId).executeAsList().map { row ->
+                    grants = queries.selectGrantsForPlug(plugId.value).executeAsList().map { row ->
                         LinkGrant(
-                            plugId = row.plug_id,
+                            plugId = PlugId(row.plug_id),
                             linkId = LinkId(row.link_id),
                             grantedAt = Instant.fromEpochMilliseconds(row.granted_at),
                             revokedAt = row.revoked_at?.let(Instant::fromEpochMilliseconds),
@@ -163,7 +164,7 @@ class SqlDelightLinkStore(
             runCatching {
                 queries.selectGrantsForLink(linkId.value).executeAsList().map { row ->
                     LinkGrant(
-                        plugId = row.plug_id,
+                        plugId = PlugId(row.plug_id),
                         linkId = LinkId(row.link_id),
                         grantedAt = Instant.fromEpochMilliseconds(row.granted_at),
                         revokedAt = row.revoked_at?.let(Instant::fromEpochMilliseconds),
@@ -220,7 +221,8 @@ class InMemoryLinkStore(
 ) : LinkStore {
 
     private val links = links.associateBy { it.id }.toMutableMap()
-    private val grants = grants.associateBy { it.plugId to it.linkId }.toMutableMap()
+    private val grants: MutableMap<Pair<PlugId, LinkId>, LinkGrant> =
+        grants.associateBy { it.plugId to it.linkId }.toMutableMap()
 
     override suspend fun upsert(link: Link, updatedAt: Instant): Result<Unit> {
         links[link.id] = link
@@ -241,7 +243,7 @@ class InMemoryLinkStore(
     }
 
     override suspend fun grant(
-        plugId: String,
+        plugId: PlugId,
         linkId: LinkId,
         grantedAt: Instant,
     ): Result<Unit> {
@@ -250,7 +252,7 @@ class InMemoryLinkStore(
     }
 
     override suspend fun revokeGrant(
-        plugId: String,
+        plugId: PlugId,
         linkId: LinkId,
         revokedAt: Instant,
     ): Result<Unit> {
@@ -264,7 +266,7 @@ class InMemoryLinkStore(
         return Result.success(Unit)
     }
 
-    override suspend fun grantsForPlug(plugId: String): Result<LinkGrants> =
+    override suspend fun grantsForPlug(plugId: PlugId): Result<LinkGrants> =
         Result.success(
             LinkGrants(plugId, grants.values.filter { it.plugId == plugId }),
         )
@@ -283,6 +285,6 @@ class InMemoryLinkStore(
 
         links[linkId]?.let { links[linkId] = it.copy(revokedAt = revokedAt) }
 
-        return Result.success(affected)
+        return Result.success(affected.map { it.value })
     }
 }

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/PlugContext.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/PlugContext.kt
@@ -1,10 +1,11 @@
 package link.socket.ampere.plug
 
 import link.socket.ampere.agents.config.AgentActionAutonomy
+import link.socket.ampere.agents.definition.AgentId
 import link.socket.ampere.agents.execution.tools.McpTool
 import link.socket.ampere.agents.execution.tools.Tool
 import link.socket.ampere.agents.tools.mcp.connection.McpServerConnection
-import link.socket.ampere.link.LinkId
+import link.socket.ampere.link.LinkResolutionService
 import link.socket.ampere.mcp.McpClient
 import link.socket.ampere.mcp.McpCredential
 import link.socket.ampere.mcp.McpCredentialBinding
@@ -20,11 +21,17 @@ import link.socket.ampere.mcp.defaultHttpConnection
  * carries the originating manifest so [PlugPermissionGate][link.socket.ampere.plug.permission.PlugPermissionGate]
  * still gates dispatch.
  *
- * Construction goes through [create]. It validates the manifest, opens an
- * [McpClient] per dependency, runs the handshake, lists tools, and wraps
- * each descriptor as an [McpTool]. Server failures are surfaced per server
- * (mirroring the existing [link.socket.ampere.agents.tools.mcp.McpServerManager]
- * resilience pattern) so one bad server doesn't kill the plug.
+ * Construction goes through [create]. It validates the manifest, resolves
+ * [PlugManifest.requiredLinks] through [LinkResolutionService] — callers pass
+ * the service, never a pre-resolved [link.socket.ampere.link.LinkId], so a
+ * misconfigured or revoked Link fails at construction instead of at first
+ * dispatch — then opens an [McpClient] per [McpServerDependency] using the
+ * Link resolved for the requirement of the same name, runs the handshake,
+ * lists tools, and wraps each descriptor as an [McpTool]. Server failures are
+ * surfaced per server (mirroring the existing
+ * [link.socket.ampere.agents.tools.mcp.McpServerManager] resilience pattern)
+ * so one bad server doesn't kill the plug — including a dependency with no
+ * matching requirement, or one whose requirement resolved to nothing.
  *
  * Tools are dispatched through
  * [link.socket.ampere.propel.ExecuteStep], which resolves the right
@@ -66,7 +73,8 @@ class PlugContext private constructor(
         suspend fun create(
             manifest: PlugManifest,
             credentialBinding: McpCredentialBinding,
-            linkId: LinkId,
+            linkResolutionService: LinkResolutionService,
+            agentId: AgentId? = null,
             nativeTools: List<Tool<*>> = emptyList(),
             connectionFactory: (McpServerDependency, McpCredential?) -> McpServerConnection =
                 ::defaultHttpConnection,
@@ -78,15 +86,27 @@ class PlugContext private constructor(
                 )
             }
 
+            val resolvedLinks = linkResolutionService.resolve(manifest.id, manifest, agentId)
+                .getOrElse { return Result.failure(it) }
+
             val clientsByUri = mutableMapOf<String, McpClient>()
             val toolsByUri = mutableMapOf<String, List<McpTool>>()
             val failures = mutableListOf<PlugContextServerFailure>()
 
             manifest.mcpServers.forEach { dependency ->
+                val link = resolvedLinks[dependency.name]
+                if (link == null) {
+                    failures += PlugContextServerFailure(
+                        dependency = dependency,
+                        cause = UnresolvedPlugLinkException(dependency.name),
+                    )
+                    return@forEach
+                }
+
                 val client = McpClient(
                     dependency = dependency,
                     credentialBinding = credentialBinding,
-                    linkId = linkId,
+                    linkId = link.id,
                     connectionFactory = connectionFactory,
                 )
 
@@ -155,3 +175,13 @@ data class PlugContextServerFailure(
 class PlugManifestValidationException(
     val reasons: List<ManifestValidationReason>,
 ) : Exception("Plug manifest validation failed: $reasons")
+
+/**
+ * Thrown internally when an [McpServerDependency] has no [LinkRequirement]
+ * of the same name resolved in [PlugContext.create]'s
+ * [link.socket.ampere.link.ResolvedLinks] — never crosses [PlugContext.create]
+ * itself, only [PlugContextServerFailure.cause].
+ */
+class UnresolvedPlugLinkException(
+    dependencyName: String,
+) : Exception("No resolved Link for MCP dependency \"$dependencyName\"")

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/PlugId.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/PlugId.kt
@@ -1,0 +1,30 @@
+package link.socket.ampere.plug
+
+import kotlin.jvm.JvmInline
+import kotlinx.serialization.Serializable
+
+/**
+ * Identifier for a [PlugManifest].
+ *
+ * Constrained to the same grammar as Socket's `ComponentId`
+ * (`[a-z0-9_-]+`) so a Plug id is always addressable by the consent
+ * ledger, the marketplace, and the registry on the other side of the
+ * wire. A shipped Socket defect traced back to a Plug id containing
+ * dots that could never be a valid `ComponentId` — validating here
+ * turns that into a construction-time failure instead of a silent,
+ * late one.
+ */
+@JvmInline
+@Serializable
+value class PlugId(val value: String) {
+
+    init {
+        require(value.matches(VALID_PATTERN)) {
+            "PlugId must match $VALID_PATTERN, was: \"$value\""
+        }
+    }
+
+    companion object {
+        private val VALID_PATTERN = Regex("^[a-z0-9_-]+$")
+    }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/PlugManifest.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/PlugManifest.kt
@@ -24,11 +24,10 @@ import link.socket.ampere.plug.permission.PlugPermission
  */
 @Serializable
 data class PlugManifest(
-    val id: String,
+    val id: PlugId,
     val name: String,
     val version: String,
     val description: String? = null,
-    val entrypoint: String? = null,
     val requiredPermissions: List<PlugPermission> = emptyList(),
     val mcpServers: List<McpServerDependency> = emptyList(),
     val requiredLinks: List<LinkRequirement> = emptyList(),

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/PlugManifestValidator.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/PlugManifestValidator.kt
@@ -1,5 +1,6 @@
 package link.socket.ampere.plug
 
+import link.socket.ampere.canon.CanonType
 import link.socket.ampere.plug.permission.PlugPermission
 
 /**
@@ -60,10 +61,12 @@ object PlugManifestValidator {
     /**
      * Structural checks on [PlugManifest.requiredLinks].
      *
-     * Both rules exist because the failure they catch is silent otherwise: a
-     * duplicate requirement name means one of the two Links is unreachable
-     * through [link.socket.ampere.link.ResolvedLinks], and an empty scope means
-     * a wire that resolves successfully and then may carry nothing.
+     * All three rules exist because the failure they catch is silent
+     * otherwise: a duplicate requirement name means one of the two Links is
+     * unreachable through [link.socket.ampere.link.ResolvedLinks], an empty
+     * scope means a wire that resolves successfully and then may carry
+     * nothing, and a scope naming a canon type the Plug never declares means
+     * the Plug is asking for data it has no stated way to produce or use.
      */
     private fun validateLinkRequirements(
         manifest: PlugManifest,
@@ -83,6 +86,16 @@ object PlugManifestValidator {
             .forEach { requirement ->
                 reasons += ManifestValidationReason.EmptyLinkRequirementScope(requirement.name)
             }
+
+        val declaredCanonTypes = manifest.emits + manifest.consumes
+        manifest.requiredLinks.forEach { requirement ->
+            (requirement.minimumScope - declaredCanonTypes).forEach { undeclared ->
+                reasons += ManifestValidationReason.UndeclaredCanonScope(
+                    requirementName = requirement.name,
+                    canonType = undeclared,
+                )
+            }
+        }
 
         return reasons
     }
@@ -152,5 +165,16 @@ sealed interface ManifestValidationReason {
      */
     data class DuplicateDeviceCapability(
         val capability: String,
+    ) : ManifestValidationReason
+
+    /**
+     * A [link.socket.ampere.link.LinkRequirement.minimumScope] names a
+     * [CanonType] the manifest neither [PlugManifest.emits] nor
+     * [PlugManifest.consumes] — the Plug is asking for data it has no stated
+     * way to produce or use.
+     */
+    data class UndeclaredCanonScope(
+        val requirementName: String,
+        val canonType: CanonType,
     ) : ManifestValidationReason
 }

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/permission/PlugPermissionGate.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/permission/PlugPermissionGate.kt
@@ -1,6 +1,7 @@
 package link.socket.ampere.plug.permission
 
 import kotlinx.serialization.Serializable
+import link.socket.ampere.plug.PlugId
 import link.socket.ampere.plug.PlugManifest
 
 /**
@@ -31,7 +32,7 @@ object PlugPermissionGate {
 
 @Serializable
 data class PlugToolCall(
-    val plugId: String,
+    val plugId: PlugId,
     val toolId: String,
     val requestedPermissions: List<PlugPermission> = emptyList(),
 )

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/permission/UserGrantStore.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/permission/UserGrantStore.kt
@@ -5,25 +5,26 @@ import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlinx.serialization.json.Json
 import link.socket.ampere.db.Database
+import link.socket.ampere.plug.PlugId
 import link.socket.ampere.util.ioDispatcher
 
 interface UserGrantStore {
 
     suspend fun grant(
-        plugId: String,
+        plugId: PlugId,
         permission: PlugPermission,
         grantedAt: Instant = Clock.System.now(),
     ): Result<Unit>
 
     suspend fun revoke(
-        plugId: String,
+        plugId: PlugId,
         permission: PlugPermission,
     ): Result<Unit>
 
-    suspend fun listGrants(plugId: String): Result<UserGrants>
+    suspend fun listGrants(plugId: PlugId): Result<UserGrants>
 
     suspend fun hasGrant(
-        plugId: String,
+        plugId: PlugId,
         permission: PlugPermission,
     ): Result<Boolean>
 }
@@ -40,14 +41,14 @@ class SqlDelightUserGrantStore(
         get() = database.plugGrantsQueries
 
     override suspend fun grant(
-        plugId: String,
+        plugId: PlugId,
         permission: PlugPermission,
         grantedAt: Instant,
     ): Result<Unit> =
         withContext(ioDispatcher) {
             runCatching {
                 queries.upsertGrant(
-                    plug_id = plugId,
+                    plug_id = plugId.value,
                     permission_json = encode(permission),
                     granted_at = grantedAt.toEpochMilliseconds(),
                 )
@@ -55,22 +56,22 @@ class SqlDelightUserGrantStore(
         }
 
     override suspend fun revoke(
-        plugId: String,
+        plugId: PlugId,
         permission: PlugPermission,
     ): Result<Unit> =
         withContext(ioDispatcher) {
             runCatching {
                 queries.revokeGrant(
-                    plug_id = plugId,
+                    plug_id = plugId.value,
                     permission_json = encode(permission),
                 )
             }.map { }
         }
 
-    override suspend fun listGrants(plugId: String): Result<UserGrants> =
+    override suspend fun listGrants(plugId: PlugId): Result<UserGrants> =
         withContext(ioDispatcher) {
             runCatching {
-                val granted = queries.listGrants(plugId)
+                val granted = queries.listGrants(plugId.value)
                     .executeAsList()
                     .map { row -> decode(row.permission_json) }
 
@@ -79,13 +80,13 @@ class SqlDelightUserGrantStore(
         }
 
     override suspend fun hasGrant(
-        plugId: String,
+        plugId: PlugId,
         permission: PlugPermission,
     ): Result<Boolean> =
         withContext(ioDispatcher) {
             runCatching {
                 queries.countGrant(
-                    plug_id = plugId,
+                    plug_id = plugId.value,
                     permission_json = encode(permission),
                 ).executeAsOne() > 0
             }

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/bundle/PlugBundleParserTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/bundle/PlugBundleParserTest.kt
@@ -5,6 +5,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 import kotlinx.serialization.json.Json
+import link.socket.ampere.plug.PlugId
 import link.socket.ampere.plug.PlugManifest
 import link.socket.ampere.plug.permission.PlugPermission
 
@@ -22,7 +23,7 @@ class PlugBundleParserTest {
         val manifest = BundleManifest(
             bundleFormatVersion = 1,
             plug = PlugManifest(
-                id = "github-plug",
+                id = PlugId("github-plug"),
                 name = "GitHub Plug",
                 version = "1.0.0",
                 requiredPermissions = listOf(
@@ -55,7 +56,7 @@ class PlugBundleParserTest {
     fun `bundle without optional entries omits assets and signature`() {
         val manifest = BundleManifest(
             bundleFormatVersion = 1,
-            plug = PlugManifest(id = "x", name = "X", version = "0.1.0"),
+            plug = PlugManifest(id = PlugId("x"), name = "X", version = "0.1.0"),
         )
         val source = MapBundleSource(
             mapOf(

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/bundle/PlugBundleSignatureVerifierTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/bundle/PlugBundleSignatureVerifierTest.kt
@@ -3,13 +3,14 @@ package link.socket.ampere.bundle
 import kotlin.test.Test
 import kotlin.test.assertSame
 import kotlinx.coroutines.test.runTest
+import link.socket.ampere.plug.PlugId
 import link.socket.ampere.plug.PlugManifest
 
 class PlugBundleSignatureVerifierTest {
 
     private val bundle = PlugBundle(
         bundleFormatVersion = 1,
-        manifest = PlugManifest(id = "x", name = "X", version = "1.0.0"),
+        manifest = PlugManifest(id = PlugId("x"), name = "X", version = "1.0.0"),
         assets = emptyMap(),
         signature = byteArrayOf(0x01, 0x02),
     )
@@ -24,7 +25,7 @@ class PlugBundleSignatureVerifierTest {
     fun `default no-op verifier returns Verified Skipped even when signature is absent`() = runTest {
         val unsigned = PlugBundle(
             bundleFormatVersion = 1,
-            manifest = PlugManifest(id = "x", name = "X", version = "1.0.0"),
+            manifest = PlugManifest(id = PlugId("x"), name = "X", version = "1.0.0"),
             assets = emptyMap(),
             signature = null,
         )

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/bundle/PlugBundleValidatorTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/bundle/PlugBundleValidatorTest.kt
@@ -2,8 +2,10 @@ package link.socket.ampere.bundle
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
+import link.socket.ampere.plug.PlugId
 import link.socket.ampere.plug.PlugManifest
 import link.socket.ampere.plug.permission.PlugPermission
 
@@ -12,7 +14,7 @@ class PlugBundleValidatorTest {
     private val validator = PlugBundleValidator()
 
     private fun bundle(
-        manifest: PlugManifest = PlugManifest(id = "x", name = "X", version = "1.0.0"),
+        manifest: PlugManifest = PlugManifest(id = PlugId("x"), name = "X", version = "1.0.0"),
         bundleFormatVersion: Int = CURRENT_BUNDLE_FORMAT_VERSION,
         signature: ByteArray? = null,
         assets: Map<String, ByteArray> = emptyMap(),
@@ -33,7 +35,7 @@ class PlugBundleValidatorTest {
         val result = validator.validate(
             bundle(
                 manifest = PlugManifest(
-                    id = "github-plug",
+                    id = PlugId("github-plug"),
                     name = "GitHub",
                     version = "1.0.0",
                     requiredPermissions = permissions,
@@ -59,18 +61,16 @@ class PlugBundleValidatorTest {
     }
 
     @Test
-    fun `blank manifest id is reported`() {
-        val result = validator.validate(
-            bundle(manifest = PlugManifest(id = "  ", name = "x", version = "1.0.0")),
-        )
-        val failed = assertIs<BundleValidation.Failed>(result)
-        assertEquals(listOf("manifest.id is blank."), failed.reasons)
+    fun `blank manifest id fails at PlugId construction before the validator ever runs`() {
+        assertFailsWith<IllegalArgumentException> {
+            PlugId("  ")
+        }
     }
 
     @Test
     fun `blank manifest name is reported`() {
         val result = validator.validate(
-            bundle(manifest = PlugManifest(id = "x", name = "", version = "1.0.0")),
+            bundle(manifest = PlugManifest(id = PlugId("x"), name = "", version = "1.0.0")),
         )
         val failed = assertIs<BundleValidation.Failed>(result)
         assertEquals(listOf("manifest.name is blank."), failed.reasons)
@@ -79,7 +79,7 @@ class PlugBundleValidatorTest {
     @Test
     fun `blank manifest version is reported`() {
         val result = validator.validate(
-            bundle(manifest = PlugManifest(id = "x", name = "x", version = "")),
+            bundle(manifest = PlugManifest(id = PlugId("x"), name = "x", version = "")),
         )
         val failed = assertIs<BundleValidation.Failed>(result)
         assertEquals(listOf("manifest.version is blank."), failed.reasons)
@@ -100,7 +100,7 @@ class PlugBundleValidatorTest {
             val result = validator.validate(
                 bundle(
                     manifest = PlugManifest(
-                        id = "x",
+                        id = PlugId("x"),
                         name = "x",
                         version = "1.0.0",
                         requiredPermissions = listOf(permission),
@@ -119,7 +119,7 @@ class PlugBundleValidatorTest {
         val result = validator.validate(
             bundle(
                 manifest = PlugManifest(
-                    id = "exotic-plug",
+                    id = PlugId("exotic-plug"),
                     name = "Exotic",
                     version = "1.0.0",
                     requiredPermissions = listOf(
@@ -145,10 +145,10 @@ class PlugBundleValidatorTest {
         val result = validator.validate(
             bundle(
                 bundleFormatVersion = 999,
-                manifest = PlugManifest(id = "", name = "", version = ""),
+                manifest = PlugManifest(id = PlugId("x"), name = "", version = ""),
             ),
         )
         val failed = assertIs<BundleValidation.Failed>(result)
-        assertTrue(failed.reasons.size >= 4)
+        assertTrue(failed.reasons.size >= 3)
     }
 }

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/link/LinkResolutionGateTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/link/LinkResolutionGateTest.kt
@@ -6,6 +6,7 @@ import kotlin.test.assertIs
 import kotlin.test.assertTrue
 import kotlinx.datetime.Instant
 import link.socket.ampere.canon.CanonType
+import link.socket.ampere.plug.PlugId
 
 class LinkResolutionGateTest {
 
@@ -30,8 +31,8 @@ class LinkResolutionGateTest {
     )
 
     private fun grants(plugId: String, links: List<LinkId>) = LinkGrants(
-        plugId = plugId,
-        grants = links.map { LinkGrant(plugId, it, grantedAt) },
+        plugId = PlugId(plugId),
+        grants = links.map { LinkGrant(PlugId(plugId), it, grantedAt) },
     )
 
     private fun grants(plugId: String, link: LinkId) = grants(plugId, listOf(link))
@@ -76,7 +77,7 @@ class LinkResolutionGateTest {
         val result = LinkResolutionGate.resolve(
             requirement = requirement(),
             candidates = listOf(googleLink),
-            grants = LinkGrants.empty("stranger-plug"),
+            grants = LinkGrants.empty(PlugId("stranger-plug")),
             platform = PlatformTarget.ANDROID,
         )
 
@@ -205,8 +206,8 @@ class LinkResolutionGateTest {
     @Test
     fun `a revoked Plug grant reports PLUG_GRANT scope and spares other Plugs`() {
         val revokedGrants = LinkGrants(
-            plugId = "calendar-plug",
-            grants = listOf(LinkGrant("calendar-plug", googleLink.id, grantedAt, revokedAt)),
+            plugId = PlugId("calendar-plug"),
+            grants = listOf(LinkGrant(PlugId("calendar-plug"), googleLink.id, grantedAt, revokedAt)),
         )
 
         val revokedPlug = LinkResolutionGate.resolve(
@@ -308,7 +309,7 @@ class LinkResolutionGateTest {
         val result = LinkResolutionGate.resolve(
             requirement = requirement(optional = true),
             candidates = emptyList(),
-            grants = LinkGrants.empty("calendar-plug"),
+            grants = LinkGrants.empty(PlugId("calendar-plug")),
             platform = PlatformTarget.ANDROID,
         )
 

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/link/LinkResolutionServiceTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/link/LinkResolutionServiceTest.kt
@@ -18,6 +18,7 @@ import link.socket.ampere.agents.events.bus.EventSerialBus
 import link.socket.ampere.agents.events.bus.subscribe
 import link.socket.ampere.agents.events.subscription.EventSubscription
 import link.socket.ampere.canon.CanonType
+import link.socket.ampere.plug.PlugId
 import link.socket.ampere.plug.PlugManifest
 
 class LinkResolutionServiceTest {
@@ -39,7 +40,7 @@ class LinkResolutionServiceTest {
     )
 
     private fun manifest(vararg requirements: LinkRequirement) = PlugManifest(
-        id = "calendar-plug",
+        id = PlugId("calendar-plug"),
         name = "Calendar Plug",
         version = "1.0.0",
         requiredLinks = requirements.toList(),
@@ -56,10 +57,10 @@ class LinkResolutionServiceTest {
     @Test
     fun `resolution returns the Link keyed by requirement name`() = runTest {
         val store = InMemoryLinkStore(listOf(googleLink))
-        store.grant("calendar-plug", googleLink.id, Instant.fromEpochMilliseconds(1))
+        store.grant(PlugId("calendar-plug"), googleLink.id, Instant.fromEpochMilliseconds(1))
 
         val resolved = service(store)
-            .resolve("calendar-plug", manifest(calendarRequirement))
+            .resolve(PlugId("calendar-plug"), manifest(calendarRequirement))
             .getOrThrow()
 
         assertEquals(googleLink, resolved["calendar"])
@@ -70,7 +71,7 @@ class LinkResolutionServiceTest {
     fun `a missing Link is a Result failure and never a throw`() = runTest {
         val store = InMemoryLinkStore()
 
-        val result = service(store).resolve("calendar-plug", manifest(calendarRequirement))
+        val result = service(store).resolve(PlugId("calendar-plug"), manifest(calendarRequirement))
 
         assertTrue(result.isFailure)
         val error = assertIs<LinkResolutionException>(result.exceptionOrNull())
@@ -80,10 +81,10 @@ class LinkResolutionServiceTest {
     @Test
     fun `every failure is reported rather than just the first`() = runTest {
         val store = InMemoryLinkStore(listOf(googleLink))
-        store.grant("calendar-plug", googleLink.id, Instant.fromEpochMilliseconds(1))
+        store.grant(PlugId("calendar-plug"), googleLink.id, Instant.fromEpochMilliseconds(1))
 
         val result = service(store).resolve(
-            plugId = "calendar-plug",
+            plugId = PlugId("calendar-plug"),
             manifest = manifest(
                 calendarRequirement.copy(
                     name = "health",
@@ -109,10 +110,10 @@ class LinkResolutionServiceTest {
     @Test
     fun `an optional requirement does not fail the whole resolution`() = runTest {
         val store = InMemoryLinkStore(listOf(googleLink))
-        store.grant("calendar-plug", googleLink.id, Instant.fromEpochMilliseconds(1))
+        store.grant(PlugId("calendar-plug"), googleLink.id, Instant.fromEpochMilliseconds(1))
 
         val resolved = service(store).resolve(
-            plugId = "calendar-plug",
+            plugId = PlugId("calendar-plug"),
             manifest = manifest(
                 calendarRequirement,
                 LinkRequirement(
@@ -139,11 +140,11 @@ class LinkResolutionServiceTest {
             scope = setOf(CanonType.MESSAGE),
         )
         val store = InMemoryLinkStore(listOf(googleLink, writeOnly))
-        store.grant("calendar-plug", googleLink.id, Instant.fromEpochMilliseconds(1))
-        store.grant("calendar-plug", writeOnly.id, Instant.fromEpochMilliseconds(2))
+        store.grant(PlugId("calendar-plug"), googleLink.id, Instant.fromEpochMilliseconds(1))
+        store.grant(PlugId("calendar-plug"), writeOnly.id, Instant.fromEpochMilliseconds(2))
 
         val resolved = service(store, platform = PlatformTarget.JVM_DESKTOP).resolve(
-            plugId = "calendar-plug",
+            plugId = PlugId("calendar-plug"),
             manifest = manifest(
                 calendarRequirement,
                 LinkRequirement(
@@ -166,10 +167,10 @@ class LinkResolutionServiceTest {
     fun `granting an unknown Link fails without touching the store`() = runTest {
         val store = InMemoryLinkStore()
 
-        val result = service(store).grant("calendar-plug", LinkId("ghost"))
+        val result = service(store).grant(PlugId("calendar-plug"), LinkId("ghost"))
 
         assertIs<UnknownLinkException>(result.exceptionOrNull())
-        assertTrue(store.grantsForPlug("calendar-plug").getOrThrow().grants.isEmpty())
+        assertTrue(store.grantsForPlug(PlugId("calendar-plug")).getOrThrow().grants.isEmpty())
     }
 
     // -----------------------------------------------------------------
@@ -179,29 +180,29 @@ class LinkResolutionServiceTest {
     @Test
     fun `revoking a Link cascades to every Plug that held a grant`() = runTest {
         val store = InMemoryLinkStore(listOf(googleLink))
-        store.grant("calendar-plug", googleLink.id, Instant.fromEpochMilliseconds(1))
-        store.grant("gmail-plug", googleLink.id, Instant.fromEpochMilliseconds(2))
+        store.grant(PlugId("calendar-plug"), googleLink.id, Instant.fromEpochMilliseconds(1))
+        store.grant(PlugId("gmail-plug"), googleLink.id, Instant.fromEpochMilliseconds(2))
 
         val affected = service(store).revokeLink(googleLink.id).getOrThrow()
 
         assertEquals(setOf("calendar-plug", "gmail-plug"), affected.toSet())
         assertTrue(store.get(googleLink.id).getOrThrow()!!.isRevoked)
-        assertTrue(store.grantsForPlug("gmail-plug").getOrThrow().isRevoked(googleLink.id))
+        assertTrue(store.grantsForPlug(PlugId("gmail-plug")).getOrThrow().isRevoked(googleLink.id))
     }
 
     @Test
     fun `revoking one Plug's grant leaves the other Plug working`() = runTest {
         val store = InMemoryLinkStore(listOf(googleLink))
-        store.grant("calendar-plug", googleLink.id, Instant.fromEpochMilliseconds(1))
-        store.grant("gmail-plug", googleLink.id, Instant.fromEpochMilliseconds(2))
+        store.grant(PlugId("calendar-plug"), googleLink.id, Instant.fromEpochMilliseconds(1))
+        store.grant(PlugId("gmail-plug"), googleLink.id, Instant.fromEpochMilliseconds(2))
 
         val svc = service(store)
-        svc.revokeGrant("calendar-plug", googleLink.id).getOrThrow()
+        svc.revokeGrant(PlugId("calendar-plug"), googleLink.id).getOrThrow()
 
-        assertTrue(svc.resolve("calendar-plug", manifest(calendarRequirement)).isFailure)
+        assertTrue(svc.resolve(PlugId("calendar-plug"), manifest(calendarRequirement)).isFailure)
         assertTrue(
             svc.resolve(
-                "gmail-plug",
+                PlugId("gmail-plug"),
                 manifest(calendarRequirement.copy(name = "mail", minimumScope = setOf(CanonType.EMAIL_MESSAGE))),
             ).isSuccess,
         )
@@ -225,10 +226,10 @@ class LinkResolutionServiceTest {
             }
 
             val store = InMemoryLinkStore(listOf(googleLink))
-            store.grant("calendar-plug", googleLink.id, Instant.fromEpochMilliseconds(1))
+            store.grant(PlugId("calendar-plug"), googleLink.id, Instant.fromEpochMilliseconds(1))
 
             service(store, bus = bus)
-                .resolve("calendar-plug", manifest(calendarRequirement))
+                .resolve(PlugId("calendar-plug"), manifest(calendarRequirement))
                 .getOrThrow()
 
             val seen = withTimeout(5.seconds) { received.await() }
@@ -252,7 +253,7 @@ class LinkResolutionServiceTest {
             }
 
             service(InMemoryLinkStore(), bus = bus)
-                .resolve("calendar-plug", manifest(calendarRequirement))
+                .resolve(PlugId("calendar-plug"), manifest(calendarRequirement))
 
             val seen = withTimeout(5.seconds) { received.await() }
             assertIs<LinkResolutionFailure.MissingLink>(seen.failure)
@@ -274,8 +275,8 @@ class LinkResolutionServiceTest {
             }
 
             val store = InMemoryLinkStore(listOf(googleLink))
-            store.grant("calendar-plug", googleLink.id, Instant.fromEpochMilliseconds(1))
-            store.grant("gmail-plug", googleLink.id, Instant.fromEpochMilliseconds(2))
+            store.grant(PlugId("calendar-plug"), googleLink.id, Instant.fromEpochMilliseconds(1))
+            store.grant(PlugId("gmail-plug"), googleLink.id, Instant.fromEpochMilliseconds(2))
 
             service(store, bus = bus).revokeLink(googleLink.id).getOrThrow()
 
@@ -288,11 +289,11 @@ class LinkResolutionServiceTest {
     @Test
     fun `resolution works with no bus wired`() = runTest {
         val store = InMemoryLinkStore(listOf(googleLink))
-        store.grant("calendar-plug", googleLink.id, Instant.fromEpochMilliseconds(1))
+        store.grant(PlugId("calendar-plug"), googleLink.id, Instant.fromEpochMilliseconds(1))
 
         assertTrue(
             service(store, bus = null)
-                .resolve("calendar-plug", manifest(calendarRequirement))
+                .resolve(PlugId("calendar-plug"), manifest(calendarRequirement))
                 .isSuccess,
         )
     }

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/plug/PlugIdTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/plug/PlugIdTest.kt
@@ -1,0 +1,62 @@
+package link.socket.ampere.plug
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlinx.serialization.json.Json
+
+class PlugIdTest {
+
+    @Test
+    fun `accepts lowercase alphanumeric with dashes and underscores`() {
+        listOf("github-plug", "calendar_plug", "plug1", "x", "a-b_c-1").forEach { value ->
+            assertEquals(value, PlugId(value).value)
+        }
+    }
+
+    @Test
+    fun `rejects a dotted id like the Calendar Plug incident`() {
+        assertFailsWith<IllegalArgumentException> {
+            PlugId("link.socket.plug.calendar")
+        }
+    }
+
+    @Test
+    fun `rejects uppercase`() {
+        assertFailsWith<IllegalArgumentException> {
+            PlugId("GitHub-Plug")
+        }
+    }
+
+    @Test
+    fun `rejects blank`() {
+        assertFailsWith<IllegalArgumentException> {
+            PlugId("")
+        }
+    }
+
+    @Test
+    fun `rejects whitespace`() {
+        assertFailsWith<IllegalArgumentException> {
+            PlugId("github plug")
+        }
+    }
+
+    @Test
+    fun `fails at construction during json decoding of an invalid id`() {
+        assertFailsWith<IllegalArgumentException> {
+            Json.decodeFromString(PlugId.serializer(), "\"link.socket.plug.calendar\"")
+        }
+    }
+
+    @Test
+    fun `round-trips through json as the bare string value`() {
+        val id = PlugId("github-plug")
+
+        val encoded = Json.encodeToString(PlugId.serializer(), id)
+        assertEquals("\"github-plug\"", encoded)
+
+        val decoded = Json.decodeFromString(PlugId.serializer(), encoded)
+        assertEquals(id, decoded)
+    }
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/plug/PlugManifestSerializationTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/plug/PlugManifestSerializationTest.kt
@@ -1,0 +1,56 @@
+package link.socket.ampere.plug
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.serialization.json.Json
+import link.socket.ampere.plug.permission.PlugPermission
+
+class PlugManifestSerializationTest {
+
+    private val json = Json {
+        classDiscriminator = "type"
+        encodeDefaults = true
+        ignoreUnknownKeys = true
+    }
+
+    @Test
+    fun `round-trips a manifest through json unchanged`() {
+        val manifest = PlugManifest(
+            id = PlugId("github-plug"),
+            name = "GitHub Plug",
+            version = "1.0.0",
+            description = "Open and review GitHub PRs from inside Ampere.",
+            requiredPermissions = listOf(
+                PlugPermission.NetworkDomain("api.github.com"),
+                PlugPermission.MCPServer("mcp://github"),
+            ),
+            mcpServers = listOf(McpServerDependency(name = "github", uri = "mcp://github")),
+        )
+
+        val encoded = json.encodeToString(PlugManifest.serializer(), manifest)
+        val decoded = json.decodeFromString(PlugManifest.serializer(), encoded)
+
+        assertEquals(manifest, decoded)
+    }
+
+    @Test
+    fun `a pre-existing manifest still decodes with its now-removed entrypoint field ignored`() {
+        val legacyManifestJson = """
+            {
+              "id": "github-plug",
+              "name": "GitHub Plug",
+              "version": "1.0.0",
+              "entrypoint": "main",
+              "requiredPermissions": [
+                { "type": "mcp_server", "uri": "mcp://github" }
+              ]
+            }
+        """.trimIndent()
+
+        val decoded = json.decodeFromString(PlugManifest.serializer(), legacyManifestJson)
+
+        assertEquals(PlugId("github-plug"), decoded.id)
+        assertEquals("GitHub Plug", decoded.name)
+        assertEquals(listOf(PlugPermission.MCPServer("mcp://github")), decoded.requiredPermissions)
+    }
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/plug/PlugManifestValidationTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/plug/PlugManifestValidationTest.kt
@@ -15,7 +15,7 @@ class PlugManifestValidationTest {
     @Test
     fun `manifest with declared mcp server and matching permission validates`() {
         val manifest = PlugManifest(
-            id = "github-plug",
+            id = PlugId("github-plug"),
             name = "GitHub Plug",
             version = "1.0.0",
             requiredPermissions = listOf(
@@ -37,7 +37,7 @@ class PlugManifestValidationTest {
     @Test
     fun `manifest missing matching mcp permission fails with diagnostic naming the uri`() {
         val manifest = PlugManifest(
-            id = "github-plug",
+            id = PlugId("github-plug"),
             name = "GitHub Plug",
             version = "1.0.0",
             requiredPermissions = emptyList(),
@@ -62,7 +62,7 @@ class PlugManifestValidationTest {
     fun `dependency permission not lifted to manifest is flagged`() {
         val knowledgeQuery = PlugPermission.KnowledgeQuery("workspace")
         val manifest = PlugManifest(
-            id = "github-plug",
+            id = PlugId("github-plug"),
             name = "GitHub Plug",
             version = "1.0.0",
             requiredPermissions = listOf(
@@ -90,7 +90,7 @@ class PlugManifestValidationTest {
     @Test
     fun `manifest with no mcp servers validates regardless of permissions`() {
         val manifest = PlugManifest(
-            id = "no-mcp-plug",
+            id = PlugId("no-mcp-plug"),
             name = "No MCP Plug",
             version = "1.0.0",
         )
@@ -103,7 +103,7 @@ class PlugManifestValidationTest {
     @Test
     fun `multiple mcp servers all require their own permissions`() {
         val manifest = PlugManifest(
-            id = "multi-mcp",
+            id = PlugId("multi-mcp"),
             name = "Multi MCP",
             version = "1.0.0",
             requiredPermissions = listOf(
@@ -142,14 +142,14 @@ class PlugManifestValidationTest {
     @Test
     fun `a manifest declaring well-formed link requirements validates`() {
         val manifest = PlugManifest(
-            id = "calendar-plug",
+            id = PlugId("calendar-plug"),
             name = "Calendar Plug",
             version = "1.0.0",
             requiredLinks = listOf(
                 linkRequirement("calendar"),
                 linkRequirement("mail", setOf(CanonType.EMAIL_MESSAGE)),
             ),
-            emits = setOf(CanonType.CALENDAR_EVENT),
+            emits = setOf(CanonType.CALENDAR_EVENT, CanonType.EMAIL_MESSAGE),
             consumes = setOf(CanonType.PERSON),
         )
 
@@ -161,7 +161,7 @@ class PlugManifestValidationTest {
         // Both would collapse onto one key in ResolvedLinks, so one Link would
         // be silently unreachable at execution time.
         val manifest = PlugManifest(
-            id = "calendar-plug",
+            id = PlugId("calendar-plug"),
             name = "Calendar Plug",
             version = "1.0.0",
             requiredLinks = listOf(
@@ -185,7 +185,7 @@ class PlugManifestValidationTest {
     @Test
     fun `a link requirement with an empty scope is rejected`() {
         val manifest = PlugManifest(
-            id = "calendar-plug",
+            id = PlugId("calendar-plug"),
             name = "Calendar Plug",
             version = "1.0.0",
             requiredLinks = listOf(linkRequirement("calendar", emptySet())),
@@ -210,7 +210,7 @@ class PlugManifestValidationTest {
     @Test
     fun `a manifest declaring a device capability validates`() {
         val manifest = PlugManifest(
-            id = "calendar-plug",
+            id = PlugId("calendar-plug"),
             name = "Calendar Plug",
             version = "1.0.0",
             requiredPermissions = listOf(
@@ -227,7 +227,7 @@ class PlugManifestValidationTest {
         // capability token is a renderer-time concern, not an install-time
         // failure.
         val manifest = PlugManifest(
-            id = "exotic-plug",
+            id = PlugId("exotic-plug"),
             name = "Exotic Plug",
             version = "1.0.0",
             requiredPermissions = listOf(
@@ -241,7 +241,7 @@ class PlugManifestValidationTest {
     @Test
     fun `duplicate device capability declarations are rejected`() {
         val manifest = PlugManifest(
-            id = "calendar-plug",
+            id = PlugId("calendar-plug"),
             name = "Calendar Plug",
             version = "1.0.0",
             requiredPermissions = listOf(
@@ -263,9 +263,48 @@ class PlugManifestValidationTest {
     }
 
     @Test
+    fun `a link requirement scoped to a canon type the manifest neither emits nor consumes is rejected`() {
+        val manifest = PlugManifest(
+            id = PlugId("calendar-plug"),
+            name = "Calendar Plug",
+            version = "1.0.0",
+            requiredLinks = listOf(linkRequirement("calendar", setOf(CanonType.CALENDAR_EVENT))),
+            emits = setOf(CanonType.PERSON),
+            consumes = emptySet(),
+        )
+
+        val invalid = assertIs<ManifestValidationResult.Invalid>(
+            PlugManifestValidator.validate(manifest),
+        )
+
+        val undeclared = invalid.reasons
+            .filterIsInstance<ManifestValidationReason.UndeclaredCanonScope>()
+        assertEquals(1, undeclared.size)
+        assertEquals("calendar", undeclared.single().requirementName)
+        assertEquals(CanonType.CALENDAR_EVENT, undeclared.single().canonType)
+    }
+
+    @Test
+    fun `a link requirement scoped to a canon type in either emits or consumes validates`() {
+        val manifest = PlugManifest(
+            id = PlugId("calendar-plug"),
+            name = "Calendar Plug",
+            version = "1.0.0",
+            requiredLinks = listOf(
+                linkRequirement("calendar", setOf(CanonType.CALENDAR_EVENT)),
+                linkRequirement("contacts", setOf(CanonType.PERSON)),
+            ),
+            emits = setOf(CanonType.CALENDAR_EVENT),
+            consumes = setOf(CanonType.PERSON),
+        )
+
+        assertEquals(ManifestValidationResult.Valid, PlugManifestValidator.validate(manifest))
+    }
+
+    @Test
     fun `a manifest written before link requirements existed still decodes`() {
         // The defaults are what keep pre-AMPR-223 manifests valid.
-        val manifest = PlugManifest(id = "legacy", name = "Legacy", version = "0.1.0")
+        val manifest = PlugManifest(id = PlugId("legacy"), name = "Legacy", version = "0.1.0")
 
         assertTrue(manifest.requiredLinks.isEmpty())
         assertTrue(manifest.emits.isEmpty())

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/plug/permission/PlugPermissionGateTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/plug/permission/PlugPermissionGateTest.kt
@@ -2,13 +2,14 @@ package link.socket.ampere.plug.permission
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import link.socket.ampere.plug.PlugId
 import link.socket.ampere.plug.PlugManifest
 
 class PlugPermissionGateTest {
 
     private val permission = PlugPermission.NetworkDomain("api.example.com")
     private val manifest = PlugManifest(
-        id = "example-plug",
+        id = PlugId("example-plug"),
         name = "Example Plug",
         version = "1.0.0",
         requiredPermissions = listOf(permission),

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/plug/permission/PlugPermissionSerializationTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/plug/permission/PlugPermissionSerializationTest.kt
@@ -5,6 +5,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 import kotlinx.serialization.json.Json
 import link.socket.ampere.plug.McpServerDependency
+import link.socket.ampere.plug.PlugId
 import link.socket.ampere.plug.PlugManifest
 
 class PlugPermissionSerializationTest {
@@ -92,7 +93,7 @@ class PlugPermissionSerializationTest {
     @Test
     fun `manifest surfaces declared required permissions`() {
         val original = PlugManifest(
-            id = "github-plug",
+            id = PlugId("github-plug"),
             name = "GitHub Plug",
             version = "1.0.0",
             requiredPermissions = listOf(
@@ -125,7 +126,7 @@ class PlugPermissionSerializationTest {
     @Test
     fun `manifest round-trips mcp server dependencies through json`() {
         val original = PlugManifest(
-            id = "github-plug",
+            id = PlugId("github-plug"),
             name = "GitHub Plug",
             version = "1.0.0",
             requiredPermissions = listOf(

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/plug/permission/ToolExecutionPermissionGateTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/plug/permission/ToolExecutionPermissionGateTest.kt
@@ -28,6 +28,7 @@ import link.socket.ampere.domain.agent.bundled.WriteCodeAgent
 import link.socket.ampere.domain.ai.configuration.AIConfiguration_Default
 import link.socket.ampere.domain.ai.model.AIModel_Claude
 import link.socket.ampere.domain.ai.provider.AIProvider_Anthropic
+import link.socket.ampere.plug.PlugId
 import link.socket.ampere.plug.PlugManifest
 
 class ToolExecutionPermissionGateTest {
@@ -38,7 +39,7 @@ class ToolExecutionPermissionGateTest {
         val executor = FunctionExecutor.create()
         val permission = PlugPermission.NetworkDomain("api.example.com")
         val manifest = PlugManifest(
-            id = "example-plug",
+            id = PlugId("example-plug"),
             name = "Example Plug",
             version = "1.0.0",
             requiredPermissions = listOf(permission),

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/plug/spi/PerceiveSourceTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/plug/spi/PerceiveSourceTest.kt
@@ -12,6 +12,7 @@ import link.socket.ampere.canon.CanonType
 import link.socket.ampere.canon.SourceHandle
 import link.socket.ampere.canon.adapter.CanonConversionFailure
 import link.socket.ampere.link.LinkId
+import link.socket.ampere.plug.PlugId
 import link.socket.ampere.plug.PlugManifest
 
 class PerceiveSourceTest {
@@ -87,7 +88,7 @@ class PerceiveSourceTest {
     @Test
     fun `emits disagreeing with a manifest is detectable by a caller`() {
         val manifest = PlugManifest(
-            id = "contacts-plug",
+            id = PlugId("contacts-plug"),
             name = "Contacts",
             version = "1.0.0",
             emits = setOf(CanonType.PERSON, CanonType.EMAIL_MESSAGE),

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/tools/DefaultToolRegistryTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/tools/DefaultToolRegistryTest.kt
@@ -7,6 +7,7 @@ import kotlin.test.assertNotNull
 import link.socket.ampere.agents.config.AgentActionAutonomy
 import link.socket.ampere.agents.execution.tools.FunctionTool
 import link.socket.ampere.knowledge.InMemoryKnowledgeStore
+import link.socket.ampere.plug.PlugId
 import link.socket.ampere.plug.PlugManifest
 import link.socket.ampere.plug.permission.GateResult
 import link.socket.ampere.plug.permission.PlugPermission
@@ -96,7 +97,7 @@ class DefaultToolRegistryTest {
         id: String,
         vararg permissions: PlugPermission,
     ): PlugManifest = PlugManifest(
-        id = id,
+        id = PlugId(id),
         name = "Test plug $id",
         version = "1.0.0",
         requiredPermissions = permissions.toList(),

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/tools/KnowledgeQueryToolTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/tools/KnowledgeQueryToolTest.kt
@@ -25,6 +25,7 @@ import link.socket.ampere.knowledge.InMemoryKnowledgeStore
 import link.socket.ampere.knowledge.KnowledgeDocument
 import link.socket.ampere.knowledge.KnowledgeScope
 import link.socket.ampere.knowledge.QueryMode
+import link.socket.ampere.plug.PlugId
 import link.socket.ampere.plug.PlugManifest
 import link.socket.ampere.plug.permission.GateResult
 import link.socket.ampere.plug.permission.PlugPermission
@@ -59,7 +60,7 @@ class KnowledgeQueryToolTest {
         val tool = KnowledgeQueryTool(store = store, plugManifest = manifest)
 
         val plugManifest = assertNotNull(tool.plugManifest)
-        assertEquals("pl-1", plugManifest.id)
+        assertEquals(PlugId("pl-1"), plugManifest.id)
     }
 
     @Test
@@ -158,7 +159,7 @@ class KnowledgeQueryToolTest {
         )
 
         val gateResult = PlugPermissionGate.check(
-            toolCall = PlugToolCall(plugId = "pl-1", toolId = tool.id),
+            toolCall = PlugToolCall(plugId = PlugId("pl-1"), toolId = tool.id),
             manifest = tool.plugManifest!!,
             userGrants = UserGrants(),
         )
@@ -177,7 +178,7 @@ class KnowledgeQueryToolTest {
         )
 
         val gateResult = PlugPermissionGate.check(
-            toolCall = PlugToolCall(plugId = "pl-1", toolId = tool.id),
+            toolCall = PlugToolCall(plugId = PlugId("pl-1"), toolId = tool.id),
             manifest = tool.plugManifest!!,
             // User granted "personal" — not the "work" the manifest requires.
             userGrants = UserGrants.granted(PlugPermission.KnowledgeQuery("personal")),
@@ -197,7 +198,7 @@ class KnowledgeQueryToolTest {
         )
 
         val gateResult = PlugPermissionGate.check(
-            toolCall = PlugToolCall(plugId = "pl-1", toolId = tool.id),
+            toolCall = PlugToolCall(plugId = PlugId("pl-1"), toolId = tool.id),
             manifest = tool.plugManifest!!,
             userGrants = UserGrants.granted(PlugPermission.KnowledgeQuery("work")),
         )
@@ -240,7 +241,7 @@ class KnowledgeQueryToolTest {
         id: String,
         vararg permissions: PlugPermission,
     ): PlugManifest = PlugManifest(
-        id = id,
+        id = PlugId(id),
         name = "Test plug $id",
         version = "1.0.0",
         requiredPermissions = permissions.toList(),

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/bundle/OkioPlugBundleSourceTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/bundle/OkioPlugBundleSourceTest.kt
@@ -13,6 +13,7 @@ import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.serialization.json.Json
+import link.socket.ampere.plug.PlugId
 import link.socket.ampere.plug.PlugManifest
 import link.socket.ampere.plug.permission.PlugPermission
 import okio.FileSystem
@@ -30,7 +31,7 @@ class OkioPlugBundleSourceTest {
     private val fixtureManifest = BundleManifest(
         bundleFormatVersion = 1,
         plug = PlugManifest(
-            id = "github-plug",
+            id = PlugId("github-plug"),
             name = "GitHub Plug",
             version = "1.0.0",
             requiredPermissions = listOf(

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/link/SqlDelightLinkStoreTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/link/SqlDelightLinkStoreTest.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Instant
 import link.socket.ampere.canon.CanonType
 import link.socket.ampere.db.Database
+import link.socket.ampere.plug.PlugId
 
 class SqlDelightLinkStoreTest {
 
@@ -87,9 +88,9 @@ class SqlDelightLinkStoreTest {
     @Test
     fun `grants round-trip per Plug`() = runTest {
         store.upsert(googleLink, at).getOrThrow()
-        store.grant("calendar-plug", googleLink.id, at).getOrThrow()
+        store.grant(PlugId("calendar-plug"), googleLink.id, at).getOrThrow()
 
-        val grants = store.grantsForPlug("calendar-plug").getOrThrow()
+        val grants = store.grantsForPlug(PlugId("calendar-plug")).getOrThrow()
 
         assertTrue(grants.isGranted(googleLink.id))
         assertFalse(grants.isRevoked(googleLink.id))
@@ -99,10 +100,10 @@ class SqlDelightLinkStoreTest {
     @Test
     fun `revoking a grant preserves the original grant timestamp`() = runTest {
         store.upsert(googleLink, at).getOrThrow()
-        store.grant("calendar-plug", googleLink.id, at).getOrThrow()
-        store.revokeGrant("calendar-plug", googleLink.id, later).getOrThrow()
+        store.grant(PlugId("calendar-plug"), googleLink.id, at).getOrThrow()
+        store.revokeGrant(PlugId("calendar-plug"), googleLink.id, later).getOrThrow()
 
-        val grant = store.grantsForPlug("calendar-plug").getOrThrow().grantFor(googleLink.id)
+        val grant = store.grantsForPlug(PlugId("calendar-plug")).getOrThrow().grantFor(googleLink.id)
 
         assertEquals(at, grant?.grantedAt)
         assertEquals(later, grant?.revokedAt)
@@ -111,21 +112,21 @@ class SqlDelightLinkStoreTest {
     @Test
     fun `revoking a Link cascades across Plugs and persists on the Link itself`() = runTest {
         store.upsert(googleLink, at).getOrThrow()
-        store.grant("calendar-plug", googleLink.id, at).getOrThrow()
-        store.grant("gmail-plug", googleLink.id, at).getOrThrow()
+        store.grant(PlugId("calendar-plug"), googleLink.id, at).getOrThrow()
+        store.grant(PlugId("gmail-plug"), googleLink.id, at).getOrThrow()
 
         val affected = store.revokeLink(googleLink.id, later).getOrThrow()
 
         assertEquals(setOf("calendar-plug", "gmail-plug"), affected.toSet())
         assertTrue(store.get(googleLink.id).getOrThrow()!!.isRevoked)
-        assertTrue(store.grantsForPlug("calendar-plug").getOrThrow().isRevoked(googleLink.id))
-        assertTrue(store.grantsForPlug("gmail-plug").getOrThrow().isRevoked(googleLink.id))
+        assertTrue(store.grantsForPlug(PlugId("calendar-plug")).getOrThrow().isRevoked(googleLink.id))
+        assertTrue(store.grantsForPlug(PlugId("gmail-plug")).getOrThrow().isRevoked(googleLink.id))
     }
 
     @Test
     fun `an already-revoked grant is not re-reported by a second cascade`() = runTest {
         store.upsert(googleLink, at).getOrThrow()
-        store.grant("calendar-plug", googleLink.id, at).getOrThrow()
+        store.grant(PlugId("calendar-plug"), googleLink.id, at).getOrThrow()
 
         store.revokeLink(googleLink.id, later).getOrThrow()
         val second = store.revokeLink(googleLink.id, later).getOrThrow()
@@ -136,7 +137,7 @@ class SqlDelightLinkStoreTest {
     @Test
     fun `deleting a Link removes its grants too`() = runTest {
         store.upsert(googleLink, at).getOrThrow()
-        store.grant("calendar-plug", googleLink.id, at).getOrThrow()
+        store.grant(PlugId("calendar-plug"), googleLink.id, at).getOrThrow()
 
         store.delete(googleLink.id).getOrThrow()
 
@@ -147,7 +148,7 @@ class SqlDelightLinkStoreTest {
     @Test
     fun `a Link persisted through the store resolves through the service`() = runTest {
         store.upsert(googleLink, at).getOrThrow()
-        store.grant("calendar-plug", googleLink.id, at).getOrThrow()
+        store.grant(PlugId("calendar-plug"), googleLink.id, at).getOrThrow()
 
         val service = LinkResolutionService(
             linkStore = store,
@@ -155,7 +156,7 @@ class SqlDelightLinkStoreTest {
         )
 
         val resolution = service.resolveOne(
-            plugId = "calendar-plug",
+            plugId = PlugId("calendar-plug"),
             requirement = LinkRequirement(
                 name = "calendar",
                 transport = Transport.OAUTH_REST,

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/plug/PlugContextEndToEndTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/plug/PlugContextEndToEndTest.kt
@@ -5,6 +5,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
 import kotlinx.serialization.json.JsonElement
 import link.socket.ampere.agents.tools.mcp.connection.McpServerConnection
 import link.socket.ampere.agents.tools.mcp.protocol.ContentItem
@@ -13,7 +14,16 @@ import link.socket.ampere.agents.tools.mcp.protocol.McpToolDescriptor
 import link.socket.ampere.agents.tools.mcp.protocol.ServerCapabilities
 import link.socket.ampere.agents.tools.mcp.protocol.ServerInfo
 import link.socket.ampere.agents.tools.mcp.protocol.ToolCallResult
+import link.socket.ampere.canon.CanonType
+import link.socket.ampere.link.EgressClass
+import link.socket.ampere.link.InMemoryLinkStore
+import link.socket.ampere.link.Link
+import link.socket.ampere.link.LinkDirection
 import link.socket.ampere.link.LinkId
+import link.socket.ampere.link.LinkRequirement
+import link.socket.ampere.link.LinkResolutionService
+import link.socket.ampere.link.PlatformTarget
+import link.socket.ampere.link.Transport
 import link.socket.ampere.mcp.InMemoryMcpCredentialBinding
 import link.socket.ampere.plug.permission.PlugPermission
 import link.socket.ampere.plug.permission.UserGrants
@@ -24,16 +34,45 @@ class PlugContextEndToEndTest {
 
     private val mcpUri = "mcp://github"
     private val toolName = "list_repos"
+    private val plugId = PlugId("github-plug")
+    private val linkId = LinkId("github-link")
 
     private val manifest = PlugManifest(
-        id = "github-plug",
+        id = plugId,
         name = "GitHub Plug",
         version = "1.0.0",
         requiredPermissions = listOf(PlugPermission.MCPServer(mcpUri)),
         mcpServers = listOf(
             McpServerDependency(name = "github", uri = mcpUri),
         ),
+        requiredLinks = listOf(
+            LinkRequirement(
+                name = "github",
+                transport = Transport.MCP,
+                direction = LinkDirection.READ_WRITE,
+                minimumScope = setOf(CanonType.DOCUMENT),
+            ),
+        ),
+        emits = setOf(CanonType.DOCUMENT),
+        consumes = setOf(CanonType.DOCUMENT),
     )
+
+    /** A [LinkResolutionService] with a granted Link satisfying the manifest's one requirement. */
+    private suspend fun grantedLinkResolutionService(): LinkResolutionService {
+        val store = InMemoryLinkStore(
+            links = listOf(
+                Link(
+                    id = linkId,
+                    transport = Transport.MCP,
+                    direction = LinkDirection.READ_WRITE,
+                    egress = EgressClass.ThirdParty("github"),
+                    scope = setOf(CanonType.DOCUMENT),
+                ),
+            ),
+        )
+        store.grant(plugId, linkId, Instant.fromEpochMilliseconds(0))
+        return LinkResolutionService(linkStore = store, platform = PlatformTarget.JVM_DESKTOP)
+    }
 
     @Test
     fun `granted user invokes mcp tool successfully`() = runTest {
@@ -52,7 +91,7 @@ class PlugContextEndToEndTest {
         val context = PlugContext.create(
             manifest = manifest,
             credentialBinding = InMemoryMcpCredentialBinding(),
-            linkId = LinkId("test-link"),
+            linkResolutionService = grantedLinkResolutionService(),
             connectionFactory = { _, _ -> mock },
         ).getOrThrow()
 
@@ -82,7 +121,7 @@ class PlugContextEndToEndTest {
         val context = PlugContext.create(
             manifest = manifest,
             credentialBinding = InMemoryMcpCredentialBinding(),
-            linkId = LinkId("test-link"),
+            linkResolutionService = grantedLinkResolutionService(),
             connectionFactory = { _, _ -> mock },
         ).getOrThrow()
 
@@ -109,7 +148,7 @@ class PlugContextEndToEndTest {
         val context = PlugContext.create(
             manifest = manifest,
             credentialBinding = InMemoryMcpCredentialBinding(),
-            linkId = LinkId("test-link"),
+            linkResolutionService = grantedLinkResolutionService(),
             connectionFactory = { _, _ -> mock },
         ).getOrThrow()
 

--- a/ampere-core/src/jvmTest/kotlin/link/socket/ampere/plug/permission/UserGrantStoreTest.kt
+++ b/ampere-core/src/jvmTest/kotlin/link/socket/ampere/plug/permission/UserGrantStoreTest.kt
@@ -10,6 +10,7 @@ import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Instant
 import link.socket.ampere.db.Database
+import link.socket.ampere.plug.PlugId
 
 class UserGrantStoreTest {
 
@@ -33,15 +34,15 @@ class UserGrantStoreTest {
         val permission = PlugPermission.KnowledgeQuery("workspace")
 
         store.grant(
-            plugId = "plug-1",
+            plugId = PlugId("plug-1"),
             permission = permission,
             grantedAt = Instant.fromEpochMilliseconds(1_000),
         ).getOrThrow()
 
-        val grants = store.listGrants("plug-1").getOrThrow()
+        val grants = store.listGrants(PlugId("plug-1")).getOrThrow()
 
         assertEquals(listOf(permission), grants.granted)
-        assertTrue(store.hasGrant("plug-1", permission).getOrThrow())
+        assertTrue(store.hasGrant(PlugId("plug-1"), permission).getOrThrow())
     }
 
     @Test
@@ -49,15 +50,15 @@ class UserGrantStoreTest {
         val permission = PlugPermission.NativeAction("open-url")
 
         store.grant(
-            plugId = "plug-1",
+            plugId = PlugId("plug-1"),
             permission = permission,
             grantedAt = Instant.fromEpochMilliseconds(1_000),
         ).getOrThrow()
-        store.revoke("plug-1", permission).getOrThrow()
+        store.revoke(PlugId("plug-1"), permission).getOrThrow()
 
-        val grants = store.listGrants("plug-1").getOrThrow()
+        val grants = store.listGrants(PlugId("plug-1")).getOrThrow()
 
         assertEquals(emptyList(), grants.granted)
-        assertFalse(store.hasGrant("plug-1", permission).getOrThrow())
+        assertFalse(store.hasGrant(PlugId("plug-1"), permission).getOrThrow())
     }
 }

--- a/docs/ampere/plug-bundle-format.md
+++ b/docs/ampere/plug-bundle-format.md
@@ -33,7 +33,6 @@ Unknown top-level entries are ignored by the parser. This keeps the format addit
     "name": "GitHub Plug",
     "version": "1.0.0",
     "description": "Open and review GitHub PRs from inside Ampere.",
-    "entrypoint": "main",
     "requiredPermissions": [
       { "type": "network_domain", "host": "api.github.com" },
       { "type": "mcp_server", "uri": "mcp://github" }
@@ -46,11 +45,10 @@ Unknown top-level entries are ignored by the parser. This keeps the format addit
 | --- | --- | --- | --- |
 | `bundleFormatVersion` | `Int` | Yes | Currently `1`. Parsers reject any other value with `UnknownVersion`. |
 | `plug` | `PlugManifest` | Yes | The W0.1 plug manifest, embedded verbatim. |
-| `plug.id` | `String` | Yes | Stable identifier; must be non-blank. |
+| `plug.id` | `PlugId` | Yes | Stable identifier; must match `[a-z0-9_-]+` (validated at construction). |
 | `plug.name` | `String` | Yes | Human-readable name; must be non-blank. |
 | `plug.version` | `String` | Yes | Plug's own version; must be non-blank. Independent of `bundleFormatVersion`. |
 | `plug.description` | `String?` | No | Free-form description. |
-| `plug.entrypoint` | `String?` | No | Plug-defined entry handle; opaque to the bundle format. |
 | `plug.requiredPermissions` | `List<PlugPermission>` | No (defaults to `[]`) | W0.1 permission objects. |
 
 `PlugPermission` uses `type` as its discriminator and is reused unchanged from W0.1. See [`PlugPermission.kt`][PlugPermission] for the closed set of variants (`network_domain`, `mcp_server`, `knowledge_query`, `native_action`, `link_access`).


### PR DESCRIPTION
## Summary
- Adds a validated `PlugId` value class (regex-constrained like Socket's `ComponentId`) threaded through `PlugManifest.id`, `PlugToolCall.plugId`, `LinkGrant`/`LinkGrants`, `UserGrantStore`, `LinkStore`, and `LinkResolutionService`, so a malformed id fails at construction instead of silently failing grant lookups later.
- Removes the dead `PlugManifest.entrypoint` field (nothing read it) and updates `docs/ampere/plug-bundle-format.md` accordingly.
- Adds a `PlugManifestValidator` rule rejecting a `requiredLinks` scope not covered by `emits`/`consumes`.
- Wires `PlugContext.create` to resolve Links through `LinkResolutionService` internally instead of accepting a pre-resolved `LinkId`, so callers no longer have to worry about resolution themselves.

## Test plan
- [x] `./gradlew :ampere-core:jvmTest` — 1626 tests passing
- [x] `./gradlew :ampere-core:compileTestKotlinJvm`
- [x] `./gradlew :ampere-core:compileCommonMainKotlinMetadata`
- [x] `./gradlew :ampere-core:compileTestKotlinIosSimulatorArm64`
- [x] `./gradlew ktlintFormat`

Closes #639

🤖 Generated with [Claude Code](https://claude.com/claude-code)