### PR TITLE
Bump publish workflow test timeout to 20 minutes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,7 +59,7 @@ jobs:
         run: ./gradlew ktlintCheck
 
       - name: Run tests before publish
-        timeout-minutes: 10
+        timeout-minutes: 20
         run: ./gradlew :ampere-core:jvmTest
 
       - name: Decode signing key

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,6 @@ plugins {
 
 allprojects {
     tasks.withType<Test>().configureEach {
-        maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(1)
+        maxParallelForks = Runtime.getRuntime().availableProcessors().coerceIn(2, 8)
     }
 }


### PR DESCRIPTION
## Summary
- The v0.12.0 publish run's "Run tests before publish" step hit its 10-minute timeout on `:ampere-core:jvmTest` on the `macos-latest` runner, with zero test output/failures.
- Root cause: `maxParallelForks = availableProcessors() / 2` collapses to **1 fork** on the 3-vCPU `macos-latest` runner (vs 5 forks locally on a 10-core machine, 2 forks on the 4-vCPU `ubuntu-latest` CI runner), serializing the ~1655-test `ampere-core` suite.
- Fixes: use `availableProcessors().coerceIn(2, 8)` so low-core runners still get real parallelism, and bump the step's `timeout-minutes` from 10 to 20 as a safety margin.

## Test plan
- [x] `./gradlew :ampere-core:jvmTest` locally (fast, uses 8 forks under the new cap)
- [ ] Validate via the next publish run that the step no longer times out

🤖 Generated with [Claude Code](https://claude.com/claude-code)