### PR TITLE
Publish ampere-core-test-fixtures to Maven Central on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,13 +76,13 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
         run: |
           export ORG_GRADLE_PROJECT_signingInMemoryKey="$(cat /tmp/signing-key.asc)"
-          ./gradlew :ampere-core:publishAllPublicationsToMavenCentralRepository :ampere-phosphor:publishAllPublicationsToMavenCentralRepository
+          ./gradlew :ampere-core:publishAllPublicationsToMavenCentralRepository :ampere-core-test-fixtures:publishAllPublicationsToMavenCentralRepository :ampere-phosphor:publishAllPublicationsToMavenCentralRepository
 
       - name: Dry run publish
         if: ${{ github.event.inputs.dry_run == 'true' }}
         run: |
           echo "Dry run mode - skipping actual publish"
-          ./gradlew :ampere-core:publishAllPublicationsToMavenCentralRepository :ampere-phosphor:publishAllPublicationsToMavenCentralRepository --dry-run
+          ./gradlew :ampere-core:publishAllPublicationsToMavenCentralRepository :ampere-core-test-fixtures:publishAllPublicationsToMavenCentralRepository :ampere-phosphor:publishAllPublicationsToMavenCentralRepository --dry-run
 
       - name: Create GitHub Release
         if: startsWith(github.ref, 'refs/tags/v') && github.event.inputs.dry_run != 'true'


### PR DESCRIPTION
## Summary
- `publish.yml` only published `:ampere-core` and `:ampere-phosphor` to Maven Central, so `:ampere-core-test-fixtures` never got published on tagged releases
- This meant 0.13.0's test-fixtures artifact was missing from Central, breaking downstream consumers (e.g. the socket repo's `:common` test compilation) that vendor/depend on it
- 0.13.0 was published manually as a stopgap; this adds the module to both the real and dry-run publish steps so it's included automatically going forward

## Test plan
- [x] Manually ran `:ampere-core-test-fixtures:publishAllPublicationsToMavenCentralRepository` and confirmed 0.13.0 is now published to Central
- [ ] Next tagged release (`v*`) should publish `-core`, `-core-test-fixtures`, and `-phosphor` together — verify all three land on Central after the next release

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>