### PR TITLE
AMPR-268 #672: Bound CanonDocument.plainText and other canon prose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,40 @@ The project is pre-1.0; breaking changes are acceptable and explicitly called ou
 
 ### Breaking
 
+- **Bounded prose in canon: `CanonProse` replaces raw `String` prose fields**
+  ([AMPR-268](https://linear.app/miley/issue/AMPR-268)).
+
+  `CanonDocument.plainText` predated the bulk rule admitted by AMPR-262 — an
+  unbounded `String?` that could blow the 32 KiB per-projection budget on its
+  own. `CanonProse` brings it, and every other free-form prose field the recon
+  flagged, under the same rule `CanonTablePreview` established for tables: a
+  `bounded()` factory truncates to 8,000 UTF-16 units (never splitting a
+  surrogate pair) and sets `truncated` rather than rejecting at decode time —
+  a canon type must always decode, so bounding stays a write-side concern.
+
+  Changed from `String`/`String?` to `CanonProse`/`CanonProse?`:
+  - `CanonDocument.plainText`
+  - `CanonMessage.bodyText`
+  - `CanonNote.bodyText`
+  - `CanonJournalEntry.bodyText`
+  - `CanonProject.summary`
+
+  `CanonEmailMessage.bodyText` and `CanonEmailDraft.bodyText` are **not**
+  changed — both already have a live write-back adapter
+  (`MailMessageAdapter`) that round-trips the raw string through
+  `NativePayload.fields`, and truncating a field an adapter writes back would
+  silently corrupt provider data. That decision is scoped to this ticket, not
+  a permanent exemption.
+
+  **Migration for external consumers:** callers constructing these fields
+  must switch to `CanonProse.bounded(text)`. A recorded trace containing the
+  old wire shape (`"plainText": "..."` as a raw JSON string) will fail to
+  decode against the new shape (`"plainText": {"text": "...", "truncated":
+  false}`). No migration tooling exists for already-recorded traces — trace
+  hygiene is out of scope here (tracked separately) and none of the affected
+  types has shipped a production adapter yet, so no real trace is known to
+  carry the old shape.
+
 - **PROPEL `CognitivePhase` enum is now canonically six members**
   ([AMPR-172](https://linear.app/miley/issue/AMPR-172)).
 

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/CanonProse.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/CanonProse.kt
@@ -1,0 +1,77 @@
+package link.socket.ampere.canon
+
+import kotlinx.serialization.Serializable
+
+/**
+ * A bounded window onto a canon entity's free-form text — never the entity's
+ * full prose.
+ *
+ * [CanonTablePreview] structurally enforces the bulk rule — schema and counts
+ * in canon, content by reference — for tabular content. Prose does not
+ * decompose into rows and columns, so it needed its own bounded shape. Build
+ * one with [bounded], which truncates to [MAX_CHARS] and records whether it
+ * did.
+ *
+ * **Why the bound is a factory and not a `require` in `init`.** Rejecting an
+ * oversized value at *decode* time would make an already-recorded trace
+ * permanently undecodable, which is precisely the failure the `@SerialName`
+ * stability invariant exists to prevent. A canon type must always decode;
+ * bounding is a write-side concern. [isWithinBounds] exposes the rule so it is
+ * testable rather than merely stated.
+ *
+ * @property text The prose, already truncated to [MAX_CHARS].
+ * @property truncated True when [bounded] cut [text] short. Unlike
+ *   [CanonTablePreview], there is no sibling count field a reader can fall
+ *   back on to learn the untruncated length — a `true` value means the rest of
+ *   the prose is simply gone from this projection.
+ */
+@Serializable
+data class CanonProse(
+    val text: String = "",
+    val truncated: Boolean = false,
+) {
+
+    /** Whether this value honours the [bounded] limit. */
+    val isWithinBounds: Boolean
+        get() = text.length <= MAX_CHARS
+
+    companion object {
+
+        /**
+         * Long enough for a document snippet — several paragraphs, not one —
+         * while a worst-case value still clears the 32 KiB projection budget
+         * asserted in `CanonWorkEntitiesTest` with room to spare for the rest
+         * of the entity and JSON overhead.
+         */
+        const val MAX_CHARS: Int = 8_000
+
+        /**
+         * Truncate [text] to [MAX_CHARS], flagging whether anything was cut.
+         *
+         * The only construction path adapters should use. Worst case is
+         * [MAX_CHARS] UTF-16 units of content. In bytes that peaks at ×3, not
+         * ×4 — a four-byte codepoint costs two units, so the worst
+         * byte-per-unit ratio belongs to three-byte BMP characters like
+         * CJK — giving 24,000 bytes, comfortably inside the budget asserted in
+         * `CanonWorkEntitiesTest`.
+         */
+        fun bounded(text: String): CanonProse {
+            val truncated = text.length > MAX_CHARS
+            return CanonProse(text = text.takeProse(), truncated = truncated)
+        }
+
+        /**
+         * [MAX_CHARS] units, without splitting a surrogate pair.
+         *
+         * A naive `take` can leave a trailing lone high surrogate, which is
+         * not valid UTF-8 — it encodes as a replacement character, so the
+         * value would fail to round-trip through the very serialization these
+         * bounds exist to protect.
+         */
+        private fun String.takeProse(): String = when {
+            length <= MAX_CHARS -> this
+            this[MAX_CHARS - 1].isHighSurrogate() -> substring(0, MAX_CHARS - 1)
+            else -> substring(0, MAX_CHARS)
+        }
+    }
+}

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/CanonRing1Entities.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/CanonRing1Entities.kt
@@ -147,6 +147,10 @@ data class CanonPhotoAlbum(
  * One canon type covers Apple's five document domains. [kind] is the
  * discriminator that makes the fan-out survivable: drop it, and a projection
  * cannot find its way back to the right schema on write-back.
+ *
+ * @property plainText A bounded snippet, not the document's full text — see
+ *   [CanonProse]. A single unbounded document body was the counterexample to
+ *   the bulk rule the rest of canon holds to; this is the fix.
  */
 @Serializable
 @SerialName("canon.document")
@@ -158,7 +162,7 @@ data class CanonDocument(
     val mimeType: String? = null,
     val sizeBytes: Long? = null,
     val modifiedAt: Instant? = null,
-    val plainText: String? = null,
+    val plainText: CanonProse? = null,
     val thumbnail: CanonAssetRef? = null,
 ) : CanonEntity {
     override val canonType: CanonType get() = CanonType.DOCUMENT
@@ -222,13 +226,14 @@ data class CanonPlace(
     override val canonType: CanonType get() = CanonType.PLACE
 }
 
+/** @property bodyText A bounded snippet, not the entry's full text — see [CanonProse]. */
 @Serializable
 @SerialName("canon.journal_entry")
 data class CanonJournalEntry(
     override val canonId: CanonId,
     override val provenance: CanonProvenance,
     val title: String? = null,
-    val bodyText: String? = null,
+    val bodyText: CanonProse? = null,
     val createdAt: Instant? = null,
     val place: CanonPlace? = null,
 ) : CanonEntity {

--- a/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/CanonRing3Entities.kt
+++ b/ampere-core/src/commonMain/kotlin/link/socket/ampere/canon/CanonRing3Entities.kt
@@ -19,12 +19,13 @@ import kotlinx.serialization.Serializable
  * from "Mcp/OAuthRest only" to "any non-OS Link".
  */
 
+/** @property bodyText A bounded snippet, not the message's full text — see [CanonProse]. */
 @Serializable
 @SerialName("canon.message")
 data class CanonMessage(
     override val canonId: CanonId,
     override val provenance: CanonProvenance,
-    val bodyText: String,
+    val bodyText: CanonProse,
     val sender: CanonPerson? = null,
     val conversationId: String? = null,
     val sentAt: Instant? = null,
@@ -32,13 +33,14 @@ data class CanonMessage(
     override val canonType: CanonType get() = CanonType.MESSAGE
 }
 
+/** @property bodyText A bounded snippet, not the note's full text — see [CanonProse]. */
 @Serializable
 @SerialName("canon.note")
 data class CanonNote(
     override val canonId: CanonId,
     override val provenance: CanonProvenance,
     val title: String? = null,
-    val bodyText: String? = null,
+    val bodyText: CanonProse? = null,
     val tags: List<String> = emptyList(),
     val modifiedAt: Instant? = null,
 ) : CanonEntity {
@@ -197,6 +199,8 @@ data class CanonWorkItem(
  *   to an [Instant] silently promotes that to a precise timestamp. Adapters
  *   normalise a coarse resolution to the *last* day of the period, so a deadline
  *   is never reported earlier than the provider means it.
+ * @property summary A bounded snippet, not the project's full description — see
+ *   [CanonProse].
  */
 @Serializable
 @SerialName("canon.project")
@@ -208,7 +212,7 @@ data class CanonProject(
     val providerStatus: String? = null,
     val targetDate: Instant? = null,
     val lead: CanonPerson? = null,
-    val summary: String? = null,
+    val summary: CanonProse? = null,
 ) : CanonEntity {
     override val canonType: CanonType get() = CanonType.PROJECT
 }

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/canon/CanonProseTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/canon/CanonProseTest.kt
@@ -1,0 +1,96 @@
+package link.socket.ampere.canon
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.datetime.Instant
+import kotlinx.serialization.json.Json
+import link.socket.ampere.link.LinkId
+
+/**
+ * [CanonProse] (AMPR-268): the bounded-prose counterpart to [CanonTablePreview]
+ * for canon types whose free-form text does not decompose into rows and
+ * columns.
+ */
+class CanonProseTest {
+
+    private val json = Json {
+        prettyPrint = false
+        encodeDefaults = true
+        classDiscriminator = "type"
+        ignoreUnknownKeys = true
+    }
+
+    private val provenance = CanonProvenance(
+        sourceHandle = SourceHandle(
+            linkId = LinkId("link-1"),
+            sourceSystem = "apple.files",
+            nativeId = "doc-1",
+        ),
+        observedAt = Instant.fromEpochMilliseconds(1_700_000_000_000),
+    )
+
+    private fun documentCarrying(plainText: CanonProse) = CanonDocument(
+        canonId = CanonId("doc-1"),
+        provenance = provenance,
+        title = "Spec",
+        kind = DocumentKind.WORD_PROCESSOR,
+        plainText = plainText,
+    )
+
+    private fun roundTrip(entity: CanonEntity): CanonEntity =
+        json.decodeFromString(
+            CanonEntity.serializer(),
+            json.encodeToString(CanonEntity.serializer(), entity),
+        )
+
+    @Test
+    fun `short prose survives bounding untouched`() {
+        val text = "A few sentences of plain text."
+
+        val prose = CanonProse.bounded(text)
+
+        assertEquals(text, prose.text)
+        assertFalse(prose.truncated, "nothing was cut; truncated must not claim otherwise")
+        assertTrue(prose.isWithinBounds)
+    }
+
+    @Test
+    fun `bounding truncates text past the char limit`() {
+        val long = "x".repeat(CanonProse.MAX_CHARS * 10)
+
+        val prose = CanonProse.bounded(long)
+
+        assertEquals(CanonProse.MAX_CHARS, prose.text.length)
+        assertTrue(prose.truncated, "text over the limit was cut")
+        assertTrue(prose.isWithinBounds)
+    }
+
+    @Test
+    fun `a hand-built oversized value reports itself out of bounds`() {
+        // The bound is a write-side factory rule, not a decode-time reject: an
+        // oversized value must still decode, or a recorded trace carrying one
+        // becomes permanently unreplayable. isWithinBounds is how it stays visible.
+        val oversized = CanonProse(text = "x".repeat(CanonProse.MAX_CHARS + 1))
+
+        assertFalse(oversized.isWithinBounds)
+        assertEquals(oversized, roundTrip(documentCarrying(oversized)).let { (it as CanonDocument).plainText })
+    }
+
+    @Test
+    fun `bounding never splits a surrogate pair`() {
+        // A lone high surrogate is not valid UTF-8; it would encode as a
+        // replacement character and break the round trip these bounds protect.
+        // The leading "a" shifts the pairs so the cut index lands on a high
+        // surrogate; without the offset the boundary falls harmlessly between
+        // whole pairs and the hazard never fires.
+        val text = "a" + "𝄞".repeat(CanonProse.MAX_CHARS)
+        assertTrue(text[CanonProse.MAX_CHARS - 1].isHighSurrogate(), "fixture must straddle the bound")
+
+        val prose = CanonProse.bounded(text)
+
+        assertFalse(prose.text.last().isHighSurrogate(), "bounding left a lone high surrogate")
+        assertEquals(prose, roundTrip(documentCarrying(prose)).let { (it as CanonDocument).plainText })
+    }
+}

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/canon/CanonSerializationTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/canon/CanonSerializationTest.kt
@@ -103,7 +103,7 @@ class CanonSerializationTest {
             activity = "walking",
             recordedAt = Instant.fromEpochMilliseconds(1_700_000_400_000),
         ),
-        "canon.message" to CanonMessage(CanonId("msg"), provenance, bodyText = "yo"),
+        "canon.message" to CanonMessage(CanonId("msg"), provenance, bodyText = CanonProse.bounded("yo")),
         "canon.note" to CanonNote(CanonId("n"), provenance),
         "canon.ride" to CanonRide(
             CanonId("rd"),

--- a/ampere-core/src/commonTest/kotlin/link/socket/ampere/canon/CanonWorkEntitiesTest.kt
+++ b/ampere-core/src/commonTest/kotlin/link/socket/ampere/canon/CanonWorkEntitiesTest.kt
@@ -16,7 +16,9 @@ import link.socket.ampere.link.LinkId
  * sources are `Mcp` and `FolderMount` Links, so provenance from both is
  * exercised. Second, [CanonTable] is the first canon type that could carry bulk
  * content, and the bulk rule — schema and counts in canon, content by reference
- * — is only real if something asserts it.
+ * — is only real if something asserts it. [CanonDocument] rides along on the
+ * same budget assertion (AMPR-268): its `plainText` was the pre-existing
+ * counterexample to the rule, and [CanonProse] is what brings it into line.
  */
 class CanonWorkEntitiesTest {
 
@@ -96,7 +98,7 @@ class CanonWorkEntitiesTest {
             providerStatus = "Backlog",
             targetDate = Instant.fromEpochMilliseconds(1_700_086_400_000),
             lead = CanonPerson(CanonId("p-1"), mcpProvenance, displayName = "Miley"),
-            summary = "Chassis SPI and domain-type canon v1.",
+            summary = CanonProse.bounded("Chassis SPI and domain-type canon v1."),
         )
 
         assertEquals(entity, roundTrip(entity))
@@ -214,6 +216,30 @@ class CanonWorkEntitiesTest {
             "a worst-case canon.table serialized to $byteCount bytes over a $projectionBudgetBytes byte budget",
         )
         assertEquals(maxed, roundTrip(maxed), "worst-case cells must survive the round trip intact")
+    }
+
+    @Test
+    fun `a worst case document serializes within the projection budget`() {
+        // CanonDocument.plainText predates the bulk rule and was its one
+        // counterexample (AMPR-268); this pins it under the same budget as
+        // CanonTable now that CanonProse bounds it.
+        val worstCaseChar = "漢"
+        val maxed = CanonDocument(
+            canonId = CanonId("doc-1"),
+            provenance = folderMountProvenance,
+            title = "Spec",
+            kind = DocumentKind.WORD_PROCESSOR,
+            plainText = CanonProse.bounded(worstCaseChar.repeat(CanonProse.MAX_CHARS * 3)),
+        )
+
+        val encoded = json.encodeToString(CanonEntity.serializer(), maxed)
+
+        val byteCount = encoded.encodeToByteArray().size
+        assertTrue(
+            byteCount <= projectionBudgetBytes,
+            "a worst-case canon.document serialized to $byteCount bytes over a $projectionBudgetBytes byte budget",
+        )
+        assertEquals(maxed, roundTrip(maxed), "worst-case prose must survive the round trip intact")
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Adds `CanonProse`, a bounded value type mirroring `CanonTablePreview`'s `bounded()`/`truncated` pattern, with an 8,000-UTF-16-unit cap that never splits a surrogate pair.
- Applies it to `CanonDocument.plainText`, `CanonMessage.bodyText`, `CanonNote.bodyText`, `CanonJournalEntry.bodyText`, and `CanonProject.summary`. Leaves `CanonEmailMessage`/`CanonEmailDraft.bodyText` as raw `String` since they round-trip through a live write-back adapter (`MailMessageAdapter`) that a truncating type would corrupt.
- Extends the `CanonWorkEntitiesTest` 32 KiB projection-budget assertion to cover `CanonDocument`, and adds `CanonProseTest` for the new type.
- Documents the breaking wire-shape change and the no-migration-needed rationale in `CHANGELOG.md`.

Closes #672

## Test plan
- [x] `./gradlew jvmTest` (whole repo)
- [x] `./gradlew :ampere-core:compileCommonMainKotlinMetadata`
- [x] `./gradlew :ampere-core:compileTestKotlinIosSimulatorArm64`
- [x] `./gradlew :ampere-core:ktlintFormat`

🤖 Generated with [Claude Code](https://claude.com/claude-code)