### PR TITLE
AMPR-259 #659: Optional canon consumption on PlugManifest

### DIFF
--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/PlugManifest.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/PlugManifest.kt
@@ -19,6 +19,15 @@ import link.socket.ampere.plug.permission.PlugPermission
  * produce for other Arc steps, and what it needs handed to it. They are what a
  * future planner reads to decide two Plugs can be chained.
  *
+ * [optionalConsumes] names canon types this Plug can use if an Arc-execution
+ * planner hands them one, but does not require — e.g. a Plug that can use a
+ * [link.socket.ampere.canon.CanonType.PHOTO] earlier in an Arc without forcing
+ * every caller through whatever Plug would otherwise produce one. Unlike
+ * [consumes], no input source is required for the Plug to run. The
+ * Arc-execution planner that chains one Plug's canon output into another
+ * Plug's optional input is out of scope here; this field only needs to exist
+ * for that planner to read.
+ *
  * [resolvesAssets] declares the third, optional chassis capability — a Plug
  * implementing [link.socket.ampere.plug.spi.AssetResolver] alongside (or
  * instead of) Perceive/Execute — so a consent surface can state that a Plug
@@ -39,5 +48,6 @@ data class PlugManifest(
     val requiredLinks: List<LinkRequirement> = emptyList(),
     val emits: Set<CanonType> = emptySet(),
     val consumes: Set<CanonType> = emptySet(),
+    val optionalConsumes: Set<CanonType> = emptySet(),
     val resolvesAssets: Boolean = false,
 )

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/PlugManifestValidator.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/plug/PlugManifestValidator.kt
@@ -15,10 +15,12 @@ import link.socket.ampere.plug.permission.PlugPermission
  * Returning a sealed result keeps the validator usable both for early failure
  * (during plug install) and for surfacing diagnostics in tooling.
  *
- * This validator does not check [PlugManifest.emits] / [PlugManifest.consumes]
- * at all, and the only production call site today is [PlugContext.create].
- * It is expected to run at plug install time on every host that accepts
- * manifests — including Socket, which does not currently call it.
+ * This validator does not check [PlugManifest.emits] itself, only that
+ * [PlugManifest.requiredLinks] scopes and [PlugManifest.optionalConsumes]
+ * stay consistent with [PlugManifest.consumes]. The only production call
+ * site today is [PlugContext.create]. It is expected to run at plug install
+ * time on every host that accepts manifests — including Socket, which does
+ * not currently call it.
  */
 object PlugManifestValidator {
 
@@ -50,6 +52,7 @@ object PlugManifestValidator {
 
         reasons += validateLinkRequirements(manifest)
         reasons += validateDeviceCapabilities(manifest)
+        reasons += validateCanonConsumption(manifest)
 
         return if (reasons.isEmpty()) {
             ManifestValidationResult.Valid
@@ -87,7 +90,7 @@ object PlugManifestValidator {
                 reasons += ManifestValidationReason.EmptyLinkRequirementScope(requirement.name)
             }
 
-        val declaredCanonTypes = manifest.emits + manifest.consumes
+        val declaredCanonTypes = manifest.emits + manifest.consumes + manifest.optionalConsumes
         manifest.requiredLinks.forEach { requirement ->
             (requirement.minimumScope - declaredCanonTypes).forEach { undeclared ->
                 reasons += ManifestValidationReason.UndeclaredCanonScope(
@@ -114,6 +117,18 @@ object PlugManifestValidator {
             .filterValues { it.size > 1 }
             .keys
             .map { ManifestValidationReason.DuplicateDeviceCapability(it) }
+    }
+
+    /**
+     * A canon type in both [PlugManifest.consumes] and
+     * [PlugManifest.optionalConsumes] is a contradiction: the Plug cannot
+     * simultaneously require and merely-accept-if-available the same type.
+     */
+    private fun validateCanonConsumption(
+        manifest: PlugManifest,
+    ): List<ManifestValidationReason> {
+        return (manifest.consumes intersect manifest.optionalConsumes)
+            .map { ManifestValidationReason.RedundantOptionalConsumes(it) }
     }
 }
 
@@ -169,12 +184,21 @@ sealed interface ManifestValidationReason {
 
     /**
      * A [link.socket.ampere.link.LinkRequirement.minimumScope] names a
-     * [CanonType] the manifest neither [PlugManifest.emits] nor
-     * [PlugManifest.consumes] — the Plug is asking for data it has no stated
-     * way to produce or use.
+     * [CanonType] the manifest declares in none of [PlugManifest.emits],
+     * [PlugManifest.consumes], or [PlugManifest.optionalConsumes] — the Plug
+     * is asking for data it has no stated way to produce or use.
      */
     data class UndeclaredCanonScope(
         val requirementName: String,
+        val canonType: CanonType,
+    ) : ManifestValidationReason
+
+    /**
+     * A [CanonType] appears in both [PlugManifest.consumes] and
+     * [PlugManifest.optionalConsumes] — the Plug cannot both require and
+     * merely-accept-if-available the same canon type.
+     */
+    data class RedundantOptionalConsumes(
         val canonType: CanonType,
     ) : ManifestValidationReason
 }

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/plug/PlugManifestSerializationTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/plug/PlugManifestSerializationTest.kt
@@ -2,7 +2,9 @@ package link.socket.ampere.plug
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import kotlinx.serialization.json.Json
+import link.socket.ampere.canon.CanonType
 import link.socket.ampere.plug.permission.PlugPermission
 
 class PlugManifestSerializationTest {
@@ -31,6 +33,37 @@ class PlugManifestSerializationTest {
         val decoded = json.decodeFromString(PlugManifest.serializer(), encoded)
 
         assertEquals(manifest, decoded)
+    }
+
+    @Test
+    fun `round-trips a manifest declaring optional canon consumption unchanged`() {
+        val manifest = PlugManifest(
+            id = PlugId("vision-ocr-plug"),
+            name = "Vision OCR Plug",
+            version = "1.0.0",
+            optionalConsumes = setOf(CanonType.PHOTO),
+        )
+
+        val encoded = json.encodeToString(PlugManifest.serializer(), manifest)
+        val decoded = json.decodeFromString(PlugManifest.serializer(), encoded)
+
+        assertEquals(manifest, decoded)
+        assertEquals(setOf(CanonType.PHOTO), decoded.optionalConsumes)
+    }
+
+    @Test
+    fun `a manifest written before optionalConsumes existed still decodes`() {
+        val legacyManifestJson = """
+            {
+              "id": "github-plug",
+              "name": "GitHub Plug",
+              "version": "1.0.0"
+            }
+        """.trimIndent()
+
+        val decoded = json.decodeFromString(PlugManifest.serializer(), legacyManifestJson)
+
+        assertTrue(decoded.optionalConsumes.isEmpty())
     }
 
     @Test

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/plug/PlugManifestValidationTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/plug/PlugManifestValidationTest.kt
@@ -302,6 +302,53 @@ class PlugManifestValidationTest {
     }
 
     @Test
+    fun `a manifest declaring an optional canon type it does not also require validates`() {
+        val manifest = PlugManifest(
+            id = PlugId("vision-ocr-plug"),
+            name = "Vision OCR Plug",
+            version = "1.0.0",
+            optionalConsumes = setOf(CanonType.PHOTO),
+        )
+
+        assertEquals(ManifestValidationResult.Valid, PlugManifestValidator.validate(manifest))
+    }
+
+    @Test
+    fun `a link requirement scoped to a canon type only in optionalConsumes validates`() {
+        val manifest = PlugManifest(
+            id = PlugId("vision-ocr-plug"),
+            name = "Vision OCR Plug",
+            version = "1.0.0",
+            requiredLinks = listOf(linkRequirement("photos", setOf(CanonType.PHOTO))),
+            optionalConsumes = setOf(CanonType.PHOTO),
+        )
+
+        assertEquals(ManifestValidationResult.Valid, PlugManifestValidator.validate(manifest))
+    }
+
+    @Test
+    fun `a canon type declared in both consumes and optionalConsumes is rejected`() {
+        val manifest = PlugManifest(
+            id = PlugId("vision-ocr-plug"),
+            name = "Vision OCR Plug",
+            version = "1.0.0",
+            consumes = setOf(CanonType.PHOTO),
+            optionalConsumes = setOf(CanonType.PHOTO),
+        )
+
+        val invalid = assertIs<ManifestValidationResult.Invalid>(
+            PlugManifestValidator.validate(manifest),
+        )
+
+        assertEquals(
+            listOf(CanonType.PHOTO),
+            invalid.reasons
+                .filterIsInstance<ManifestValidationReason.RedundantOptionalConsumes>()
+                .map { it.canonType },
+        )
+    }
+
+    @Test
     fun `a manifest written before link requirements existed still decodes`() {
         // The defaults are what keep pre-AMPR-223 manifests valid.
         val manifest = PlugManifest(id = PlugId("legacy"), name = "Legacy", version = "0.1.0")
@@ -309,6 +356,7 @@ class PlugManifestValidationTest {
         assertTrue(manifest.requiredLinks.isEmpty())
         assertTrue(manifest.emits.isEmpty())
         assertTrue(manifest.consumes.isEmpty())
+        assertTrue(manifest.optionalConsumes.isEmpty())
         assertEquals(ManifestValidationResult.Valid, PlugManifestValidator.validate(manifest))
     }
 }


### PR DESCRIPTION
Closes #659

Adds `PlugManifest.optionalConsumes: Set<CanonType>` alongside `consumes` so a Plug (e.g. Vision OCR, SCKT-436) can declare a canon type it can use if available without requiring it, mirroring `LinkRequirement.optional`'s "usable without" semantics as an additive, wire-compatible field rather than replacing `consumes`'s element type. `PlugManifestValidator` now counts `optionalConsumes` toward the `UndeclaredCanonScope` subset check and rejects a canon type declared in both `consumes` and `optionalConsumes` via a new `RedundantOptionalConsumes` reason. Covered by serialization round-trip and validator tests; the Arc-execution planner that would actually chain this (SCKT-445) is out of scope.

This PR was written by Claude, on behalf of Miley Chandonnet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)