### PR TITLE
AMPR-261 #662: Add FolderRef alongside CredentialRef on Link

### DIFF
--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/link/Link.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/link/Link.kt
@@ -23,6 +23,10 @@ import link.socket.ampere.canon.CanonType
  *   Narrower than the transport can technically carry, on purpose.
  * @property credentialRef A *reference*. Raw credentials never live in this
  *   type, never reach a trace, and never cross the bus.
+ * @property folderRef A *reference* to a mounted folder, e.g. a security-scoped
+ *   bookmark. Distinct from [credentialRef]: a folder mount is not a secret,
+ *   so it belongs to a different storage class and a different row in the
+ *   consent ledger.
  */
 @Serializable
 data class Link(
@@ -32,6 +36,7 @@ data class Link(
     val egress: EgressClass,
     val scope: Set<CanonType> = emptySet(),
     val credentialRef: CredentialRef? = null,
+    val folderRef: FolderRef? = null,
     val revokedAt: Instant? = null,
 ) {
     /** A revoked Link resolves for nobody, regardless of standing grants. */
@@ -80,6 +85,30 @@ sealed interface EgressClass {
 @Serializable
 data class CredentialRef(
     val keychainAlias: String,
+    val revokedAt: Instant? = null,
+) {
+    val isRevoked: Boolean get() = revokedAt != null
+}
+
+/**
+ * A pointer to a mounted folder, e.g. a security-scoped bookmark.
+ *
+ * A folder mount is not a secret — it is an opaque path token, useless to an
+ * attacker without the app's entitlements — so it does not belong in the
+ * keychain-backed [CredentialRef] seam, and presenting it as a credential in
+ * the consent ledger would misrepresent the Link in exactly the surface where
+ * clarity matters most. Storage of the bookmark bytes themselves is
+ * platform-side and out of scope here; this type exists so a Link can *name*
+ * its folder mount without carrying it.
+ *
+ * @property mountId The key under which the platform-side bookmark blob is
+ *   stored, e.g. in an app-group-shared folder mount store.
+ * @property revokedAt Set when the folder mount itself is revoked, as
+ *   distinct from a Plug's grant being revoked.
+ */
+@Serializable
+data class FolderRef(
+    val mountId: String,
     val revokedAt: Instant? = null,
 ) {
     val isRevoked: Boolean get() = revokedAt != null

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/link/LinkResolutionFailure.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/link/LinkResolutionFailure.kt
@@ -92,6 +92,10 @@ enum class RevocationScope {
     @SerialName("credential")
     CREDENTIAL,
 
+    /** The folder mount is gone. Cascades to every Plug that used it. */
+    @SerialName("folder")
+    FOLDER,
+
     /** Only this Plug's grant on the Link was revoked. */
     @SerialName("plug_grant")
     PLUG_GRANT,

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/link/LinkResolutionGate.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/link/LinkResolutionGate.kt
@@ -125,6 +125,7 @@ object LinkResolutionGate {
     private fun revocationOf(link: Link, grants: LinkGrants): RevocationScope? = when {
         link.isRevoked -> RevocationScope.LINK
         link.credentialRef?.isRevoked == true -> RevocationScope.CREDENTIAL
+        link.folderRef?.isRevoked == true -> RevocationScope.FOLDER
         grants.isRevoked(link.id) -> RevocationScope.PLUG_GRANT
         else -> null
     }
@@ -139,5 +140,6 @@ object LinkResolutionGate {
     fun permits(link: Link, operation: LinkOperation): Boolean =
         !link.isRevoked &&
             link.credentialRef?.isRevoked != true &&
+            link.folderRef?.isRevoked != true &&
             link.direction.permits(operation)
 }

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/link/LinkResolutionGateTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/link/LinkResolutionGateTest.kt
@@ -139,6 +139,13 @@ class LinkResolutionGateTest {
         assertTrue(!LinkResolutionGate.permits(apnsLink, LinkOperation.PERCEIVE))
     }
 
+    @Test
+    fun `an already-resolved Link with a revoked folder ref no longer permits`() {
+        val revokedFolder = googleLink.copy(folderRef = FolderRef("mount-1", revokedAt))
+
+        assertTrue(!LinkResolutionGate.permits(revokedFolder, LinkOperation.PERCEIVE))
+    }
+
     // -----------------------------------------------------------------
     // Scope
     // -----------------------------------------------------------------
@@ -201,6 +208,22 @@ class LinkResolutionGateTest {
         val failed = assertIs<LinkResolution.Failed>(result)
         val failure = assertIs<LinkResolutionFailure.RevokedCredential>(failed.failure)
         assertEquals(RevocationScope.CREDENTIAL, failure.scope)
+    }
+
+    @Test
+    fun `a revoked folder ref reports FOLDER scope`() {
+        val result = LinkResolutionGate.resolve(
+            requirement = requirement(),
+            candidates = listOf(
+                googleLink.copy(folderRef = FolderRef("mount-1", revokedAt)),
+            ),
+            grants = grants("calendar-plug", googleLink.id),
+            platform = PlatformTarget.ANDROID,
+        )
+
+        val failed = assertIs<LinkResolution.Failed>(result)
+        val failure = assertIs<LinkResolutionFailure.RevokedCredential>(failed.failure)
+        assertEquals(RevocationScope.FOLDER, failure.scope)
     }
 
     @Test

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/link/LinkSerializationTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/link/LinkSerializationTest.kt
@@ -82,6 +82,31 @@ class LinkSerializationTest {
     }
 
     @Test
+    fun `a folder ref never carries the bookmark bytes`() {
+        val folderRef = FolderRef("mount-1")
+        val encoded = json.encodeToString(FolderRef.serializer(), folderRef)
+
+        // The mount id is a pointer; if bookmark bytes ever appear in this
+        // type, every trace that recorded a Link becomes a breach.
+        assertTrue(encoded.contains("mount-1"))
+        assertEquals(
+            setOf("mountId", "revokedAt"),
+            Regex("\"(\\w+)\":").findAll(encoded).map { it.groupValues[1] }.toSet(),
+        )
+    }
+
+    @Test
+    fun `a Link round-trips with its folder ref intact`() {
+        val withFolder = link.copy(folderRef = FolderRef("mount-1"))
+        val decoded = json.decodeFromString(
+            Link.serializer(),
+            json.encodeToString(Link.serializer(), withFolder),
+        )
+
+        assertEquals(withFolder, decoded)
+    }
+
+    @Test
     fun `every resolution failure round-trips`() {
         val failures = listOf<LinkResolutionFailure>(
             LinkResolutionFailure.MissingLink("calendar", Transport.MCP, LinkDirection.READ),
@@ -100,6 +125,11 @@ class LinkSerializationTest {
                 "calendar",
                 LinkId("google-oauth"),
                 RevocationScope.PLUG_GRANT,
+            ),
+            LinkResolutionFailure.RevokedCredential(
+                "files",
+                LinkId("folder-mount"),
+                RevocationScope.FOLDER,
             ),
             LinkResolutionFailure.TransportUnsupported(
                 "calendar",


### PR DESCRIPTION
## Summary
- Claude adds a `FolderRef(mountId, revokedAt)` type mirroring `CredentialRef`'s shape, plus a nullable `folderRef` field on `Link`, so a folder mount's reference is first-class instead of side-channel state.
- Claude adds `RevocationScope.FOLDER` and wires a revoked `folderRef` into `LinkResolutionGate`'s existing revocation precedence and `permits` check, matching how a revoked `credentialRef` already behaves.
- Claude adds round-trip/field-set serialization tests and gate revocation tests for the new type.

Closes #662

## Test plan
- [x] `./gradlew :ampere-core:jvmTest`
- [x] `./gradlew :ampere-core:compileTestKotlinIosSimulatorArm64`
- [x] `./gradlew :ampere-core:compileCommonMainKotlinMetadata`
- [x] `./gradlew ktlintFormat` (no changes)