### PR TITLE
AMPR-267 #671: Add size budget and drop policy to trace recording

### DIFF
--- a/ampere-eval/src/commonMain/kotlin/link/socket/ampere/eval/trace/Trace.kt
+++ b/ampere-eval/src/commonMain/kotlin/link/socket/ampere/eval/trace/Trace.kt
@@ -13,6 +13,10 @@ import kotlinx.serialization.json.JsonElement
  *   discriminator (which lives inside [payload]).
  * @property payload the full serialized source event as a [JsonElement]; decodable
  *   back to the original `Event` via `Event.serializer()` with the shared `DEFAULT_JSON`.
+ *   String leaves beyond [TraceBudget.MAX_STRING_FIELD_CHARS] are cut in place
+ *   (see `truncateStringLeaves`) when the event exceeds [TraceBudget.MAX_EVENT_BYTES];
+ *   the JSON shape is never changed, so this always remains decodable.
+ * @property truncated true if [payload] was cut to fit [TraceBudget.MAX_EVENT_BYTES] (AMPR-267).
  */
 @Serializable
 data class TraceEvent(
@@ -20,6 +24,7 @@ data class TraceEvent(
     val timestamp: Long,
     val type: String,
     val payload: JsonElement,
+    val truncated: Boolean = false,
 )
 
 /**
@@ -34,6 +39,9 @@ data class TraceEvent(
  * @property arcId the orchestration pathway (Arc) this run belongs to.
  * @property createdAt epoch milliseconds when the trace was recorded.
  * @property events the captured events, in emission order.
+ * @property droppedEventCount trailing events cut when the trace exceeded
+ *   [TraceBudget.MAX_TRACE_BYTES] (AMPR-267's drop-with-a-marker policy).
+ *   Zero for a trace that stayed within budget.
  */
 @Serializable
 data class Trace(
@@ -42,6 +50,7 @@ data class Trace(
     val arcId: String,
     val createdAt: Long,
     val events: List<TraceEvent>,
+    val droppedEventCount: Int = 0,
 ) {
     /** Number of events in the trace. */
     val size: Int get() = events.size
@@ -61,4 +70,5 @@ data class TraceSummary(
     val arcId: String,
     val createdAt: Long,
     val eventCount: Int,
+    val droppedEventCount: Int = 0,
 )

--- a/ampere-eval/src/commonMain/kotlin/link/socket/ampere/eval/trace/TraceBudget.kt
+++ b/ampere-eval/src/commonMain/kotlin/link/socket/ampere/eval/trace/TraceBudget.kt
@@ -1,0 +1,52 @@
+package link.socket.ampere.eval.trace
+
+/**
+ * Size contract enforced on every recorded [Trace] at [RecordingHandle.stop] (AMPR-267).
+ *
+ * Two independent bounds, per AMPR-267 task 1 ("per event, per trace, or both"):
+ * a per-event bound (a single event's serialized payload cannot grow unbounded
+ * from a free-text field) and a per-trace bound (a pathological run cannot grow
+ * the persisted blob without limit). Both are enforced write-side in
+ * [RecordingHandle.stop] via truncate-and-flag ([TraceEvent.truncated]) and
+ * drop-with-a-marker ([Trace.droppedEventCount]) — never a read-side reject —
+ * so an already-persisted [Trace] always decodes; nothing here can make a
+ * recorded trace unreplayable, per the ticket's binding replay constraint.
+ */
+object TraceBudget {
+
+    /**
+     * Capacity of the recorder's buffering channel (task 5). Bounds the memory
+     * a runaway producer can consume before [RecordingHandle.stop] ever runs,
+     * independently of the byte-size contract below, which only applies once
+     * draining begins. Deliberately much larger than any real recording window
+     * is expected to need — a backstop, not the size contract itself.
+     */
+    const val CHANNEL_CAPACITY = 50_000
+
+    /**
+     * Max chars any single string leaf in an event's serialized payload may
+     * carry before [truncateStringLeaves] cuts it. `Event` is a sealed
+     * *interface* spread across ~24 files, each with its own free-text fields
+     * (description, context, prompt, preview, ...); bounding leaf length
+     * generically, from the serialized [kotlinx.serialization.json.JsonElement],
+     * keeps every current and future field covered from one place.
+     */
+    const val MAX_STRING_FIELD_CHARS = 2_000
+
+    /**
+     * Max serialized bytes a single [TraceEvent.payload] should occupy after
+     * truncation. A quarter of the 32 KiB canon projection budget established by
+     * AMPR-262's `CanonWorkEntitiesTest` — an event payload wraps a
+     * comparatively small, flat set of fields next to a full canon projection.
+     */
+    const val MAX_EVENT_BYTES = 8 * 1024
+
+    /**
+     * Max cumulative serialized bytes a [Trace]'s events may occupy. Events
+     * beyond this bound are dropped (trailing, in emission order) and counted
+     * in [Trace.droppedEventCount]. 512 KiB keeps a worst-case trace (every
+     * event at [MAX_EVENT_BYTES]) to 64 events before drop kicks in, and stays
+     * a comfortable SQLite `TEXT` value (see `Trace.sq`).
+     */
+    const val MAX_TRACE_BYTES = 512 * 1024
+}

--- a/ampere-eval/src/commonMain/kotlin/link/socket/ampere/eval/trace/TraceEventTruncation.kt
+++ b/ampere-eval/src/commonMain/kotlin/link/socket/ampere/eval/trace/TraceEventTruncation.kt
@@ -1,0 +1,66 @@
+package link.socket.ampere.eval.trace
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+
+/** Appended to any string leaf cut by [truncateStringLeaves], so a truncated
+ * field is recognizable in place rather than silently shortened. */
+const val TRUNCATION_MARKER = "…[truncated]"
+
+/**
+ * The shared `DEFAULT_JSON`'s `classDiscriminator` (see `RepositoryFactory.kt`).
+ * [truncateStringLeaves] must never cut this key's value: it is what
+ * `Event.serializer()` reads to pick the polymorphic subclass on decode, and
+ * truncating it produces a class name that resolves to nothing, hard-failing
+ * decode — the exact "unreplayable trace" failure AMPR-267 forbids.
+ */
+private const val CLASS_DISCRIMINATOR_KEY = "type"
+
+/**
+ * Truncates every string leaf in [this] longer than [maxChars], generically,
+ * without knowledge of the owning `Event` subtype's shape (AMPR-267).
+ *
+ * `Event` is a sealed *interface* spread across ~24 files; bounding every
+ * unbounded String field (description, context, prompt, preview, ...)
+ * per-subtype would mean touching all of them today and re-touching every new
+ * one. Walking the already-serialized [JsonElement] tree instead bounds every
+ * current and future free-text field from one place, and never changes the
+ * JSON shape (keys, object/array nesting) — only string leaf *values* shrink,
+ * and [CLASS_DISCRIMINATOR_KEY] is never touched — so truncated output still
+ * decodes via `Event.serializer()`.
+ *
+ * Returns the possibly-truncated tree paired with whether any leaf was cut.
+ */
+fun JsonElement.truncateStringLeaves(maxChars: Int): Pair<JsonElement, Boolean> {
+    var truncated = false
+
+    fun walk(element: JsonElement): JsonElement = when (element) {
+        is JsonObject -> buildJsonObject {
+            element.forEach { (key, value) ->
+                put(key, if (key == CLASS_DISCRIMINATOR_KEY) value else walk(value))
+            }
+        }
+        is JsonArray -> buildJsonArray { element.forEach { add(walk(it)) } }
+        is JsonNull -> element
+        is JsonPrimitive -> {
+            if (element.isString && element.content.length > maxChars) {
+                truncated = true
+                JsonPrimitive(element.content.take(maxChars) + TRUNCATION_MARKER)
+            } else {
+                element
+            }
+        }
+    }
+
+    return walk(this) to truncated
+}
+
+/** Serialized UTF-8 byte size of [this] under [json]. */
+fun JsonElement.serializedByteSize(json: Json): Int =
+    json.encodeToString(JsonElement.serializer(), this).encodeToByteArray().size

--- a/ampere-eval/src/commonMain/kotlin/link/socket/ampere/eval/trace/TraceRecorder.kt
+++ b/ampere-eval/src/commonMain/kotlin/link/socket/ampere/eval/trace/TraceRecorder.kt
@@ -29,6 +29,9 @@ import link.socket.ampere.data.DEFAULT_JSON
  *
  * @param bus the `EventSerialBus` to capture from (AMPR-183 calls this `EventSerializerBus`).
  * @param traceService persistence boundary the built [Trace] is saved through on stop.
+ * @param maxEventBytes AMPR-267 per-event budget; see [TraceBudget.MAX_EVENT_BYTES]. Overridable for tests.
+ * @param maxTraceBytes AMPR-267 per-trace budget; see [TraceBudget.MAX_TRACE_BYTES]. Overridable for tests.
+ * @param maxStringFieldChars truncation granularity; see [TraceBudget.MAX_STRING_FIELD_CHARS]. Overridable for tests.
  */
 class TraceRecorder(
     private val bus: EventSerialBus,
@@ -37,13 +40,16 @@ class TraceRecorder(
     private val eventTypes: List<EventType> = EventRegistry.allEventTypes,
     private val clockMillis: () -> Long = { Clock.System.now().toEpochMilliseconds() },
     private val idGenerator: () -> String = { generateUUID() },
+    private val maxEventBytes: Int = TraceBudget.MAX_EVENT_BYTES,
+    private val maxTraceBytes: Int = TraceBudget.MAX_TRACE_BYTES,
+    private val maxStringFieldChars: Int = TraceBudget.MAX_STRING_FIELD_CHARS,
 ) {
     /**
      * Begin recording. Subscribes to the bus immediately; events published after
      * this call are captured until [RecordingHandle.stop].
      */
     fun start(runId: String, arcId: String): RecordingHandle {
-        val buffer = Channel<Event>(Channel.UNLIMITED)
+        val buffer = Channel<Event>(TraceBudget.CHANNEL_CAPACITY)
         val agentId = "trace-recorder/$runId/${idGenerator()}"
 
         val subscriptions = eventTypes.map { eventType ->
@@ -66,6 +72,9 @@ class TraceRecorder(
             bus = bus,
             traceService = traceService,
             json = json,
+            maxEventBytes = maxEventBytes,
+            maxTraceBytes = maxTraceBytes,
+            maxStringFieldChars = maxStringFieldChars,
         )
     }
 }
@@ -83,6 +92,9 @@ class RecordingHandle internal constructor(
     private val bus: EventSerialBus,
     private val traceService: TraceService,
     private val json: Json,
+    private val maxEventBytes: Int,
+    private val maxTraceBytes: Int,
+    private val maxStringFieldChars: Int,
 ) {
     /**
      * Stop recording, build the [Trace] from buffered events (in emission order),
@@ -108,13 +120,41 @@ class RecordingHandle internal constructor(
             }
         }
 
-        val events = captured.mapIndexed { index, event ->
-            TraceEvent(
-                index = index,
-                timestamp = event.timestamp.toEpochMilliseconds(),
-                type = event.eventType,
-                payload = json.encodeToJsonElement(Event.serializer(), event),
-            )
+        // Enforce the AMPR-267 size contract at this single chokepoint every
+        // captured event passes through. Per event: truncate-and-flag any
+        // payload over MAX_EVENT_BYTES by cutting oversized string leaves
+        // (never the JSON shape), so it always stays decodable. Per trace:
+        // once cumulative bytes would exceed MAX_TRACE_BYTES, drop the
+        // remaining events (trailing, in emission order) with a marker rather
+        // than growing the persisted blob without limit.
+        var traceBytes = 0
+        var droppedEventCount = 0
+        val events = buildList {
+            for ((index, event) in captured.withIndex()) {
+                val encoded = json.encodeToJsonElement(Event.serializer(), event)
+                val (payload, wasTruncated) = if (encoded.serializedByteSize(json) > maxEventBytes) {
+                    encoded.truncateStringLeaves(maxStringFieldChars)
+                } else {
+                    encoded to false
+                }
+
+                val eventBytes = payload.serializedByteSize(json)
+                if (traceBytes + eventBytes > maxTraceBytes) {
+                    droppedEventCount = captured.size - index
+                    break
+                }
+                traceBytes += eventBytes
+
+                add(
+                    TraceEvent(
+                        index = index,
+                        timestamp = event.timestamp.toEpochMilliseconds(),
+                        type = event.eventType,
+                        payload = payload,
+                        truncated = wasTruncated,
+                    ),
+                )
+            }
         }
 
         val trace = Trace(
@@ -123,6 +163,7 @@ class RecordingHandle internal constructor(
             arcId = arcId,
             createdAt = createdAt,
             events = events,
+            droppedEventCount = droppedEventCount,
         )
 
         return traceService.save(trace).map { trace }

--- a/ampere-eval/src/commonMain/kotlin/link/socket/ampere/eval/trace/TraceService.kt
+++ b/ampere-eval/src/commonMain/kotlin/link/socket/ampere/eval/trace/TraceService.kt
@@ -38,6 +38,7 @@ class TraceService(
                 created_at = trace.createdAt,
                 event_count = trace.size.toLong(),
                 events_json = json.encodeToString(eventsSerializer, trace.events),
+                dropped_event_count = trace.droppedEventCount.toLong(),
             )
             Unit
         }
@@ -46,13 +47,14 @@ class TraceService(
     /** Load a full [Trace] by id. Fails if no trace with [traceId] exists. */
     suspend fun load(traceId: String): Result<Trace> = withContext(dispatcher) {
         runCatching {
-            queries.selectById(traceId) { id, runId, arcId, createdAt, _, eventsJson ->
+            queries.selectById(traceId) { id, runId, arcId, createdAt, _, eventsJson, droppedEventCount ->
                 Trace(
                     id = id,
                     runId = runId,
                     arcId = arcId,
                     createdAt = createdAt,
                     events = json.decodeFromString(eventsSerializer, eventsJson),
+                    droppedEventCount = droppedEventCount.toInt(),
                 )
             }.executeAsOneOrNull()
                 ?: error("Trace not found: $traceId")
@@ -62,13 +64,21 @@ class TraceService(
     /** List trace metadata, newest first; optionally scoped to a single [arcId]. */
     suspend fun list(arcId: String? = null): Result<List<TraceSummary>> = withContext(dispatcher) {
         runCatching {
-            val mapper = { id: String, runId: String, arc: String, createdAt: Long, eventCount: Long ->
+            val mapper = {
+                    id: String,
+                    runId: String,
+                    arc: String,
+                    createdAt: Long,
+                    eventCount: Long,
+                    droppedEventCount: Long,
+                ->
                 TraceSummary(
                     id = id,
                     runId = runId,
                     arcId = arc,
                     createdAt = createdAt,
                     eventCount = eventCount.toInt(),
+                    droppedEventCount = droppedEventCount.toInt(),
                 )
             }
             if (arcId == null) {

--- a/ampere-eval/src/commonMain/sqldelight/link/socket/ampere/eval/db/Trace.sq
+++ b/ampere-eval/src/commonMain/sqldelight/link/socket/ampere/eval/db/Trace.sq
@@ -7,12 +7,13 @@
 -- per-event rows in v1.
 
 CREATE TABLE trace (
-  id          TEXT NOT NULL PRIMARY KEY,
-  run_id      TEXT NOT NULL,
-  arc_id      TEXT NOT NULL,
-  created_at  INTEGER NOT NULL,
-  event_count INTEGER NOT NULL,
-  events_json TEXT NOT NULL
+  id                  TEXT NOT NULL PRIMARY KEY,
+  run_id              TEXT NOT NULL,
+  arc_id              TEXT NOT NULL,
+  created_at          INTEGER NOT NULL,
+  event_count         INTEGER NOT NULL,
+  events_json         TEXT NOT NULL,
+  dropped_event_count INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE INDEX idx_trace_arc_id ON trace(arc_id);
@@ -21,25 +22,25 @@ CREATE INDEX idx_trace_created_at ON trace(created_at);
 
 -- Persist (or overwrite) a full trace.
 upsertTrace:
-INSERT OR REPLACE INTO trace(id, run_id, arc_id, created_at, event_count, events_json)
-VALUES (?, ?, ?, ?, ?, ?);
+INSERT OR REPLACE INTO trace(id, run_id, arc_id, created_at, event_count, events_json, dropped_event_count)
+VALUES (?, ?, ?, ?, ?, ?, ?);
 
 -- Load a full trace (blob included) by id.
 selectById:
-SELECT id, run_id, arc_id, created_at, event_count, events_json
+SELECT id, run_id, arc_id, created_at, event_count, events_json, dropped_event_count
 FROM trace
 WHERE id = ?
 LIMIT 1;
 
 -- Metadata-only listing (no blob) of all traces, newest first.
 selectSummaries:
-SELECT id, run_id, arc_id, created_at, event_count
+SELECT id, run_id, arc_id, created_at, event_count, dropped_event_count
 FROM trace
 ORDER BY created_at DESC;
 
 -- Metadata-only listing (no blob) filtered by arc, newest first.
 selectSummariesByArcId:
-SELECT id, run_id, arc_id, created_at, event_count
+SELECT id, run_id, arc_id, created_at, event_count, dropped_event_count
 FROM trace
 WHERE arc_id = ?
 ORDER BY created_at DESC;

--- a/ampere-eval/src/jvmTest/kotlin/link/socket/ampere/eval/trace/TraceRecorderTest.kt
+++ b/ampere-eval/src/jvmTest/kotlin/link/socket/ampere/eval/trace/TraceRecorderTest.kt
@@ -5,12 +5,17 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Instant
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import link.socket.ampere.agents.domain.Urgency
+import link.socket.ampere.agents.domain.event.AssetAccessEvent
 import link.socket.ampere.agents.domain.event.Event
 import link.socket.ampere.agents.domain.event.EventSource
 import link.socket.ampere.agents.events.bus.EventSerialBus
@@ -87,6 +92,85 @@ class TraceRecorderTest {
         val replayed = TraceCursor(loaded).replayTo(loaded.size - 1)
         assertEquals(recorded.events, replayed)
         assertEquals(emitted.map { it.eventId }, replayed.map { it.payload.eventId() })
+    }
+
+    // --- AMPR-267 trace-hygiene tests ---
+
+    @Test
+    fun `oversized event is truncated and flagged but still decodes`() = runTest {
+        val recorder = TraceRecorder(bus, service, maxEventBytes = 200, maxStringFieldChars = 50)
+        val handle = recorder.start(runId = "run-3", arcId = "arc-3")
+
+        bus.publish(
+            Event.QuestionRaised(
+                eventId = "e1",
+                urgency = Urgency.LOW,
+                timestamp = Instant.fromEpochMilliseconds(1),
+                eventSource = source,
+                questionText = "why?",
+                context = "x".repeat(1_000),
+            ),
+        )
+
+        val trace = handle.stop().getOrThrow()
+
+        assertEquals(1, trace.size)
+        assertEquals(0, trace.droppedEventCount)
+        val traceEvent = trace.events.single()
+        assertTrue(traceEvent.truncated)
+
+        // Truncation only shrinks string leaves; the shape is untouched, so this
+        // still decodes via Event.serializer() (AMPR-267's replay constraint).
+        val decoded = DEFAULT_JSON.decodeFromJsonElement(Event.serializer(), traceEvent.payload) as Event.QuestionRaised
+        assertEquals("e1", decoded.eventId)
+        assertTrue(decoded.context.endsWith(TRUNCATION_MARKER))
+        assertTrue(decoded.context.length <= 50 + TRUNCATION_MARKER.length)
+    }
+
+    @Test
+    fun `trace exceeding the byte budget drops trailing events and records the count`() = runTest {
+        val recorder = TraceRecorder(bus, service, maxTraceBytes = 300)
+        val handle = recorder.start(runId = "run-4", arcId = "arc-4")
+        val emitted = events(5)
+        emitted.forEach { bus.publish(it) }
+
+        val trace = handle.stop().getOrThrow()
+
+        assertTrue(trace.size < 5, "expected some events dropped, kept ${trace.size}")
+        assertEquals(5, trace.size + trace.droppedEventCount)
+        assertEquals(
+            emitted.take(trace.size).map { it.eventId },
+            trace.events.map { it.payload.eventId() },
+        )
+    }
+
+    @Test
+    fun `asset access event carries a byte count, never the asset bytes, in a recorded trace`() = runTest {
+        val handle = recorder.start(runId = "run-5", arcId = "arc-5")
+
+        bus.publish(
+            AssetAccessEvent(
+                eventId = "e1",
+                timestamp = Instant.fromEpochMilliseconds(1),
+                eventSource = source,
+                linkId = null,
+                plugId = "plug-1",
+                byteCount = 4_096,
+            ),
+        )
+
+        val trace = handle.stop().getOrThrow()
+        val payload: JsonObject = trace.events.single().payload.jsonObject
+
+        // The metadata is present...
+        assertEquals(4_096, payload.getValue("byteCount").jsonPrimitive.content.toInt())
+        // ...but there is no field anywhere carrying the resolved bytes themselves —
+        // AssetAccessEvent has no such field by construction, so nothing here can
+        // leak them into a trace no matter what is truncated or dropped upstream.
+        assertEquals(
+            setOf("byteCount"),
+            payload.keys.filter { it.contains("byte", ignoreCase = true) }.toSet(),
+        )
     }
 
     private fun kotlinx.serialization.json.JsonElement.eventId(): String =


### PR DESCRIPTION
Closes #671

Trace recording was unbounded: `TraceRecorder` buffered on `Channel.UNLIMITED`, `Trace.sq`'s `events_json` column had no size constraint, and no test asserted anything about recording size or content absence. This adds a real, enforced size contract at `RecordingHandle.stop()` — the single chokepoint every event passes through — using a per-event truncate-and-flag policy (`TraceEvent.truncated`) and a per-trace drop-with-a-marker policy (`Trace.droppedEventCount`), persisted via a new `dropped_event_count` column. Truncation walks the already-serialized event JSON generically (skipping the polymorphic `"type"` discriminator) so it never breaks `Event.serializer()` decode, satisfying the ticket's binding replay-compatibility constraint. The recorder's buffering channel is also now bounded as a producer-side backstop against a runaway event source. Three new hygiene tests cover truncation-survives-decode, trace-level dropping, and structural absence of raw asset bytes in a recorded `AssetAccessEvent`.

I (Claude) wrote this commit and PR description.

## Test plan
- [x] `./gradlew :ampere-eval:jvmTest` — all tests pass, including new hygiene tests
- [x] `./gradlew :ampere-eval:ktlintFormat` — clean
- [x] `./gradlew :ampere-core:compileCommonMainKotlinMetadata :ampere-eval:compileCommonMainKotlinMetadata` — compiles
- [x] `./gradlew :ampere-eval:compileTestKotlinIosSimulatorArm64` — compiles