### PR TITLE
AMPR-248 #636: NativeFields cursor, NativeSchema value class, child provenance

### DIFF
--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/CanonProvenance.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/CanonProvenance.kt
@@ -51,7 +51,7 @@ data class SourceHandle(
  */
 @Serializable
 data class NativePayload(
-    val schema: String,
+    val schema: NativeSchema,
     val fields: JsonObject,
 )
 

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/NativeSchema.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/NativeSchema.kt
@@ -1,0 +1,30 @@
+package link.socket.ampere.canon
+
+import kotlin.jvm.JvmInline
+import kotlinx.serialization.Serializable
+
+/**
+ * The identifier of a native shape an adapter reads and writes — `EKEvent`, `CNContact`,
+ * `MailMessageEntity`.
+ *
+ * [link.socket.ampere.canon.adapter.ReadableCanonAdapter.nativeSchema] and [NativePayload.schema]
+ * are compared on every projection and every merge. When the two halves of a projection are
+ * written in different source sets — the field-reading half in commonMain, the framework glue
+ * that produces the native payload in a platform set — a bare string literal is duplicated
+ * across files with nothing tying them together, and a typo surfaces as a
+ * [link.socket.ampere.canon.adapter.CanonConversionFailure.SchemaMismatch] at runtime rather
+ * than a compile error.
+ *
+ * Declaring the schema once as a named constant of this type and referencing it from both
+ * halves closes that seam. Wrapping it in a value class costs nothing at runtime and makes
+ * "which string is this?" answerable from the type.
+ */
+@JvmInline
+@Serializable
+value class NativeSchema(val value: String) {
+    init {
+        require(value.isNotBlank()) { "NativeSchema must not be blank" }
+    }
+
+    override fun toString(): String = value
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/adapter/CanonChildren.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/adapter/CanonChildren.kt
@@ -1,0 +1,76 @@
+package link.socket.ampere.canon.adapter
+
+import link.socket.ampere.canon.CanonProvenance
+
+/*
+ * Identity and provenance rules for canon entities extracted from *inside* another one.
+ *
+ * Several canon types nest others: a `CanonCalendarEvent` carries a `CanonPlace` and a list of
+ * `CanonPerson`; an album carries assets; a folder carries files. Each nested entity needs its own
+ * `CanonId` and `CanonProvenance`, and neither is available from the native payload — the adapter
+ * has to synthesise both. Two ways of doing that are wrong, and both are easy to reach for:
+ *
+ *  - Deriving a child id from its position in a collection. `"$eventId:attendee:0"` changes the
+ *    moment the provider reorders the array, so anything that cached or referenced the child is
+ *    silently pointing at a different entity.
+ *  - Reusing the parent's provenance verbatim. The parent's provenance carries the parent's
+ *    `nativeId` and the parent's `nativePayload`, so a person extracted from a calendar event ends
+ *    up claiming to *be* an `EKEvent`. Write-back through a Contacts adapter would then fail the
+ *    schema check — safe, but only by accident.
+ *
+ * These helpers make the correct construction the short one: `childNativeId` for the identifier (fed
+ * to both `CanonId` and `forChild`, so the two cannot disagree), `forChild` for provenance, and a
+ * natural key rather than an index wherever the provider offers one.
+ */
+
+/**
+ * Provenance for an entity extracted from inside the entity this provenance belongs to.
+ *
+ * Retargets [CanonProvenance.sourceHandle] at the child's own native identifier and drops the
+ * parent's [CanonProvenance.nativePayload]. Dropping the payload is deliberate: the payload is
+ * what makes write-back a pure merge, and a child is *not* independently writable through its
+ * parent's adapter — carrying the parent's payload would advertise a write path that cannot
+ * work. A child that needs write-back gets it from the adapter that owns its own schema.
+ *
+ * [CanonProvenance.observedAt] is preserved, because the child was observed at the same moment
+ * as its parent. The parent's `etag` is dropped for the same reason as the payload: it is an
+ * optimistic-concurrency token for the parent object, and applying it to a child would let a
+ * stale-check pass on the wrong record.
+ */
+fun CanonProvenance.forChild(childNativeId: String): CanonProvenance =
+    copy(
+        sourceHandle = sourceHandle.copy(nativeId = childNativeId, etag = null),
+        nativePayload = null,
+    )
+
+/**
+ * A stable native identifier for a child entity, qualified by the parent it came from.
+ *
+ * @param parentNativeId The containing entity's native id — scopes the child so two events
+ *   with an attendee of the same address don't collide into one canon identity.
+ * @param role What the child is to its parent, e.g. `"attendee"`, `"place"`. Keeps two child
+ *   collections on the same parent from colliding.
+ * @param naturalKey A value the *provider* considers identifying — an email address, a file
+ *   path, an asset id. **Never a collection index.** Where a source genuinely offers no natural
+ *   key, call [unstableChildNativeId] instead, so the instability is visible at the call site
+ *   rather than hidden in a string template.
+ */
+fun childNativeId(
+    parentNativeId: String,
+    role: String,
+    naturalKey: String,
+): String = "$parentNativeId:$role:$naturalKey"
+
+/**
+ * A child identifier for a source that offers no natural key.
+ *
+ * Positionally derived and therefore **not stable across reordering**. Named to say so: an
+ * adapter reaching for this is accepting that the child's identity may change between two
+ * observations of an unchanged parent. Prefer [childNativeId]; use this only when the provider
+ * exposes nothing identifying, and say so in the adapter's KDoc.
+ */
+fun unstableChildNativeId(
+    parentNativeId: String,
+    role: String,
+    index: Int,
+): String = "$parentNativeId:$role:#$index"

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/adapter/CanonConversionFailure.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/adapter/CanonConversionFailure.kt
@@ -1,6 +1,7 @@
 package link.socket.ampere.canon.adapter
 
 import link.socket.ampere.canon.CanonType
+import link.socket.ampere.canon.NativeSchema
 
 /**
  * Why a canon projection or write-back could not complete.
@@ -17,15 +18,15 @@ sealed interface CanonConversionFailure {
      */
     data class SchemaMismatch(
         val canonType: CanonType,
-        val expectedSchema: String,
-        val actualSchema: String,
+        val expectedSchema: NativeSchema,
+        val actualSchema: NativeSchema,
     ) : CanonConversionFailure
 
     /** A field the canon type requires was absent from the native payload. */
     data class MissingRequiredField(
         val canonType: CanonType,
         val field: String,
-        val schema: String,
+        val schema: NativeSchema,
     ) : CanonConversionFailure
 
     /** A field was present but could not be read as the canon type expects. */

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/adapter/NativeFields.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/adapter/NativeFields.kt
@@ -1,0 +1,192 @@
+package link.socket.ampere.canon.adapter
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.longOrNull
+import link.socket.ampere.canon.CanonType
+import link.socket.ampere.canon.NativeSchema
+
+/**
+ * A typed cursor over one native object's fields, used by [ReadableCanonAdapter.projectFields]
+ * implementations.
+ *
+ * ## Why this exists
+ *
+ * Written by hand, every required-field read in a canon projection is four lines of the same
+ * shape:
+ *
+ * ```
+ * val title = fields["title"]?.jsonPrimitive?.contentOrNull
+ *     ?: return canonFailure(CanonConversionFailure.MissingRequiredField(canonType, "title", nativeSchema))
+ * ```
+ *
+ * At roughly eight fields per adapter across a growing Plug surface that is on the order of a
+ * thousand lines of near-identical `?: return canonFailure(...)`, which is both a maintenance
+ * cost and the most likely place for the failure taxonomy to drift between adapters — one
+ * reporting `MalformedField` where another reports `MissingRequiredField` for the same
+ * situation. Centralising the reads makes the taxonomy uniform by construction.
+ *
+ * ## Why it throws internally
+ *
+ * The canon SPI's public contract is that conversions are `Result`-typed and never throw
+ * ([CanonConversionException] exists only to carry a typed failure across the `Result`
+ * boundary). A reader that returned `Result` per field would force every projection back into
+ * the `?: return` shape this type exists to remove, so instead the accessors throw
+ * [CanonConversionException] and [project] catches it.
+ *
+ * **The throw never escapes.** [project] is the only way to obtain a [NativeFields], and it
+ * converts the exception back to `Result.failure` — so a projection written with this type
+ * satisfies the same never-throws contract as one written by hand. Callers must not construct
+ * a reader outside [project]; the constructor is private for that reason.
+ *
+ * Nested reads return child cursors, so failures carry a path: `location.latitude`,
+ * `people[1].name`.
+ */
+class NativeFields private constructor(
+    private val fields: JsonObject,
+    private val canonType: CanonType,
+    private val schema: NativeSchema,
+    private val path: String,
+) {
+    // -----------------------------------------------------------------
+    // Required reads — absent or unreadable is a typed failure
+    // -----------------------------------------------------------------
+
+    fun requireString(key: String): String = optionalString(key) ?: missing(key)
+
+    /** Reads an epoch-millisecond `Long`, the shape platform glue projects dates into. */
+    fun requireEpochMillis(key: String): Instant = optionalEpochMillis(key) ?: missing(key)
+
+    fun requireDouble(key: String): Double = optionalDouble(key) ?: missing(key)
+
+    fun requireInt(key: String): Int = optionalInt(key) ?: missing(key)
+
+    fun requireLong(key: String): Long = optionalLong(key) ?: missing(key)
+
+    fun requireBoolean(key: String): Boolean = optionalBoolean(key) ?: missing(key)
+
+    fun requireObject(key: String): NativeFields = optionalObject(key) ?: missing(key)
+
+    // -----------------------------------------------------------------
+    // Optional reads — absent is null; present-but-unreadable is still a failure
+    // -----------------------------------------------------------------
+
+    /**
+     * Absent or JSON `null` yields null. A value of the wrong *kind* (an object where a
+     * string was expected) is a [CanonConversionFailure.MalformedField] rather than null,
+     * so a provider changing a field's shape surfaces loudly instead of silently reading
+     * as "not set".
+     */
+    fun optionalString(key: String): String? =
+        primitive(key)?.let { it.contentOrNull ?: malformed(key, "expected a string") }
+
+    fun optionalEpochMillis(key: String): Instant? =
+        primitive(key)?.let { primitive ->
+            primitive.longOrNull?.let(Instant::fromEpochMilliseconds)
+                ?: malformed(key, "expected an epoch-millisecond long")
+        }
+
+    fun optionalDouble(key: String): Double? =
+        primitive(key)?.let { it.doubleOrNull ?: malformed(key, "expected a number") }
+
+    fun optionalInt(key: String): Int? =
+        primitive(key)?.let { it.intOrNull ?: malformed(key, "expected an integer") }
+
+    fun optionalLong(key: String): Long? =
+        primitive(key)?.let { it.longOrNull ?: malformed(key, "expected a long") }
+
+    fun optionalBoolean(key: String): Boolean? =
+        primitive(key)?.let { it.booleanOrNull ?: malformed(key, "expected a boolean") }
+
+    fun optionalBoolean(
+        key: String,
+        default: Boolean,
+    ): Boolean = optionalBoolean(key) ?: default
+
+    /** Nested objects read through a child cursor, so their failures carry the full path. */
+    fun optionalObject(key: String): NativeFields? =
+        when (val element = fields[key]) {
+            null -> null
+            is JsonObject -> NativeFields(element, canonType, schema, child(key))
+            else -> malformed(key, "expected an object")
+        }
+
+    /**
+     * Reads a homogeneous array of objects. Absent yields an empty list; a present non-array
+     * is a failure. Non-object members are skipped rather than failing the whole read — an
+     * array that mixes shapes is a provider quirk, not a corrupt record.
+     */
+    fun objectArray(key: String): List<NativeFields> =
+        when (val element = fields[key]) {
+            null -> emptyList()
+            is JsonArray ->
+                element.mapIndexedNotNull { index, member ->
+                    (member as? JsonObject)?.let {
+                        NativeFields(it, canonType, schema, "${child(key)}[$index]")
+                    }
+                }
+            else -> malformed(key, "expected an array")
+        }
+
+    fun contains(key: String): Boolean = fields.containsKey(key)
+
+    // -----------------------------------------------------------------
+    // Failure construction
+    // -----------------------------------------------------------------
+
+    /**
+     * Fails the projection with a caller-supplied reason. For the cases a generic reader
+     * can't express — an enum discriminator that maps to nothing, a pair of fields that
+     * disagree.
+     */
+    fun <T> malformed(
+        key: String,
+        reason: String,
+    ): T =
+        throw CanonConversionException(
+            CanonConversionFailure.MalformedField(canonType, child(key), reason),
+        )
+
+    private fun <T> missing(key: String): T =
+        throw CanonConversionException(
+            CanonConversionFailure.MissingRequiredField(canonType, child(key), schema),
+        )
+
+    /** Absent and JSON `null` are the same thing to a projection: the field is not set. */
+    private fun primitive(key: String): JsonPrimitive? =
+        when (val element = fields[key]) {
+            null, JsonNull -> null
+            is JsonPrimitive -> element
+            else -> malformed(key, "expected a primitive")
+        }
+
+    /** Qualifies a key with its position in the object graph, e.g. `location.latitude`. */
+    private fun child(key: String): String = if (path.isEmpty()) key else "$path.$key"
+
+    companion object {
+        /**
+         * Runs [block] against a cursor over [fields], converting any typed failure the
+         * cursor raises back into `Result.failure`.
+         *
+         * This is the only entry point, so the internal throw cannot escape into caller code.
+         */
+        fun <E> project(
+            fields: JsonObject,
+            canonType: CanonType,
+            schema: NativeSchema,
+            block: (NativeFields) -> E,
+        ): Result<E> =
+            try {
+                Result.success(block(NativeFields(fields, canonType, schema, path = "")))
+            } catch (failure: CanonConversionException) {
+                Result.failure(failure)
+            }
+    }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/adapter/ReadableCanonAdapter.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/adapter/ReadableCanonAdapter.kt
@@ -6,6 +6,7 @@ import link.socket.ampere.canon.CanonEntity
 import link.socket.ampere.canon.CanonProvenance
 import link.socket.ampere.canon.CanonType
 import link.socket.ampere.canon.NativePayload
+import link.socket.ampere.canon.NativeSchema
 import link.socket.ampere.canon.SourceHandle
 
 /**
@@ -30,7 +31,7 @@ abstract class ReadableCanonAdapter<E : CanonEntity> {
      * The native shape identifier this adapter reads, e.g. `MailMessageEntity`.
      * Checked on every projection.
      */
-    abstract val nativeSchema: String
+    abstract val nativeSchema: NativeSchema
 
     /**
      * Native → canon. The provenance is built for you and cannot be omitted.

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/canon/CanonSerializationTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/canon/CanonSerializationTest.kt
@@ -33,7 +33,7 @@ class CanonSerializationTest {
         ),
         observedAt = Instant.fromEpochMilliseconds(1_700_000_000_000),
         nativePayload = NativePayload(
-            schema = "MailMessageEntity",
+            schema = NativeSchema("MailMessageEntity"),
             fields = JsonObject(mapOf("subject" to JsonPrimitive("hi"))),
         ),
     )

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/canon/adapter/CanonAdapterFixtures.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/canon/adapter/CanonAdapterFixtures.kt
@@ -3,7 +3,6 @@ package link.socket.ampere.canon.adapter
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonPrimitive
 import link.socket.ampere.canon.CanonDocument
@@ -13,6 +12,7 @@ import link.socket.ampere.canon.CanonProvenance
 import link.socket.ampere.canon.CanonType
 import link.socket.ampere.canon.DocumentKind
 import link.socket.ampere.canon.NativePayload
+import link.socket.ampere.canon.NativeSchema
 import link.socket.ampere.canon.SourceHandle
 import link.socket.ampere.link.LinkId
 
@@ -69,33 +69,27 @@ private fun mailFields(entity: CanonEmailMessage): Map<String, JsonElement> =
 
 private fun projectMailFields(
     canonType: CanonType,
-    nativeSchema: String,
+    nativeSchema: NativeSchema,
     fields: JsonObject,
     provenance: CanonProvenance,
-): Result<CanonEmailMessage> {
-    val subject = fields["subject"]?.jsonPrimitive?.contentOrNull
-        ?: return canonFailure(
-            CanonConversionFailure.MissingRequiredField(canonType, "subject", nativeSchema),
-        )
-
-    return Result.success(
+): Result<CanonEmailMessage> =
+    NativeFields.project(fields, canonType, nativeSchema) { mail ->
         CanonEmailMessage(
             canonId = CanonId(provenance.sourceHandle.nativeId),
             provenance = provenance,
-            subject = subject,
+            subject = mail.requireString("subject"),
             from = null,
-            bodyText = fields["bodyText"]?.jsonPrimitive?.contentOrNull,
-            isRead = fields["isRead"]?.jsonPrimitive?.booleanOrNull ?: false,
-        ),
-    )
-}
+            bodyText = mail.optionalString("bodyText"),
+            isRead = mail.optionalBoolean("isRead", default = false),
+        )
+    }
 
 class MailMessageAdapter(
     private val store: FakeNativeStore,
 ) : WritableCanonAdapter<CanonEmailMessage>() {
 
     override val canonType: CanonType = CanonType.EMAIL_MESSAGE
-    override val nativeSchema: String = "MailMessageEntity"
+    override val nativeSchema: NativeSchema = NativeSchema("MailMessageEntity")
     override val ownedFields: Set<String> = setOf("subject", "bodyText", "isRead")
 
     override fun projectFields(
@@ -120,38 +114,29 @@ class FileDocumentAdapter(
 ) : WritableCanonAdapter<CanonDocument>() {
 
     override val canonType: CanonType = CanonType.DOCUMENT
-    override val nativeSchema: String = "FileEntity"
+    override val nativeSchema: NativeSchema = NativeSchema("FileEntity")
     override val ownedFields: Set<String> = setOf("title", "documentKind", "mimeType")
 
     override fun projectFields(
         fields: JsonObject,
         provenance: CanonProvenance,
-    ): Result<CanonDocument> {
-        val title = fields["title"]?.jsonPrimitive?.contentOrNull
-            ?: return canonFailure(
-                CanonConversionFailure.MissingRequiredField(canonType, "title", nativeSchema),
-            )
-
-        val rawKind = fields["documentKind"]?.jsonPrimitive?.contentOrNull ?: "file"
-        val kind = DocumentKind.entries.firstOrNull { it.appleDomain == rawKind }
-            ?: return canonFailure(
-                CanonConversionFailure.MalformedField(
-                    canonType,
+    ): Result<CanonDocument> =
+        NativeFields.project(fields, canonType, nativeSchema) { document ->
+            val rawKind = document.optionalString("documentKind") ?: "file"
+            val kind = DocumentKind.entries.firstOrNull { it.appleDomain == rawKind }
+                ?: document.malformed<DocumentKind>(
                     "documentKind",
                     "no DocumentKind maps to Apple domain '$rawKind'",
-                ),
-            )
+                )
 
-        return Result.success(
             CanonDocument(
                 canonId = CanonId(provenance.sourceHandle.nativeId),
                 provenance = provenance,
-                title = title,
+                title = document.requireString("title"),
                 kind = kind,
-                mimeType = fields["mimeType"]?.jsonPrimitive?.contentOrNull,
-            ),
-        )
-    }
+                mimeType = document.optionalString("mimeType"),
+            )
+        }
 
     override fun canonFields(entity: CanonDocument): Result<Map<String, JsonElement>> =
         Result.success(
@@ -180,7 +165,7 @@ class OverreachingMailAdapter(
 ) : WritableCanonAdapter<CanonEmailMessage>() {
 
     override val canonType: CanonType = CanonType.EMAIL_MESSAGE
-    override val nativeSchema: String = "MailMessageEntity"
+    override val nativeSchema: NativeSchema = NativeSchema("MailMessageEntity")
     override val ownedFields: Set<String> = setOf("subject")
 
     override fun projectFields(
@@ -223,7 +208,7 @@ class ReadOnlyMailAdapter(
 ) : ReadableCanonAdapter<CanonEmailMessage>() {
 
     override val canonType: CanonType = CanonType.EMAIL_MESSAGE
-    override val nativeSchema: String = "MailMessageEntity"
+    override val nativeSchema: NativeSchema = NativeSchema("MailMessageEntity")
 
     override fun projectFields(
         fields: JsonObject,
@@ -243,7 +228,7 @@ class CreatingMailAdapter(
 ) : CreatingCanonAdapter<CanonEmailMessage>() {
 
     override val canonType: CanonType = CanonType.EMAIL_MESSAGE
-    override val nativeSchema: String = "MailMessageEntity"
+    override val nativeSchema: NativeSchema = NativeSchema("MailMessageEntity")
     override val ownedFields: Set<String> = setOf("subject", "bodyText", "isRead")
 
     private var nextId = 0
@@ -287,7 +272,7 @@ class OverreachingCreatingMailAdapter(
 ) : CreatingCanonAdapter<CanonEmailMessage>() {
 
     override val canonType: CanonType = CanonType.EMAIL_MESSAGE
-    override val nativeSchema: String = "MailMessageEntity"
+    override val nativeSchema: NativeSchema = NativeSchema("MailMessageEntity")
     override val ownedFields: Set<String> = setOf("subject")
 
     override fun projectFields(

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/canon/adapter/CanonAdapterOwnershipTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/canon/adapter/CanonAdapterOwnershipTest.kt
@@ -1,0 +1,42 @@
+package link.socket.ampere.canon.adapter
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import link.socket.ampere.canon.CanonType
+
+/**
+ * `CanonBinding.lossyFields` (what a projection drops) and `WritableCanonAdapter.ownedFields`
+ * (what it writes back) are declared in two different files with nothing tying them together.
+ * A field cannot honestly be both: `ownedFields` names what the canon entity captures and can
+ * write, `lossyFields` names what it never captured in the first place. An adapter that owns a
+ * field its own canon type calls lossy is contradicting its binding's documentation of itself.
+ */
+class CanonAdapterOwnershipTest {
+
+    @Test
+    fun `a reference adapter never owns a field its canon type declares lossy`() {
+        val adapters: List<Pair<CanonType, Set<String>>> = listOf(
+            CanonType.EMAIL_MESSAGE to MailMessageAdapter(FakeNativeStore()).ownedFields,
+            CanonType.DOCUMENT to FileDocumentAdapter(FakeNativeStore()).ownedFields,
+        )
+
+        adapters.forEach { (canonType, ownedFields) ->
+            val overlap = ownedFields intersect canonType.binding.lossyFields.toSet()
+            assertTrue(
+                overlap.isEmpty(),
+                "${canonType.wireName} declares $overlap as both owned (written) and lossy " +
+                    "(dropped) — the projection and the binding disagree about what this " +
+                    "adapter captures",
+            )
+        }
+    }
+
+    @Test
+    fun `an adapter that overreaches ownedFields writes a field its canon type already calls lossy`() {
+        // Ties the two guards together: OverreachingMailAdapter's stray write (providerLabels) is
+        // not an arbitrary string picked for the test — it is a field EMAIL_MESSAGE's binding
+        // already documents as dropped by the projection, i.e. exactly the kind of field the
+        // ownership check above exists to keep out of ownedFields.
+        assertTrue("providerLabels" in CanonType.EMAIL_MESSAGE.binding.lossyFields)
+    }
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/canon/adapter/CanonAdapterTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/canon/adapter/CanonAdapterTest.kt
@@ -13,6 +13,7 @@ import link.socket.ampere.canon.CanonRing
 import link.socket.ampere.canon.CanonType
 import link.socket.ampere.canon.DocumentKind
 import link.socket.ampere.canon.NativePayload
+import link.socket.ampere.canon.NativeSchema
 import link.socket.ampere.canon.SourceHandle
 import link.socket.ampere.link.LinkId
 
@@ -31,7 +32,7 @@ class CanonAdapterTest {
      * four it does not. The four are the ones a naive write-back destroys.
      */
     private fun nativeMail() = NativePayload(
-        schema = "MailMessageEntity",
+        schema = NativeSchema("MailMessageEntity"),
         fields = JsonObject(
             mapOf(
                 "subject" to JsonPrimitive("Quarterly review"),
@@ -94,19 +95,19 @@ class CanonAdapterTest {
     @Test
     fun `projecting the wrong native schema fails rather than guessing`() {
         val adapter = MailMessageAdapter(FakeNativeStore())
-        val wrongShape = NativePayload("CalendarEventEntity", JsonObject(emptyMap()))
+        val wrongShape = NativePayload(NativeSchema("CalendarEventEntity"), JsonObject(emptyMap()))
 
         val failure = failureOf(adapter.project(wrongShape, handle, observedAt))
 
         assertIs<CanonConversionFailure.SchemaMismatch>(failure)
-        assertEquals("MailMessageEntity", failure.expectedSchema)
-        assertEquals("CalendarEventEntity", failure.actualSchema)
+        assertEquals(NativeSchema("MailMessageEntity"), failure.expectedSchema)
+        assertEquals(NativeSchema("CalendarEventEntity"), failure.actualSchema)
     }
 
     @Test
     fun `a missing required field is a typed failure and never a throw`() {
         val adapter = MailMessageAdapter(FakeNativeStore())
-        val empty = NativePayload("MailMessageEntity", JsonObject(emptyMap()))
+        val empty = NativePayload(NativeSchema("MailMessageEntity"), JsonObject(emptyMap()))
 
         val failure = failureOf(adapter.project(empty, handle, observedAt))
 
@@ -133,7 +134,7 @@ class CanonAdapterTest {
     fun `document round-trip preserves the fan-out discriminator`() = runTest {
         val adapter = FileDocumentAdapter(FakeNativeStore())
         val original = NativePayload(
-            schema = "FileEntity",
+            schema = NativeSchema("FileEntity"),
             fields = JsonObject(
                 mapOf(
                     "title" to JsonPrimitive("Roadmap"),
@@ -155,7 +156,7 @@ class CanonAdapterTest {
     fun `an unmappable document kind is a typed failure`() {
         val adapter = FileDocumentAdapter(FakeNativeStore())
         val payload = NativePayload(
-            schema = "FileEntity",
+            schema = NativeSchema("FileEntity"),
             fields = JsonObject(
                 mapOf(
                     "title" to JsonPrimitive("Mystery"),
@@ -268,7 +269,7 @@ class CanonAdapterTest {
         val entity = adapter.project(nativeMail(), handle, observedAt).getOrThrow()
         val corrupted = entity.copy(
             provenance = entity.provenance.copy(
-                nativePayload = NativePayload("CalendarEventEntity", JsonObject(emptyMap())),
+                nativePayload = NativePayload(NativeSchema("CalendarEventEntity"), JsonObject(emptyMap())),
             ),
         )
 

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/canon/adapter/CanonChildrenTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/canon/adapter/CanonChildrenTest.kt
@@ -1,0 +1,99 @@
+package link.socket.ampere.canon.adapter
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.datetime.Instant
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import link.socket.ampere.canon.CanonProvenance
+import link.socket.ampere.canon.NativePayload
+import link.socket.ampere.canon.NativeSchema
+import link.socket.ampere.canon.SourceHandle
+import link.socket.ampere.link.LinkId
+
+class CanonChildrenTest {
+    private val observedAt = Instant.fromEpochMilliseconds(1_700_000_000_000)
+
+    private val parent =
+        CanonProvenance(
+            sourceHandle =
+            SourceHandle(
+                linkId = LinkId("link-1"),
+                sourceSystem = "apple.calendar",
+                nativeId = "event-42",
+                etag = "v3",
+            ),
+            observedAt = observedAt,
+            nativePayload =
+            NativePayload(NativeSchema("EKEvent"), JsonObject(mapOf("title" to JsonPrimitive("Design review")))),
+        )
+
+    @Test
+    fun `a child does not carry the parent's native payload`() {
+        // The payload is what makes write-back a pure merge. A child is not independently writable
+        // through its parent's adapter, so carrying it would advertise a path that cannot work.
+        val child = parent.forChild("event-42:attendee:ada@example.com")
+
+        assertNull(child.nativePayload)
+    }
+
+    @Test
+    fun `a child does not carry the parent's etag`() {
+        // An etag is an optimistic-concurrency token for the parent object. Applied to a child it
+        // would let a staleness check pass against the wrong record.
+        val child = parent.forChild("event-42:place:self")
+
+        assertNull(child.sourceHandle.etag)
+    }
+
+    @Test
+    fun `a child is retargeted at its own native id but keeps the Link and the observation time`() {
+        val child = parent.forChild("event-42:attendee:ada@example.com")
+
+        assertEquals("event-42:attendee:ada@example.com", child.sourceHandle.nativeId)
+        assertNotEquals(parent.sourceHandle.nativeId, child.sourceHandle.nativeId)
+        // Same Link, same moment — the child was observed as part of the parent.
+        assertEquals(parent.sourceHandle.linkId, child.sourceHandle.linkId)
+        assertEquals(parent.sourceHandle.sourceSystem, child.sourceHandle.sourceSystem)
+        assertEquals(observedAt, child.observedAt)
+    }
+
+    @Test
+    fun `a natural key produces the same id regardless of when it is computed`() {
+        assertEquals(
+            childNativeId("event-42", "attendee", "ada@example.com"),
+            childNativeId("event-42", "attendee", "ada@example.com"),
+        )
+    }
+
+    @Test
+    fun `the same key under different parents yields different ids`() {
+        // Scoping to the parent is what stops two events sharing an attendee from collapsing into
+        // one canon identity — an assertion this adapter has no basis to make.
+        assertNotEquals(
+            childNativeId("event-42", "attendee", "ada@example.com"),
+            childNativeId("event-99", "attendee", "ada@example.com"),
+        )
+    }
+
+    @Test
+    fun `the same key in different roles yields different ids`() {
+        assertNotEquals(
+            childNativeId("event-42", "attendee", "self"),
+            childNativeId("event-42", "place", "self"),
+        )
+    }
+
+    @Test
+    fun `a positional id is visibly positional`() {
+        // The point of the separate function is that a reader can see the instability at the call
+        // site and in the resulting id, rather than it hiding inside a string template.
+        val id = unstableChildNativeId("event-42", "attendee", index = 3)
+
+        assertTrue(id.contains("#3"), id)
+        assertNotEquals(childNativeId("event-42", "attendee", "3"), id)
+    }
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/canon/adapter/NativeFieldsTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/canon/adapter/NativeFieldsTest.kt
@@ -1,0 +1,252 @@
+package link.socket.ampere.canon.adapter
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.datetime.Instant
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import link.socket.ampere.canon.CanonType
+import link.socket.ampere.canon.NativeSchema
+
+class NativeFieldsTest {
+    private val schema = NativeSchema("TestEntity")
+    private val canonType = CanonType.CALENDAR_EVENT
+
+    private fun <E> read(
+        fields: JsonObject,
+        block: (NativeFields) -> E,
+    ): Result<E> = NativeFields.project(fields, canonType, schema, block)
+
+    private fun failureOf(result: Result<*>): CanonConversionFailure {
+        val error = result.exceptionOrNull()
+        assertIs<CanonConversionException>(error)
+        return error.failure
+    }
+
+    // -----------------------------------------------------------------
+    // The contract that matters most: the internal throw never escapes
+    // -----------------------------------------------------------------
+
+    @Test
+    fun `a missing required field becomes a Result failure rather than a thrown exception`() {
+        // The reader throws internally so projections can read fields inline instead of
+        // `?: return canonFailure(...)`. `project` is the only entry point precisely so that
+        // throw cannot reach caller code — this is the test that pins it.
+        val result = read(JsonObject(emptyMap())) { it.requireString("title") }
+
+        assertTrue(result.isFailure)
+        val failure = failureOf(result)
+        assertIs<CanonConversionFailure.MissingRequiredField>(failure)
+        assertEquals("title", failure.field)
+        assertEquals(schema, failure.schema)
+    }
+
+    @Test
+    fun `an unrelated exception is not swallowed`() {
+        // Only CanonConversionException is converted. A genuine bug in a projection must still
+        // surface as a crash rather than being laundered into a typed canon failure.
+        val thrown =
+            runCatching {
+                read(JsonObject(emptyMap())) { error("bug in projection") }
+            }.exceptionOrNull()
+
+        assertIs<IllegalStateException>(thrown)
+        assertEquals("bug in projection", thrown.message)
+    }
+
+    // -----------------------------------------------------------------
+    // Required reads
+    // -----------------------------------------------------------------
+
+    @Test
+    fun `required reads return values when present`() {
+        val fields =
+            buildJsonObject {
+                put("name", JsonPrimitive("Ada"))
+                put("at", JsonPrimitive(1_700_000_000_000))
+                put("score", JsonPrimitive(1.5))
+                put("ok", JsonPrimitive(true))
+            }
+
+        val result =
+            read(fields) {
+                listOf(
+                    it.requireString("name"),
+                    it.requireEpochMillis("at"),
+                    it.requireDouble("score"),
+                    it.requireBoolean("ok"),
+                )
+            }.getOrThrow()
+
+        assertEquals("Ada", result[0])
+        assertEquals(Instant.fromEpochMilliseconds(1_700_000_000_000), result[1])
+        assertEquals(1.5, result[2])
+        assertEquals(true, result[3])
+    }
+
+    @Test
+    fun `Int and Long reads cover the numeric shapes Double and epoch-millis don't`() {
+        // widthPixels/unreadCount are plain Int; sizeBytes is a plain Long — neither is a
+        // date, so requireEpochMillis is the wrong reader and requireDouble would silently
+        // truncate a value a provider meant to be exact.
+        val fields =
+            buildJsonObject {
+                put("widthPixels", JsonPrimitive(1920))
+                put("sizeBytes", JsonPrimitive(4_294_967_296L))
+            }
+
+        val result =
+            read(fields) {
+                it.requireInt("widthPixels") to it.requireLong("sizeBytes")
+            }.getOrThrow()
+
+        assertEquals(1920, result.first)
+        assertEquals(4_294_967_296L, result.second)
+    }
+
+    @Test
+    fun `a present but unreadable value is malformed rather than missing`() {
+        // The distinction matters: "absent" is often legitimate, "present in the wrong shape"
+        // means the provider changed and someone should look.
+        val failure =
+            failureOf(read(buildJsonObject { put("at", JsonPrimitive("nope")) }) { it.requireEpochMillis("at") })
+
+        assertIs<CanonConversionFailure.MalformedField>(failure)
+        assertEquals("at", failure.field)
+    }
+
+    // -----------------------------------------------------------------
+    // Optional reads
+    // -----------------------------------------------------------------
+
+    @Test
+    fun `absent and JSON null read the same as not set`() {
+        val fields = buildJsonObject { put("maybe", JsonNull) }
+
+        assertNull(read(fields) { it.optionalString("maybe") }.getOrThrow())
+        assertNull(read(JsonObject(emptyMap())) { it.optionalString("maybe") }.getOrThrow())
+        assertNull(read(fields) { it.optionalEpochMillis("maybe") }.getOrThrow())
+        assertNull(read(fields) { it.optionalDouble("maybe") }.getOrThrow())
+        assertNull(read(fields) { it.optionalInt("maybe") }.getOrThrow())
+        assertNull(read(fields) { it.optionalLong("maybe") }.getOrThrow())
+        assertNull(read(fields) { it.optionalBoolean("maybe") }.getOrThrow())
+    }
+
+    @Test
+    fun `optionalBoolean falls back to the supplied default`() {
+        assertEquals(true, read(JsonObject(emptyMap())) { it.optionalBoolean("flag", default = true) }.getOrThrow())
+        assertEquals(
+            false,
+            read(buildJsonObject { put("flag", JsonPrimitive(false)) }) {
+                it.optionalBoolean("flag", default = true)
+            }.getOrThrow(),
+        )
+    }
+
+    @Test
+    fun `an optional read of the wrong kind still fails`() {
+        // Reading an object where a string was expected must not quietly become null, or a
+        // provider reshaping a field looks identical to the user never setting it.
+        val fields = buildJsonObject { put("name", buildJsonObject { put("first", JsonPrimitive("Ada")) }) }
+
+        val failure = failureOf(read(fields) { it.optionalString("name") })
+
+        assertIs<CanonConversionFailure.MalformedField>(failure)
+    }
+
+    // -----------------------------------------------------------------
+    // Nesting — the reason failures carry a path
+    // -----------------------------------------------------------------
+
+    @Test
+    fun `nested failures report the full path`() {
+        val fields =
+            buildJsonObject {
+                put("place", buildJsonObject { put("latitude", JsonPrimitive("not-a-number")) })
+            }
+
+        val failure = failureOf(read(fields) { it.requireObject("place").requireDouble("latitude") })
+
+        assertIs<CanonConversionFailure.MalformedField>(failure)
+        assertEquals("place.latitude", failure.field)
+    }
+
+    @Test
+    fun `array member failures report their index`() {
+        val fields =
+            buildJsonObject {
+                put(
+                    "people",
+                    buildJsonArray {
+                        add(buildJsonObject { put("name", JsonPrimitive("Ada")) })
+                        add(buildJsonObject { })
+                    },
+                )
+            }
+
+        val failure =
+            failureOf(read(fields) { reader -> reader.objectArray("people").map { it.requireString("name") } })
+
+        assertIs<CanonConversionFailure.MissingRequiredField>(failure)
+        assertEquals("people[1].name", failure.field)
+    }
+
+    @Test
+    fun `objectArray is empty when absent and skips non-object members`() {
+        assertTrue(read(JsonObject(emptyMap())) { it.objectArray("people") }.getOrThrow().isEmpty())
+
+        val mixed =
+            buildJsonObject {
+                put(
+                    "people",
+                    buildJsonArray {
+                        add(buildJsonObject { put("name", JsonPrimitive("Ada")) })
+                        add(JsonPrimitive("not an object"))
+                    },
+                )
+            }
+
+        // A provider mixing shapes in one array is a quirk, not a corrupt record: read what
+        // parses rather than failing the whole projection.
+        val names = read(mixed) { reader -> reader.objectArray("people").map { it.requireString("name") } }.getOrThrow()
+        assertEquals(listOf("Ada"), names)
+    }
+
+    @Test
+    fun `a present non-array where an array was expected fails`() {
+        val failure = failureOf(read(buildJsonObject { put("people", JsonPrimitive(3)) }) { it.objectArray("people") })
+
+        assertIs<CanonConversionFailure.MalformedField>(failure)
+        assertEquals("people", failure.field)
+    }
+
+    @Test
+    fun `a caller can fail the projection with its own reason`() {
+        val fields = buildJsonObject { put("kind", JsonPrimitive("unheard-of")) }
+
+        val failure =
+            failureOf(
+                read(fields) { reader ->
+                    val kind = reader.requireString("kind")
+                    if (kind != "known") reader.malformed<String>("kind", "no DocumentKind maps to '$kind'") else kind
+                },
+            )
+
+        assertIs<CanonConversionFailure.MalformedField>(failure)
+        assertTrue(failure.reason.contains("unheard-of"))
+    }
+
+    @Test
+    fun `contains distinguishes an explicitly null field from an absent one`() {
+        val fields = buildJsonObject { put("maybe", JsonNull) }
+
+        assertTrue(read(fields) { it.contains("maybe") }.getOrThrow())
+        assertTrue(!read(fields) { it.contains("other") }.getOrThrow())
+    }
+}

--- a/docs/concepts/domain-canon.md
+++ b/docs/concepts/domain-canon.md
@@ -4,7 +4,7 @@ status: stable
 tracked_sources:
   - ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/**
 related: [LinkLayer, PlugPermissions, AgentSurface, CognitionTrace]
-last_verified: 2026-07-29
+last_verified: 2026-07-30
 ---
 
 # Domain Canon
@@ -45,8 +45,11 @@ result. The canon earns its keep precisely where Apple's registry stops.
 - `canon/CanonRing.kt` — `INTERCHANGE` / `PLATFORM` / `SERVICE`.
 - `canon/CanonBinding.kt` — `AppleSchemaBinding` (entity schema or system value type), `AndroidSchemaBinding`.
 - `canon/CanonProvenance.kt` — `CanonId`, `SourceHandle`, `NativePayload`, `CanonProvenance`.
+- `canon/NativeSchema.kt` — the value class wrapping a native shape identifier (`EKEvent`, `MailMessageEntity`); referenced by both `ReadableCanonAdapter.nativeSchema` and `NativePayload.schema` so the two cannot drift into a runtime-only `SchemaMismatch`.
 - `canon/CanonEntity.kt` — the sealed hierarchy; `CanonRing1Entities.kt`, `CanonRing2Entities.kt`, `CanonRing3Entities.kt`.
 - `canon/adapter/ReadableCanonAdapter.kt`, `WritableCanonAdapter.kt`, `CreatingCanonAdapter.kt` — the transport-agnostic adapter SPI, split by capability: read, write-back, create.
+- `canon/adapter/NativeFields.kt` — a typed cursor over a native object's fields, used from `projectFields`, that replaces the repeated `?: return canonFailure(...)` shape.
+- `canon/adapter/CanonChildren.kt` — `forChild`/`childNativeId`/`unstableChildNativeId`: identity and provenance rules for entities nested inside another (an event's attendees, an album's assets).
 - `canon/adapter/CanonConversionFailure.kt` — the closed failure set.
 - `ampere-core/src/commonTest/.../canon/` — round-trip, write-back-merge, and serialization-stability tests.
 - `.context/recon/apple-assistant-schemas-ios265.tsv` — the raw SDK enumeration.
@@ -60,18 +63,19 @@ result. The canon earns its keep precisely where Apple's registry stops.
 - **`create` touches no existing object, so it cannot clobber — but it is still final and confined to `CreatingCanonAdapter`.** `ReadableCanonAdapter` and `WritableCanonAdapter` gain no create surface; a Plug that only reads or only updates cannot acquire the ability to create by inheritance.
 - **Ring membership is a binding-provenance claim, not a support level.** A Ring 1 type maps to an Apple assistant-schema entity or system value type *without contortion*. Promoting a type into Ring 1 requires an SDK pass, not an opinion.
 - **`@SerialName` and `wireName` are wire contracts.** These types cross the wire and land in traces; renaming a discriminator breaks `PlaybackRelay` replay of every trace already recorded.
-- **Conversions are `Result`-typed.** No adapter throws.
+- **Conversions are `Result`-typed. No adapter throws.** `NativeFields` (used from inside `projectFields`) is the one narrow exception, and only internally: its accessors throw `CanonConversionException` so a projection can read a field inline instead of `?: return canonFailure(...)`, but the only way to obtain a `NativeFields` is `NativeFields.project(...)`, which catches that exception and returns `Result.failure` — the constructor is private, so the throw cannot reach an adapter's caller. An adapter written against this cursor still satisfies the never-throws contract from the outside.
 - **`SourceHandle.nativeId` is opaque.** Parsing it makes a provider's identifier format a contract Ampere has to honour.
 
 ## Common operations
 
 - **Add a canon type** — add the `CanonType` member with a stable `wireName`, ring, and `CanonBinding`; add the `@Serializable` entity with a stable `@SerialName`; add a sample to `CanonSerializationTest.samples()` (the coverage test fails otherwise).
 - **Write an adapter** — subclass the narrowest class the Plug's capability supports:
-  - Read-only: `ReadableCanonAdapter<E>`, implementing `projectFields` + `fetchNative` and declaring `nativeSchema`.
+  - Read-only: `ReadableCanonAdapter<E>`, implementing `projectFields` + `fetchNative` and declaring `nativeSchema: NativeSchema` (declare the schema once as a named constant shared by the commonMain projection and the platform glue that produces the payload).
   - Updates existing objects: `WritableCanonAdapter<E>`, additionally implementing `canonFields` + `writeNative` and declaring `ownedFields`.
   - Also creates new objects: `CreatingCanonAdapter<E>`, additionally implementing `createNative`.
 
   Never add a public write method outside `writeBack` and `create`.
+  Inside `projectFields`, read through `NativeFields.project(fields, canonType, nativeSchema) { cursor -> ... }` rather than hand-rolling `?: return canonFailure(...)` per field — it keeps the failure taxonomy (`MissingRequiredField` vs. `MalformedField`) uniform and nested/array failures report a path (`location.latitude`, `people[1].name`). When a canon type nests another entity, give the child its own id and provenance with `childNativeId(parentNativeId, role, naturalKey)` and `provenance.forChild(childNativeId)` — never derive a child id from array position, and never reuse the parent's provenance verbatim (see `CanonChildren.kt`).
 - **Preview a pending write** — `adapter.mergeForWriteBack(entity)` returns the merged payload without writing.
 - **Check a binding** — `CanonType.EMAIL_MESSAGE.binding.apple` gives the `mail.message` address and the fields the projection drops.
 - **Re-run the SDK pass** — the extraction commands are in the Appendix of `.context/issue-586-domain-type-canon-v1.md`; diff against the committed TSV.
@@ -83,4 +87,5 @@ result. The canon earns its keep precisely where Apple's registry stops.
 - **Adding a `Custom(payload)` canon member.** It would make the `when` non-exhaustive and hand the reconciliation problem back to the LLM. Use the native payload on a typed entity.
 - **Declaring a wide `ownedFields` "to be safe".** Over-declaring re-opens the clobber path; under-declaring merely means the field is never written.
 - **Parsing `nativeId` to extract structure.** It is opaque by design.
+- **Deriving a nested entity's id from its array position, or giving it the parent's provenance verbatim.** An index-derived id (`"$eventId:attendee:0"`) changes when the provider reorders the collection; a reused parent provenance hands the child the parent's `nativeId` and `nativePayload`, so e.g. a `CanonPerson` extracted from a `CanonCalendarEvent` claims to *be* an `EKEvent`. Use `childNativeId`/`forChild` from `CanonChildren.kt`.
 - **Reading bindings via annotations/reflection.** `kotlin-reflect` is JVM-only and Kotlin/Native cannot read annotations reflectively; bindings are data for exactly this reason.


### PR DESCRIPTION
## Summary
- Ports Socket's `NativeFields` typed cursor, `NativeSchema` value class, and `CanonChildren` (`forChild`/`childNativeId`/`unstableChildNativeId`) helpers into ampere-core (socket-link/socket#1113), replacing the repeated `?: return canonFailure(...)` shape in `projectFields` and giving nested canon entities a stable id/provenance instead of an index-derived id or the parent's provenance reused verbatim.
- Retypes `ReadableCanonAdapter.nativeSchema`, `NativePayload.schema`, and the `CanonConversionFailure` schema fields from `String` to `NativeSchema` — a breaking change across the adapter SPI, confirmed with the user before implementing.
- Adds the `lossyFields`/`ownedFields` cross-check called out separately in the ticket, and migrates `MailMessageAdapter`/`FileDocumentAdapter` onto the new cursor as the real-use proof.
- Ports Socket's `NativeFieldsTest` (13 cases, +2 for the `Int`/`Long` accessors added to cover Florence's own field shapes) and `CanonChildrenTest` suites.
- Updates `docs/concepts/domain-canon.md` to document the new types and clarify how `NativeFields`'s internal throw still satisfies the "no adapter throws" invariant.

## Test plan
- [x] `:ampere-core:ktlintCheck`
- [x] `:ampere-core:compileCommonMainKotlinMetadata`
- [x] `:ampere-core:compileTestKotlinIosSimulatorArm64`
- [x] `:ampere-core:jvmTest` (full suite, no regressions)

Closes #636

🤖 Generated with [Claude Code](https://claude.com/claude-code)