### PR TITLE
AMPR-260 #660: Accommodate canon-external Plugs in PlugManifestValidator

### DIFF
--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/PlugManifest.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/PlugManifest.kt
@@ -34,6 +34,14 @@ import link.socket.ampere.plug.permission.PlugPermission
  * resolves assets before any [link.socket.ampere.canon.CanonAssetRef.NativeHandle]
  * it produced is ever resolved.
  *
+ * [isCanonExternal] is a positive declaration that this Plug has no canon-level
+ * data contract at all — it neither emits nor consumes any [CanonType], by
+ * design, not by omission. The closed v1 canon has no member for some Plugs'
+ * data (e.g. a notification, a pasteboard payload, recognised text), so
+ * [emits] and [consumes] being empty is the correct, permanent state rather
+ * than a gap to fill in later. See [PlugManifestValidator] for how this flag
+ * changes Link requirement validation.
+ *
  * Every collection field defaults to empty so manifests written before each
  * schema addition continue to decode unchanged.
  */
@@ -50,4 +58,5 @@ data class PlugManifest(
     val consumes: Set<CanonType> = emptySet(),
     val optionalConsumes: Set<CanonType> = emptySet(),
     val resolvesAssets: Boolean = false,
+    val isCanonExternal: Boolean = false,
 )

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/PlugManifestValidator.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/PlugManifestValidator.kt
@@ -15,12 +15,14 @@ import link.socket.ampere.plug.permission.PlugPermission
  * Returning a sealed result keeps the validator usable both for early failure
  * (during plug install) and for surfacing diagnostics in tooling.
  *
- * This validator does not check [PlugManifest.emits] itself, only that
- * [PlugManifest.requiredLinks] scopes and [PlugManifest.optionalConsumes]
- * stay consistent with [PlugManifest.consumes]. The only production call
- * site today is [PlugContext.create]. It is expected to run at plug install
- * time on every host that accepts manifests — including Socket, which does
- * not currently call it.
+ * This validator does not check [PlugManifest.emits] / [PlugManifest.consumes]
+ * against anything outside the manifest itself — it only cross-references
+ * them against [PlugManifest.requiredLinks] scopes and
+ * [PlugManifest.optionalConsumes], and checks them against
+ * [PlugManifest.isCanonExternal] for internal consistency. The only
+ * production call site today is [PlugContext.create]. It is expected to run
+ * at plug install time on every host that accepts manifests — including
+ * Socket, which does not currently call it.
  */
 object PlugManifestValidator {
 
@@ -64,12 +66,24 @@ object PlugManifestValidator {
     /**
      * Structural checks on [PlugManifest.requiredLinks].
      *
-     * All three rules exist because the failure they catch is silent
+     * All four rules exist because the failure they catch is silent
      * otherwise: a duplicate requirement name means one of the two Links is
      * unreachable through [link.socket.ampere.link.ResolvedLinks], an empty
      * scope means a wire that resolves successfully and then may carry
      * nothing, and a scope naming a canon type the Plug never declares means
      * the Plug is asking for data it has no stated way to produce or use.
+     *
+     * The empty-scope and undeclared-canon-scope rules are skipped entirely
+     * for a [PlugManifest.isCanonExternal] Plug: by declaration it has no
+     * canon type it could truthfully name, so every [LinkRequirement] is
+     * allowed an empty [LinkRequirement.minimumScope] and any non-empty
+     * scope is exempt from the "declared in emits/consumes/optionalConsumes"
+     * check. This is a carve-out for a positively-declared state, not an
+     * inference from empty [PlugManifest.emits]/[PlugManifest.consumes] — a
+     * canon-bearing Plug that leaves those collections empty by mistake
+     * still fails both rules unchanged. [CanonExternalWithDeclaredCanon]
+     * catches the inverse mistake: [PlugManifest.isCanonExternal] set while
+     * still claiming a canon type.
      */
     private fun validateLinkRequirements(
         manifest: PlugManifest,
@@ -84,19 +98,27 @@ object PlugManifestValidator {
                 reasons += ManifestValidationReason.DuplicateLinkRequirementName(name)
             }
 
-        manifest.requiredLinks
-            .filter { it.minimumScope.isEmpty() }
-            .forEach { requirement ->
-                reasons += ManifestValidationReason.EmptyLinkRequirementScope(requirement.name)
-            }
+        if (manifest.isCanonExternal && (manifest.emits.isNotEmpty() || manifest.consumes.isNotEmpty())) {
+            reasons += ManifestValidationReason.CanonExternalWithDeclaredCanon(
+                canonTypes = manifest.emits + manifest.consumes,
+            )
+        }
 
-        val declaredCanonTypes = manifest.emits + manifest.consumes + manifest.optionalConsumes
-        manifest.requiredLinks.forEach { requirement ->
-            (requirement.minimumScope - declaredCanonTypes).forEach { undeclared ->
-                reasons += ManifestValidationReason.UndeclaredCanonScope(
-                    requirementName = requirement.name,
-                    canonType = undeclared,
-                )
+        if (!manifest.isCanonExternal) {
+            manifest.requiredLinks
+                .filter { it.minimumScope.isEmpty() }
+                .forEach { requirement ->
+                    reasons += ManifestValidationReason.EmptyLinkRequirementScope(requirement.name)
+                }
+
+            val declaredCanonTypes = manifest.emits + manifest.consumes + manifest.optionalConsumes
+            manifest.requiredLinks.forEach { requirement ->
+                (requirement.minimumScope - declaredCanonTypes).forEach { undeclared ->
+                    reasons += ManifestValidationReason.UndeclaredCanonScope(
+                        requirementName = requirement.name,
+                        canonType = undeclared,
+                    )
+                }
             }
         }
 
@@ -200,5 +222,16 @@ sealed interface ManifestValidationReason {
      */
     data class RedundantOptionalConsumes(
         val canonType: CanonType,
+    ) : ManifestValidationReason
+
+    /**
+     * [PlugManifest.isCanonExternal] declares that a Plug has no canon-level
+     * data contract, but [PlugManifest.emits] or [PlugManifest.consumes] is
+     * non-empty — a contradiction that would otherwise silently exempt a
+     * canon-bearing Plug from [EmptyLinkRequirementScope] and
+     * [UndeclaredCanonScope].
+     */
+    data class CanonExternalWithDeclaredCanon(
+        val canonTypes: Set<CanonType>,
     ) : ManifestValidationReason
 }

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/plug/PlugManifestValidationTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/plug/PlugManifestValidationTest.kt
@@ -349,6 +349,104 @@ class PlugManifestValidationTest {
     }
 
     @Test
+    fun `a canon-external manifest with an empty-scope link requirement validates`() {
+        val manifest = PlugManifest(
+            id = PlugId("vision-ocr-plug"),
+            name = "Vision OCR Plug",
+            version = "1.0.0",
+            requiredLinks = listOf(linkRequirement("camera", emptySet())),
+            isCanonExternal = true,
+        )
+
+        assertEquals(ManifestValidationResult.Valid, PlugManifestValidator.validate(manifest))
+    }
+
+    @Test
+    fun `a canon-external manifest with a non-empty undeclared scope validates`() {
+        val manifest = PlugManifest(
+            id = PlugId("vision-ocr-plug"),
+            name = "Vision OCR Plug",
+            version = "1.0.0",
+            requiredLinks = listOf(linkRequirement("camera", setOf(CanonType.CALENDAR_EVENT))),
+            isCanonExternal = true,
+        )
+
+        assertEquals(ManifestValidationResult.Valid, PlugManifestValidator.validate(manifest))
+    }
+
+    @Test
+    fun `a canon-bearing manifest with an empty scope still fails when isCanonExternal is unset`() {
+        val manifest = PlugManifest(
+            id = PlugId("calendar-plug"),
+            name = "Calendar Plug",
+            version = "1.0.0",
+            requiredLinks = listOf(linkRequirement("calendar", emptySet())),
+            emits = setOf(CanonType.CALENDAR_EVENT),
+        )
+
+        val invalid = assertIs<ManifestValidationResult.Invalid>(
+            PlugManifestValidator.validate(manifest),
+        )
+
+        assertEquals(
+            listOf("calendar"),
+            invalid.reasons
+                .filterIsInstance<ManifestValidationReason.EmptyLinkRequirementScope>()
+                .map { it.name },
+        )
+    }
+
+    @Test
+    fun `a canon-bearing manifest with an undeclared scope still fails when isCanonExternal is unset`() {
+        val manifest = PlugManifest(
+            id = PlugId("calendar-plug"),
+            name = "Calendar Plug",
+            version = "1.0.0",
+            requiredLinks = listOf(linkRequirement("calendar", setOf(CanonType.CALENDAR_EVENT))),
+            emits = setOf(CanonType.PERSON),
+        )
+
+        val invalid = assertIs<ManifestValidationResult.Invalid>(
+            PlugManifestValidator.validate(manifest),
+        )
+
+        assertEquals(
+            listOf(CanonType.CALENDAR_EVENT),
+            invalid.reasons
+                .filterIsInstance<ManifestValidationReason.UndeclaredCanonScope>()
+                .map { it.canonType },
+        )
+    }
+
+    @Test
+    fun `isCanonExternal set while still declaring emits or consumes is rejected`() {
+        val manifest = PlugManifest(
+            id = PlugId("mislabelled-plug"),
+            name = "Mislabelled Plug",
+            version = "1.0.0",
+            requiredLinks = listOf(linkRequirement("calendar", setOf(CanonType.CALENDAR_EVENT))),
+            emits = setOf(CanonType.CALENDAR_EVENT),
+            isCanonExternal = true,
+        )
+
+        val invalid = assertIs<ManifestValidationResult.Invalid>(
+            PlugManifestValidator.validate(manifest),
+        )
+
+        val contradiction = invalid.reasons
+            .filterIsInstance<ManifestValidationReason.CanonExternalWithDeclaredCanon>()
+        assertEquals(1, contradiction.size)
+        assertEquals(setOf(CanonType.CALENDAR_EVENT), contradiction.single().canonTypes)
+    }
+
+    @Test
+    fun `a manifest written before isCanonExternal existed still decodes as canon-bearing`() {
+        val manifest = PlugManifest(id = PlugId("legacy"), name = "Legacy", version = "0.1.0")
+
+        assertTrue(!manifest.isCanonExternal)
+    }
+
+    @Test
     fun `a manifest written before link requirements existed still decodes`() {
         // The defaults are what keep pre-AMPR-223 manifests valid.
         val manifest = PlugManifest(id = PlugId("legacy"), name = "Legacy", version = "0.1.0")


### PR DESCRIPTION
## Summary
- Adds `PlugManifest.isCanonExternal` (default `false`) as a positive declaration that a Plug intentionally has no canon-level data contract, rather than inferring it from empty `emits`/`consumes`.
- `PlugManifestValidator` skips `EmptyLinkRequirementScope` and `UndeclaredCanonScope` for a Link requirement only when `isCanonExternal` is set, so a canon-bearing Plug that mistakenly leaves `emits`/`consumes` empty still fails those rules unchanged.
- Adds `ManifestValidationReason.CanonExternalWithDeclaredCanon` to reject the contradictory case of `isCanonExternal = true` combined with a non-empty `emits`/`consumes`.
- Updates `PlugManifest`/`PlugManifestValidator` KDoc and adds tests for canon-external validation, unchanged canon-bearing validation, and the new contradiction check.

Closes #660

## Test plan
- [x] `./gradlew :ampere-core:jvmTest` (full suite)
- [x] `./gradlew ktlintFormat` (no changes needed)
- [x] `./gradlew :ampere-core:compileCommonMainKotlinMetadata`
- [x] `./gradlew :ampere-core:compileTestKotlinIosSimulatorArm64`

🤖 Generated by Claude Sonnet 5, an AI agent, with human review and approval.