### PR TITLE
AMPR-258 #655: Add CanonAssetRef + AssetResolver for canon asset references

### DIFF
--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/watch/presentation/EventCategorizer.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/cli/watch/presentation/EventCategorizer.kt
@@ -1,6 +1,7 @@
 package link.socket.ampere.cli.watch.presentation
 
 import link.socket.ampere.agents.domain.event.AgentSurfaceEvent
+import link.socket.ampere.agents.domain.event.AssetAccessEvent
 import link.socket.ampere.agents.domain.event.BenchEvent
 import link.socket.ampere.agents.domain.event.CognitiveEvent
 import link.socket.ampere.agents.domain.event.CognitivePhaseEvent
@@ -129,6 +130,7 @@ object EventCategorizer {
         is SparkEvent,
         is BenchEvent.BenchRunStarted,
         is LinkEvent.LinkResolved,
+        is AssetAccessEvent,
         is BenchEvent.ProbeGraded -> EventSignificance.ROUTINE
 
         is RoutingEvent.RouteFallback,

--- a/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/renderer/EventRenderer.kt
+++ b/ampere-cli/src/jvmMain/kotlin/link/socket/ampere/renderer/EventRenderer.kt
@@ -13,6 +13,7 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import link.socket.ampere.agents.domain.Urgency
 import link.socket.ampere.agents.domain.event.AgentSurfaceEvent
+import link.socket.ampere.agents.domain.event.AssetAccessEvent
 import link.socket.ampere.agents.domain.event.BenchEvent
 import link.socket.ampere.agents.domain.event.CognitiveEvent
 import link.socket.ampere.agents.domain.event.CognitivePhaseEvent
@@ -183,6 +184,8 @@ class EventRenderer(
             is LinkEvent.LinkGranted -> "🔌" to blue
             is LinkEvent.LinkRevoked -> "🔌" to red
             is LinkEvent.LinkResolutionFailed -> "🔌" to red
+            // Asset resolution: out-of-band, mirroring Link's icon family
+            is AssetAccessEvent -> "🖼" to green
         }
     }
 

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/AssetAccessEvent.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/AssetAccessEvent.kt
@@ -1,0 +1,53 @@
+package link.socket.ampere.agents.domain.event
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import link.socket.ampere.agents.domain.Urgency
+import link.socket.ampere.link.LinkId
+
+/**
+ * An [link.socket.ampere.plug.spi.AssetResolver] resolved a reference.
+ *
+ * Out-of-band but not invisible: asset bytes never become an [Emission] or
+ * enter a trace as payload, but resolution itself must be observable. Modelled
+ * on [LinkEvent] — metadata only, no payload bytes — rather than a new
+ * [EmissionKind], since it carries no affordances, reply semantics, or dedup
+ * key that would justify going through the heavier Emission wire contract.
+ *
+ * Lives in `agents.domain.event` because [Event] is sealed: every subtype has
+ * to share its module and package.
+ *
+ * @property linkId Null for a [link.socket.ampere.canon.CanonAssetRef.Url] —
+ *   there is no Link, and therefore no consent check, for a plain URL.
+ * @property byteCount Size of the resolved bytes. Never the bytes themselves.
+ */
+@Serializable
+@SerialName("AssetAccessEvent")
+data class AssetAccessEvent(
+    override val eventId: EventId,
+    override val timestamp: Instant,
+    override val eventSource: EventSource,
+    override val urgency: Urgency = Urgency.LOW,
+    val linkId: LinkId?,
+    val plugId: String,
+    val byteCount: Long,
+) : Event {
+
+    override val eventType: EventType = EVENT_TYPE
+
+    override fun getSummary(
+        formatUrgency: (Urgency) -> String,
+        formatSource: (EventSource) -> String,
+    ): String = buildString {
+        append("Asset resolved: plug=$plugId")
+        linkId?.let { append(" link=${it.value}") }
+        append(" bytes=$byteCount")
+        append(" ${formatUrgency(urgency)}")
+        append(" from ${formatSource(eventSource)}")
+    }
+
+    companion object {
+        const val EVENT_TYPE: EventType = "AssetAccessEvent"
+    }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/EventRegistry.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/domain/event/EventRegistry.kt
@@ -117,6 +117,9 @@ object EventRegistry {
         LinkEvent.LinkResolved.EVENT_TYPE,
         LinkEvent.LinkResolutionFailed.EVENT_TYPE,
 
+        // AssetAccessEvent types
+        AssetAccessEvent.EVENT_TYPE,
+
         // AgentSurfaceEvent types
         AgentSurfaceEvent.Requested.EVENT_TYPE,
         AgentSurfaceEvent.Responded.EVENT_TYPE,

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/utils/SignificanceAwareEventLogger.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/agents/events/utils/SignificanceAwareEventLogger.kt
@@ -3,6 +3,7 @@ package link.socket.ampere.agents.events.utils
 import co.touchlab.kermit.Logger
 import link.socket.ampere.agents.domain.Urgency
 import link.socket.ampere.agents.domain.event.AgentSurfaceEvent
+import link.socket.ampere.agents.domain.event.AssetAccessEvent
 import link.socket.ampere.agents.domain.event.BenchEvent
 import link.socket.ampere.agents.domain.event.CognitiveEvent
 import link.socket.ampere.agents.domain.event.CognitivePhaseEvent
@@ -192,6 +193,9 @@ class SignificanceAwareEventLogger(
         is LinkEvent.LinkGranted -> EventSignificance.SIGNIFICANT
         is LinkEvent.LinkRevoked -> EventSignificance.CRITICAL
         is LinkEvent.LinkResolutionFailed -> EventSignificance.CRITICAL
+
+        // Asset resolution - routine, mirroring LinkResolved.
+        is AssetAccessEvent -> EventSignificance.ROUTINE
     }
 
     private fun formatUrgency(urgency: Urgency): String = when (urgency) {

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/CanonAssetRef.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/CanonAssetRef.kt
@@ -1,0 +1,59 @@
+package link.socket.ampere.canon
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import link.socket.ampere.link.LinkId
+
+/**
+ * A reference to visual media carried by a canon entity — never the bytes
+ * themselves.
+ *
+ * Two shapes exist because the platforms that produce artwork disagree on
+ * what an asset *is*: a streaming service hands back a URL template with
+ * `{w}`/`{h}` tokens, while a local media library hands back a native image
+ * object with no URL at all. Forcing both through `artworkUrl: String?` loses
+ * the local-media case outright.
+ *
+ * Resolving a [CanonAssetRef] to bytes is an
+ * [link.socket.ampere.plug.spi.AssetResolver] concern, not a canon concern —
+ * this type only names *where* an asset lives.
+ */
+@Serializable
+sealed interface CanonAssetRef {
+
+    /**
+     * A URL, possibly a template.
+     *
+     * @property template May contain `{w}`/`{h}` tokens for a resolver to
+     *   fill at the requested [link.socket.ampere.plug.spi.AssetSpec]
+     *   dimensions. A template with no tokens is just a URL.
+     * @property width Known width, when the template's own dimensions are
+     *   fixed rather than requested.
+     * @property height Known height, when the template's own dimensions are
+     *   fixed rather than requested.
+     */
+    @Serializable
+    @SerialName("canon_asset_ref.url")
+    data class Url(
+        val template: String,
+        val width: Int? = null,
+        val height: Int? = null,
+    ) : CanonAssetRef
+
+    /**
+     * A handle into a native object a [link.socket.ampere.plug.spi.AssetResolver]
+     * must decode.
+     *
+     * @property linkId The Link that can resolve it — also the consent key:
+     *   resolution is permitted iff the per-(Plug, Link) grant that produced
+     *   the entity is still valid.
+     * @property nativeId Opaque; never parsed by consumers, mirroring
+     *   [SourceHandle.nativeId].
+     */
+    @Serializable
+    @SerialName("canon_asset_ref.native_handle")
+    data class NativeHandle(
+        val linkId: LinkId,
+        val nativeId: String,
+    ) : CanonAssetRef
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/CanonRing1Entities.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/CanonRing1Entities.kt
@@ -124,6 +124,7 @@ data class CanonPhoto(
     val isFavorite: Boolean = false,
     val place: CanonPlace? = null,
     val recognizedPeople: List<CanonPerson> = emptyList(),
+    val thumbnail: CanonAssetRef? = null,
 ) : CanonEntity {
     override val canonType: CanonType get() = CanonType.PHOTO
 }
@@ -158,6 +159,7 @@ data class CanonDocument(
     val sizeBytes: Long? = null,
     val modifiedAt: Instant? = null,
     val plainText: String? = null,
+    val thumbnail: CanonAssetRef? = null,
 ) : CanonEntity {
     override val canonType: CanonType get() = CanonType.DOCUMENT
 }

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/CanonRing2Entities.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/CanonRing2Entities.kt
@@ -68,6 +68,7 @@ data class CanonMediaItem(
     val title: String,
     val artist: String? = null,
     val durationSeconds: Long? = null,
+    val artwork: CanonAssetRef? = null,
 ) : CanonEntity {
     override val canonType: CanonType get() = CanonType.MEDIA_ITEM
 }
@@ -143,6 +144,7 @@ data class CanonPass(
     val description: String,
     val organizationName: String? = null,
     val expiresAt: Instant? = null,
+    val logo: CanonAssetRef? = null,
 ) : CanonEntity {
     override val canonType: CanonType get() = CanonType.PASS
 }

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/PlugManifest.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/PlugManifest.kt
@@ -19,6 +19,12 @@ import link.socket.ampere.plug.permission.PlugPermission
  * produce for other Arc steps, and what it needs handed to it. They are what a
  * future planner reads to decide two Plugs can be chained.
  *
+ * [resolvesAssets] declares the third, optional chassis capability — a Plug
+ * implementing [link.socket.ampere.plug.spi.AssetResolver] alongside (or
+ * instead of) Perceive/Execute — so a consent surface can state that a Plug
+ * resolves assets before any [link.socket.ampere.canon.CanonAssetRef.NativeHandle]
+ * it produced is ever resolved.
+ *
  * Every collection field defaults to empty so manifests written before each
  * schema addition continue to decode unchanged.
  */
@@ -33,4 +39,5 @@ data class PlugManifest(
     val requiredLinks: List<LinkRequirement> = emptyList(),
     val emits: Set<CanonType> = emptySet(),
     val consumes: Set<CanonType> = emptySet(),
+    val resolvesAssets: Boolean = false,
 )

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/spi/AssetResolver.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/spi/AssetResolver.kt
@@ -1,0 +1,88 @@
+package link.socket.ampere.plug.spi
+
+import link.socket.ampere.canon.CanonAssetRef
+import link.socket.ampere.link.LinkId
+
+/**
+ * Resolves a [CanonAssetRef] to bytes, out of band from Perceive.
+ *
+ * A third, optional capability alongside [PerceiveSource]/[ExecuteSink] — not
+ * a Perceive ride-along, because asset bytes must never enter an Emission or
+ * a trace (bloat; replay breakage). Resolution is render-driven, repeatable,
+ * and cacheable, none of which match Perceive's PROPEL-driven,
+ * fresh-observation lifecycle.
+ *
+ * Implementations should not enforce consent themselves — wrap with
+ * [ConsentEnforcingAssetResolver] so the check happens once, in the SPI
+ * contract, not per-implementor.
+ */
+interface AssetResolver {
+
+    /** Resolve [ref] to bytes at (or near) [spec]'s target dimensions. */
+    suspend fun resolve(ref: CanonAssetRef, spec: AssetSpec): Result<AssetBytes>
+}
+
+/** Target dimensions a renderer wants; a resolver may return something close but not exact. */
+data class AssetSpec(
+    val targetWidth: Int? = null,
+    val targetHeight: Int? = null,
+)
+
+/**
+ * Resolved asset bytes.
+ *
+ * @property width Actual width of [bytes], when known — distinct from
+ *   [AssetSpec.targetWidth], which is only a request.
+ * @property height Actual height of [bytes], when known.
+ */
+class AssetBytes(
+    val bytes: ByteArray,
+    val mimeType: String,
+    val width: Int? = null,
+    val height: Int? = null,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is AssetBytes) return false
+        return bytes.contentEquals(other.bytes) &&
+            mimeType == other.mimeType &&
+            width == other.width &&
+            height == other.height
+    }
+
+    override fun hashCode(): Int {
+        var result = bytes.contentHashCode()
+        result = 31 * result + mimeType.hashCode()
+        result = 31 * result + (width ?: 0)
+        result = 31 * result + (height ?: 0)
+        return result
+    }
+}
+
+/**
+ * Why an [AssetResolver] could not resolve a reference.
+ *
+ * Distinct from a *transport* failure (network error, decode error), which an
+ * implementation reports through its own [Result.failure] before the consent
+ * check ever runs — this is closed to failures the SPI layer itself owns.
+ */
+sealed interface AssetResolutionFailure {
+
+    /** No [link.socket.ampere.link.Link] is registered for this id. */
+    data class LinkNotFound(val linkId: LinkId) : AssetResolutionFailure
+
+    /** The Link, its credential, or the Plug's grant on it is revoked. */
+    data class ConsentRevoked(val linkId: LinkId) : AssetResolutionFailure
+}
+
+/**
+ * Carries an [AssetResolutionFailure] through [Result.failure].
+ *
+ * Resolution never throws on its own; this exception exists so the typed
+ * failure survives the `kotlin.Result` boundary, matching
+ * [link.socket.ampere.link.LinkResolutionException] and
+ * [link.socket.ampere.canon.adapter.CanonConversionException].
+ */
+class AssetResolutionException(
+    val failure: AssetResolutionFailure,
+) : Exception("Asset resolution failed: $failure")

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/spi/ConsentEnforcingAssetResolver.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/spi/ConsentEnforcingAssetResolver.kt
@@ -1,0 +1,68 @@
+package link.socket.ampere.plug.spi
+
+import kotlinx.datetime.Clock
+import link.socket.ampere.agents.domain.event.AssetAccessEvent
+import link.socket.ampere.agents.domain.event.EventSource
+import link.socket.ampere.agents.events.bus.EventSerialBus
+import link.socket.ampere.agents.events.utils.generateUUID
+import link.socket.ampere.canon.CanonAssetRef
+import link.socket.ampere.link.LinkOperation
+import link.socket.ampere.link.LinkResolutionGate
+import link.socket.ampere.link.LinkStore
+import link.socket.ampere.plug.PlugId
+
+/**
+ * Wraps an [AssetResolver] with the two contract commitments implementors
+ * must not be trusted to remember themselves:
+ *
+ * 1. **Consent rides the existing ledger for free.** A
+ *    [CanonAssetRef.NativeHandle] only resolves while the Link that produced
+ *    it, and this Plug's grant on it, are both still standing. A
+ *    [CanonAssetRef.Url] has no Link and skips the check entirely.
+ * 2. **Out-of-band but not invisible.** Every successful resolution records a
+ *    lightweight [AssetAccessEvent] on the bus — no payload bytes.
+ *
+ * Orchestration only, mirroring [link.socket.ampere.link.LinkResolutionService]:
+ * the matching policy lives in [LinkResolutionGate], and [eventBus] is
+ * optional — without it, resolution still happens, it just goes unobserved.
+ */
+class ConsentEnforcingAssetResolver(
+    private val delegate: AssetResolver,
+    private val plugId: PlugId,
+    private val linkStore: LinkStore,
+    private val eventBus: EventSerialBus? = null,
+    private val eventSource: EventSource = EventSource.Agent(plugId.value),
+    private val clock: Clock = Clock.System,
+) : AssetResolver {
+
+    override suspend fun resolve(ref: CanonAssetRef, spec: AssetSpec): Result<AssetBytes> {
+        val linkId = (ref as? CanonAssetRef.NativeHandle)?.linkId
+
+        if (linkId != null) {
+            val link = linkStore.get(linkId).getOrElse { return Result.failure(it) }
+                ?: return Result.failure(AssetResolutionException(AssetResolutionFailure.LinkNotFound(linkId)))
+            val grants = linkStore.grantsForPlug(plugId).getOrElse { return Result.failure(it) }
+
+            // Resolving an asset is a read, so it reuses Perceive's direction
+            // semantics rather than growing a third LinkOperation — a
+            // write-only Link still cannot serve up a thumbnail.
+            val permitted = grants.isGranted(linkId) && LinkResolutionGate.permits(link, LinkOperation.PERCEIVE)
+            if (!permitted) {
+                return Result.failure(AssetResolutionException(AssetResolutionFailure.ConsentRevoked(linkId)))
+            }
+        }
+
+        return delegate.resolve(ref, spec).onSuccess { bytes ->
+            eventBus?.publishAsync(
+                AssetAccessEvent(
+                    eventId = generateUUID("asset"),
+                    timestamp = clock.now(),
+                    eventSource = eventSource,
+                    linkId = linkId,
+                    plugId = plugId.value,
+                    byteCount = bytes.bytes.size.toLong(),
+                ),
+            )
+        }
+    }
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/canon/CanonAssetRefSerializationTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/canon/CanonAssetRefSerializationTest.kt
@@ -1,0 +1,101 @@
+package link.socket.ampere.canon
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.datetime.Instant
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import link.socket.ampere.link.LinkId
+
+/**
+ * [CanonAssetRef] is a field type, not a [CanonEntity] variant, so it is not
+ * exercised by [CanonSerializationTest]'s exhaustiveness check. Its
+ * `@SerialName`s are pinned here the same way, since they land in traces
+ * immediately once a Plug starts emitting populated `artwork`/`thumbnail`/
+ * `logo` fields.
+ */
+class CanonAssetRefSerializationTest {
+
+    private val json = Json {
+        prettyPrint = false
+        encodeDefaults = true
+        classDiscriminator = "type"
+        ignoreUnknownKeys = true
+    }
+
+    private val provenance = CanonProvenance(
+        sourceHandle = SourceHandle(
+            linkId = LinkId("link-1"),
+            sourceSystem = "apple.mail",
+            nativeId = "native-1",
+            etag = "etag-1",
+        ),
+        observedAt = Instant.fromEpochMilliseconds(1_700_000_000_000),
+        nativePayload = NativePayload(
+            schema = NativeSchema("MailMessageEntity"),
+            fields = JsonObject(mapOf("subject" to JsonPrimitive("hi"))),
+        ),
+    )
+
+    private fun refSamples(): Map<String, CanonAssetRef> = mapOf(
+        "canon_asset_ref.url" to CanonAssetRef.Url(
+            template = "https://img.example/{w}x{h}.jpg",
+            width = null,
+            height = null,
+        ),
+        "canon_asset_ref.native_handle" to CanonAssetRef.NativeHandle(
+            linkId = LinkId("link-1"),
+            nativeId = "PHAsset/abc123",
+        ),
+    )
+
+    @Test
+    fun `every CanonAssetRef variant round-trips through the sealed serializer`() {
+        refSamples().forEach { (discriminator, ref) ->
+            val encoded = json.encodeToString(CanonAssetRef.serializer(), ref)
+            val decoded = json.decodeFromString(CanonAssetRef.serializer(), encoded)
+
+            assertEquals(ref, decoded, "round-trip changed $discriminator")
+        }
+    }
+
+    @Test
+    fun `every CanonAssetRef variant writes its pinned discriminator`() {
+        refSamples().forEach { (discriminator, ref) ->
+            val encoded = json.encodeToString(CanonAssetRef.serializer(), ref)
+
+            assertTrue(
+                encoded.contains("\"type\":\"$discriminator\""),
+                "expected discriminator $discriminator, got $encoded",
+            )
+        }
+    }
+
+    @Test
+    fun `the four widened canon types round-trip with a populated asset ref`() {
+        val url = CanonAssetRef.Url(template = "https://img.example/{w}x{h}.jpg")
+        val handle = CanonAssetRef.NativeHandle(linkId = LinkId("link-1"), nativeId = "PHAsset/abc123")
+
+        val widened: Map<String, CanonEntity> = mapOf(
+            "canon.media_item" to CanonMediaItem(CanonId("mi"), provenance, title = "Track", artwork = url),
+            "canon.photo" to CanonPhoto(CanonId("ph"), provenance, thumbnail = handle),
+            "canon.document" to CanonDocument(
+                CanonId("doc"),
+                provenance,
+                title = "Spec",
+                kind = DocumentKind.WORD_PROCESSOR,
+                thumbnail = url,
+            ),
+            "canon.pass" to CanonPass(CanonId("pa"), provenance, description = "Boarding", logo = handle),
+        )
+
+        widened.forEach { (discriminator, entity) ->
+            val encoded = json.encodeToString(CanonEntity.serializer(), entity)
+            val decoded = json.decodeFromString(CanonEntity.serializer(), encoded)
+
+            assertEquals(entity, decoded, "round-trip changed $discriminator")
+        }
+    }
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/plug/spi/ConsentEnforcingAssetResolverTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/plug/spi/ConsentEnforcingAssetResolverTest.kt
@@ -1,0 +1,180 @@
+package link.socket.ampere.plug.spi
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import kotlinx.datetime.Instant
+import link.socket.ampere.agents.domain.event.AssetAccessEvent
+import link.socket.ampere.agents.events.bus.EventSerialBus
+import link.socket.ampere.agents.events.bus.subscribe
+import link.socket.ampere.agents.events.subscription.EventSubscription
+import link.socket.ampere.canon.CanonAssetRef
+import link.socket.ampere.canon.CanonType
+import link.socket.ampere.link.CredentialRef
+import link.socket.ampere.link.EgressClass
+import link.socket.ampere.link.InMemoryLinkStore
+import link.socket.ampere.link.Link
+import link.socket.ampere.link.LinkDirection
+import link.socket.ampere.link.LinkId
+import link.socket.ampere.link.Transport
+import link.socket.ampere.plug.PlugId
+
+class ConsentEnforcingAssetResolverTest {
+
+    private val photosLink = Link(
+        id = LinkId("photos-library"),
+        transport = Transport.NATIVE_FRAMEWORK,
+        direction = LinkDirection.READ,
+        egress = EgressClass.OnDevice,
+        scope = setOf(CanonType.PHOTO),
+        credentialRef = CredentialRef("keychain://photos"),
+    )
+
+    private val plugId = PlugId("photos-plug")
+
+    private val handle = CanonAssetRef.NativeHandle(linkId = photosLink.id, nativeId = "PHAsset/abc123")
+
+    private val stubBytes = AssetBytes(bytes = byteArrayOf(1, 2, 3), mimeType = "image/jpeg")
+
+    private class StubResolver(private val result: Result<AssetBytes>) : AssetResolver {
+        var callCount = 0
+            private set
+
+        override suspend fun resolve(ref: CanonAssetRef, spec: AssetSpec): Result<AssetBytes> {
+            callCount++
+            return result
+        }
+    }
+
+    @Test
+    fun `a URL ref has no Link so it resolves without a consent check`() = runTest {
+        val store = InMemoryLinkStore()
+        val delegate = StubResolver(Result.success(stubBytes))
+        val resolver = ConsentEnforcingAssetResolver(delegate, plugId, store)
+
+        val result = resolver.resolve(CanonAssetRef.Url(template = "https://img.example/{w}x{h}.jpg"), AssetSpec())
+
+        assertTrue(result.isSuccess)
+        assertEquals(1, delegate.callCount)
+    }
+
+    @Test
+    fun `a NativeHandle with a valid grant resolves`() = runTest {
+        val store = InMemoryLinkStore(listOf(photosLink))
+        store.grant(plugId, photosLink.id, Instant.fromEpochMilliseconds(1))
+        val delegate = StubResolver(Result.success(stubBytes))
+        val resolver = ConsentEnforcingAssetResolver(delegate, plugId, store)
+
+        val result = resolver.resolve(handle, AssetSpec())
+
+        assertEquals(stubBytes, result.getOrThrow())
+        assertEquals(1, delegate.callCount)
+    }
+
+    @Test
+    fun `no Link registered for the handle's linkId refuses without calling the delegate`() = runTest {
+        val store = InMemoryLinkStore()
+        val delegate = StubResolver(Result.success(stubBytes))
+        val resolver = ConsentEnforcingAssetResolver(delegate, plugId, store)
+
+        val result = resolver.resolve(handle, AssetSpec())
+
+        val error = assertIs<AssetResolutionException>(result.exceptionOrNull())
+        assertIs<AssetResolutionFailure.LinkNotFound>(error.failure)
+        assertEquals(0, delegate.callCount)
+    }
+
+    @Test
+    fun `a revoked Link refuses resolution at the SPI level`() = runTest {
+        val store = InMemoryLinkStore(listOf(photosLink))
+        store.grant(plugId, photosLink.id, Instant.fromEpochMilliseconds(1))
+        store.upsert(photosLink.copy(revokedAt = Instant.fromEpochMilliseconds(2)))
+        val delegate = StubResolver(Result.success(stubBytes))
+        val resolver = ConsentEnforcingAssetResolver(delegate, plugId, store)
+
+        val result = resolver.resolve(handle, AssetSpec())
+
+        val error = assertIs<AssetResolutionException>(result.exceptionOrNull())
+        assertIs<AssetResolutionFailure.ConsentRevoked>(error.failure)
+        assertEquals(0, delegate.callCount)
+    }
+
+    @Test
+    fun `a revoked grant refuses resolution even though the Link itself is fine`() = runTest {
+        val store = InMemoryLinkStore(listOf(photosLink))
+        store.grant(plugId, photosLink.id, Instant.fromEpochMilliseconds(1))
+        store.revokeGrant(plugId, photosLink.id, Instant.fromEpochMilliseconds(2))
+        val delegate = StubResolver(Result.success(stubBytes))
+        val resolver = ConsentEnforcingAssetResolver(delegate, plugId, store)
+
+        val result = resolver.resolve(handle, AssetSpec())
+
+        val error = assertIs<AssetResolutionException>(result.exceptionOrNull())
+        assertIs<AssetResolutionFailure.ConsentRevoked>(error.failure)
+        assertEquals(0, delegate.callCount)
+    }
+
+    @Test
+    fun `a successful resolution records an access event with no payload bytes`() = runTest {
+        coroutineScope {
+            val bus = EventSerialBus(scope = this)
+            val received = CompletableDeferred<AssetAccessEvent>()
+
+            bus.subscribe<AssetAccessEvent, EventSubscription.ByEventClassType>(
+                agentId = "observer",
+                eventType = AssetAccessEvent.EVENT_TYPE,
+            ) { event, _ ->
+                if (!received.isCompleted) received.complete(event)
+            }
+
+            val store = InMemoryLinkStore(listOf(photosLink))
+            store.grant(plugId, photosLink.id, Instant.fromEpochMilliseconds(1))
+            val delegate = StubResolver(Result.success(stubBytes))
+            val resolver = ConsentEnforcingAssetResolver(delegate, plugId, store, eventBus = bus)
+
+            resolver.resolve(handle, AssetSpec()).getOrThrow()
+
+            val seen = withTimeout(5.seconds) { received.await() }
+            assertEquals(photosLink.id, seen.linkId)
+            assertEquals(plugId.value, seen.plugId)
+            assertEquals(stubBytes.bytes.size.toLong(), seen.byteCount)
+        }
+    }
+
+    @Test
+    fun `a refused resolution never reaches the bus`() = runTest {
+        coroutineScope {
+            val bus = EventSerialBus(scope = this)
+            var eventCount = 0
+
+            bus.subscribe<AssetAccessEvent, EventSubscription.ByEventClassType>(
+                agentId = "observer",
+                eventType = AssetAccessEvent.EVENT_TYPE,
+            ) { _, _ -> eventCount++ }
+
+            val store = InMemoryLinkStore()
+            val delegate = StubResolver(Result.success(stubBytes))
+            val resolver = ConsentEnforcingAssetResolver(delegate, plugId, store, eventBus = bus)
+
+            resolver.resolve(handle, AssetSpec())
+
+            assertEquals(0, eventCount)
+        }
+    }
+
+    @Test
+    fun `resolution works with no bus wired`() = runTest {
+        val store = InMemoryLinkStore(listOf(photosLink))
+        store.grant(plugId, photosLink.id, Instant.fromEpochMilliseconds(1))
+        val delegate = StubResolver(Result.success(stubBytes))
+        val resolver = ConsentEnforcingAssetResolver(delegate, plugId, store, eventBus = null)
+
+        assertTrue(resolver.resolve(handle, AssetSpec()).isSuccess)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `CanonAssetRef` (`Url`/`NativeHandle`) as a canon-wide asset reference primitive, additively widening `CanonMediaItem.artwork`, `CanonPhoto.thumbnail`, `CanonDocument.thumbnail`, and `CanonPass.logo`.
- Lands `AssetResolver`/`AssetSpec`/`AssetBytes` as an optional Chassis SPI capability, with `ConsentEnforcingAssetResolver` enforcing the per-(Plug, Link) grant check via `LinkResolutionGate` (reusing `PERCEIVE` semantics) rather than leaving consent to implementors.
- Records out-of-band, payload-free `AssetAccessEvent`s on the bus (modeled on `LinkEvent`, registered in `EventRegistry`) and declares the capability via `PlugManifest.resolvesAssets`.

Closes #655

## Test plan

- [x] `./gradlew jvmTest` — full suite green
- [x] `./gradlew :ampere-core:compileCommonMainKotlinMetadata` — green
- [x] `CanonAssetRefSerializationTest` — both variants round-trip with pinned `@SerialName`s; all four widened types round-trip with populated refs; existing `CanonSerializationTest` samples unchanged
- [x] `ConsentEnforcingAssetResolverTest` — missing Link, revoked Link, and revoked grant all refuse without invoking the delegate; successful resolution emits `AssetAccessEvent` with no payload bytes; refused resolutions never reach the bus; works with no bus wired

This PR was written by Claude (Sonnet 5), an AI agent, based on the AMPR-258 Linear ticket's recon → decide → implement → validate phases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)